### PR TITLE
Phase 3: character export API

### DIFF
--- a/.claude/plans/phase3-character-export-api.md
+++ b/.claude/plans/phase3-character-export-api.md
@@ -217,10 +217,16 @@ it in Phase 4a.
 - Returns 403 if the pet is owned by a different user.
 - Returns 404 if the pet doesn't exist.
 - Returns 400 with a Zod error if the payload is malformed.
-- The returned `character.knowledge.length` equals the pet's
-  `characterConfig.knowledge.length`.
+- The returned `character.knowledge` is **intentionally empty** (`[]`).
+  Rationale: ElizaOS v2's `normalizeKnowledgeItem` (`@elizaos/core`) treats
+  each string in `Character.knowledge` as a **filesystem path**, not
+  inline RAG content — so shipping raw markdown strings here would
+  silently break RAG on the Milady side. The `skillPack` emitted
+  alongside the character is the authoritative RAG carrier; the
+  `@clawville/app-clawville` plugin ingests from there on install.
 - The returned `skillPack.length` matches the count of fully-learned
-  buildings.
+  buildings, and `summary.knowledgeCount` equals the sum of
+  `skillPack[].knowledge.length` (the real chunk total).
 - The returned `installCommand` is a single shell-safe line.
 - `bun run build` passes.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -83,6 +83,7 @@ Hard rules:
 | `chat.ts` | Location agent chat with dynamic context injection |
 | `items.ts` | Shop browse, inventory, buy, learn |
 | `agent-gateway.ts` | Universal agent connection (connect-token, polling, SKILL.md, SSE events) |
+| `agent-export.ts` | `POST /api/agent/export-character` — emits Eliza `Character` JSON + `SkillPack` + Milady install payload + curl one-liner (Phase 3 of the create-agent rollout; Phase 4a UI consumes this) |
 | `openclaw.ts` | Legacy OpenClaw bot registration (kept for backwards compat) |
 | `npc-sse.ts` | Server-Sent Events for NPC simulation state |
 | `bazaar.ts` | Skill marketplace (browse, list, buy) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,6 +350,7 @@ Agents connect via an **agent-initiated flow** — humans never paste credential
 - `GET /api/agent/connect-status/:token` — poll for connection status
 - `GET /api/agent/connect-skill?token=xxx` — SKILL.md for agents (aliased at `/api/skills/connect`)
 - `POST /api/agent/connect` — universal agent registration (accepts `connectionToken` field)
+- `POST /api/agent/export-character` — **Phase 3** emits a Milady-installable bundle for a pet the caller owns: `{character, skillPack, miladyInstallPayload, installCommand, summary}`. Accepts `{petId, targetHarness?, miladyBaseUrl?}`. Phase 4a UI wraps this with the one-click install button.
 - `POST /api/openclaw/register` — legacy endpoint (manual gateway form, kept for backwards compat)
 
 ### Manual Connect (power users)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,7 +350,7 @@ Agents connect via an **agent-initiated flow** — humans never paste credential
 - `GET /api/agent/connect-status/:token` — poll for connection status
 - `GET /api/agent/connect-skill?token=xxx` — SKILL.md for agents (aliased at `/api/skills/connect`)
 - `POST /api/agent/connect` — universal agent registration (accepts `connectionToken` field)
-- `POST /api/agent/export-character` — **Phase 3** emits a Milady-installable bundle for a pet the caller owns: `{character, skillPack, miladyInstallPayload, installCommand, summary}`. Accepts `{petId, targetHarness?, miladyBaseUrl?}`. Phase 4a UI wraps this with the one-click install button.
+- `POST /api/agent/export-character` — **Phase 3** emits a Milady-installable bundle for a pet the caller owns: `{character, skillPack, miladyInstallPayload, installCommand, exportedAt, summary}`. Accepts `{petId, targetHarness?, miladyBaseUrl?}`. `character.knowledge` is intentionally empty (ElizaOS v2 normalizes knowledge strings as filesystem paths, so the skill pack is the authoritative RAG carrier). Phase 4a UI wraps this with the one-click install button.
 - `POST /api/openclaw/register` — legacy endpoint (manual gateway form, kept for backwards compat)
 
 ### Manual Connect (power users)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -17,6 +17,7 @@ import { marketplaceRoutes } from './routes/marketplace';
 import { clawRoutes } from './routes/claws';
 import { agentGatewayRoutes } from './routes/agent-gateway';
 // pendingConnections is exported but only used internally by agent-gateway routes
+import { agentExportRoutes } from './routes/agent-export';
 import { bazaarRoutes } from './routes/bazaar';
 import { auctionRoutes } from './routes/auctions';
 import { questRoutes } from './routes/quests';
@@ -82,6 +83,11 @@ app.route('/api/research', researchApiRoutes);
 app.route('/api/marketplace', marketplaceRoutes);
 app.route('/api/claws', clawRoutes);
 app.route('/api/agent', agentGatewayRoutes);
+// Phase 3 — character export ("take my agent home") endpoint. Mounted at
+// the same `/api/agent` prefix so the route path becomes
+// `POST /api/agent/export-character`, matching the path in
+// `.claude/plans/phase3-character-export-api.md`.
+app.route('/api/agent', agentExportRoutes);
 // Alias: /api/skills/connect → /api/agent/connect-skill (user-facing SKILL.md URL)
 app.get('/api/skills/connect', (c) => {
   const token = c.req.query('token') ?? '';

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,0 +1,140 @@
+/**
+ * In-memory per-IP rate limiter — extracted from agent-gateway.ts in Phase 3
+ * so multiple routes can share the same token-bucket pattern without each
+ * one duplicating the Map + cleanup scaffolding.
+ *
+ * Usage:
+ *   const limiter = createRateLimiter({ maxPerWindow: 10, windowMs: 60_000 });
+ *   if (!limiter.check(ip)) return c.json({ error: '...' }, 429);
+ *
+ * Each call to `createRateLimiter` produces an isolated bucket map — use one
+ * per route so that bursts against `/connect` don't eat the budget for
+ * `/export-character` or vice versa.
+ */
+
+export interface RateLimiterOptions {
+  /** Max requests per IP per window. Default: 10. */
+  maxPerWindow?: number;
+  /** Window length in ms. Default: 60_000 (1 minute). */
+  windowMs?: number;
+  /** Threshold at which lazy cleanup sweeps expired entries. Default: 10_000. */
+  cleanupThreshold?: number;
+}
+
+export interface RateLimiter {
+  /** Returns true if the request is allowed, false if the IP is over budget. */
+  check(ip: string): boolean;
+  /** Forcibly clear the bucket — useful for tests. */
+  reset(): void;
+}
+
+export function createRateLimiter(options: RateLimiterOptions = {}): RateLimiter {
+  const maxPerWindow = options.maxPerWindow ?? 10;
+  const windowMs = options.windowMs ?? 60_000;
+  const cleanupThreshold = options.cleanupThreshold ?? 10_000;
+  // Phase 3 audit C6 — sweep expired entries every N checks regardless
+  // of bucket size. The size-gated cleanup above only fires when
+  // `bucket.size > cleanupThreshold`, so a steady stream of unique IPs
+  // under that threshold (each one expires after `windowMs`) would leak
+  // entries forever because their lifetime is bounded by window expiry,
+  // not by total population. Periodic sweeping amortizes O(n) work at
+  // 1-per-N requests (default 1-per-500), which is negligible overhead.
+  const periodicCleanupInterval = 500;
+  let checkCount = 0;
+
+  const bucket = new Map<string, { count: number; resetAt: number }>();
+
+  function cleanupSize() {
+    if (bucket.size <= cleanupThreshold) return;
+    const now = Date.now();
+    for (const [k, v] of bucket) {
+      if (now > v.resetAt) bucket.delete(k);
+    }
+  }
+
+  function cleanupPeriodic() {
+    const now = Date.now();
+    for (const [k, v] of bucket) {
+      if (now > v.resetAt) bucket.delete(k);
+    }
+  }
+
+  return {
+    check(ip: string): boolean {
+      cleanupSize();
+      checkCount++;
+      if (checkCount % periodicCleanupInterval === 0) {
+        cleanupPeriodic();
+      }
+      const now = Date.now();
+      const entry = bucket.get(ip);
+      if (!entry || now > entry.resetAt) {
+        bucket.set(ip, { count: 1, resetAt: now + windowMs });
+        return true;
+      }
+      entry.count++;
+      return entry.count <= maxPerWindow;
+    },
+    reset() {
+      bucket.clear();
+      checkCount = 0;
+    },
+  };
+}
+
+/**
+ * Best-effort IP resolver — checks trusted proxy headers before falling
+ * back to `'unknown'`.
+ *
+ * Preference order (Phase 3 audit C3 — defeats X-Forwarded-For spoofing):
+ *
+ *   1. `cf-connecting-ip` — authoritative inside a Cloudflare-proxied
+ *      deployment. Cloudflare strips any client-set value at the edge
+ *      and injects its own, so this header is not user-controllable
+ *      inside the proxy chain. ClawVille's prod traffic goes through
+ *      Cloudflare → Traefik → Hono, so this is the correct primary.
+ *
+ *   2. `x-real-ip` — typically set by Traefik / nginx to the upstream
+ *      IP. Safe when the app is behind a single trusted reverse proxy.
+ *
+ *   3. `x-forwarded-for` — take the LAST entry (the one the trusted
+ *      proxy appended), not the first. Trusting the first comma-
+ *      separated value lets any caller forge the IP by simply setting
+ *      `X-Forwarded-For: 1.2.3.4` on the outbound request; the trusted
+ *      proxy then appends the real client IP AFTER the forged value,
+ *      making the tail authoritative on a direct-to-proxy deployment.
+ *
+ *   4. Fallback to `'unknown'` — every request without any of the above
+ *      shares the same rate-limit bucket, which is the correct safe
+ *      default (collectively limited rather than individually
+ *      unlimited).
+ *
+ * Assumes a Cloudflare-fronted deployment in prod. On a direct-to-
+ * Traefik deployment (e.g. local `bun run dev` against a tunneled
+ * public URL), CF header will be absent, so the last-XFF-entry rule
+ * still applies. Anyone fronting ClawVille with a different edge must
+ * audit which header their edge sets and extend this function if
+ * neither CF nor Traefik conventions fit.
+ */
+export function getClientIp(headers: {
+  get(name: string): string | null | undefined;
+}): string {
+  // 1. Cloudflare-authoritative, not user-settable inside the chain.
+  const cf = headers.get('cf-connecting-ip');
+  if (cf) return cf.trim();
+
+  // 2. Reverse-proxy-set, not user-settable inside the chain.
+  const real = headers.get('x-real-ip');
+  if (real) return real.trim();
+
+  // 3. XFF — LAST entry is the one the trusted proxy appended. The
+  //    leading entries are whatever the client sent; they're attacker-
+  //    controlled in the general case.
+  const xff = headers.get('x-forwarded-for');
+  if (xff) {
+    const parts = xff.split(',').map((p) => p.trim()).filter(Boolean);
+    if (parts.length > 0) return parts[parts.length - 1];
+  }
+
+  return 'unknown';
+}

--- a/apps/api/src/routes/agent-export.ts
+++ b/apps/api/src/routes/agent-export.ts
@@ -41,13 +41,11 @@ import { requireAuth } from '../middleware/auth';
 import { createRateLimiter, getClientIp } from '../middleware/rate-limit';
 import type { AuthenticatedContext } from '../types';
 
-// Phase 3 audit C2 — `requireAuth` is a `createMiddleware<AuthenticatedContext>`
-// that validates the Lucia session AND sets `c.var.user` to a non-null `User`.
-// Typing the Hono instance as `AuthenticatedContext` lets `c.get('user')`
-// return `User` directly (no null guard), and we drop the redundant global
-// `sessionMiddleware` — it was validating the session twice per request
-// (once here, once inside `requireAuth`), burning an extra Lucia round-trip
-// on every hit. Per-route `requireAuth` is the single auth gate.
+// Per-route `requireAuth` is the single auth gate; we deliberately do NOT
+// add a global `sessionMiddleware` because that would double-validate the
+// Lucia session on every request for no benefit. `requireAuth` is typed as
+// `createMiddleware<AuthenticatedContext>` so `c.get('user')` returns a
+// non-null `User` when typing the Hono instance with the same context.
 export const agentExportRoutes = new Hono<AuthenticatedContext>();
 
 // 10 exports / IP / minute — spam-ceiling high enough that a human clicking
@@ -207,17 +205,25 @@ function buildSkillPack(
 
 // ─── Route ──────────────────────────────────────────────────────────────────
 
-agentExportRoutes.post('/export-character', requireAuth, async (c) => {
-  // --- Rate limit (before any DB work) ---
-  const ip = getClientIp({
-    get: (name) => c.req.header(name) ?? null,
-  });
-  if (!exportRateLimiter.check(ip)) {
-    throw new HTTPException(429, {
-      message: 'Too many export requests. Try again in 1 minute.',
+agentExportRoutes.post(
+  '/export-character',
+  // Rate-limit MUST run before `requireAuth` so unauthenticated spam
+  // never reaches Lucia. Otherwise a scraper hammering this endpoint with
+  // junk cookies would burn one `lucia.validateSession()` DB round-trip
+  // per request before being 401'd, defeating the purpose of the limiter.
+  async (c, next) => {
+    const ip = getClientIp({
+      get: (name) => c.req.header(name) ?? null,
     });
-  }
-
+    if (!exportRateLimiter.check(ip)) {
+      throw new HTTPException(429, {
+        message: 'Too many export requests. Try again in 1 minute.',
+      });
+    }
+    return next();
+  },
+  requireAuth,
+  async (c) => {
   const user = c.get('user');
 
   // --- Validate input ---
@@ -328,4 +334,5 @@ agentExportRoutes.post('/export-character', requireAuth, async (c) => {
       knowledgeCount,
     },
   });
-});
+  },
+);

--- a/apps/api/src/routes/agent-export.ts
+++ b/apps/api/src/routes/agent-export.ts
@@ -1,0 +1,331 @@
+/**
+ * POST /api/agent/export-character — Phase 3 "take my agent home" endpoint.
+ *
+ * Emits a complete ElizaOS-compatible character bundle for any pet owned by
+ * the authenticated user, plus a Milady-install payload the Phase 4a UI can
+ * POST verbatim against the user's local `/api/plugins/install`.
+ *
+ * Spec: `.claude/plans/phase3-character-export-api.md`.
+ *
+ * Security:
+ *   - Auth: Lucia session cookie (same pattern as `apps/api/src/routes/pets.ts`).
+ *   - Authz: 403 if pet exists but belongs to a different session user.
+ *   - Rate limit: 10 requests per IP per minute (shared pattern with /connect).
+ *   - No signing: we emit an unsigned snapshot. If chain-of-custody becomes a
+ *     marketplace concern, add `issuedAt` + `exportHash` later (Phase 5+).
+ *
+ * The route is stateless — it reads the pet, delegates to the pure
+ * `buildCharacterExport` function in `@clawville/agent-runtime`, and returns
+ * the result. No DB writes, no agent lifecycle changes.
+ */
+
+import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { db, pets } from '@clawville/database';
+import {
+  AGENT_HARNESSES,
+  BUILDING_MILADY_SKILLS,
+  KNOWLEDGE_BOOKS,
+  DEFAULT_AGENT_MODEL,
+  DEFAULT_AGENT_HARNESS,
+  getAgentModel,
+  type AgentCategory,
+  type AgentHarness,
+  type AgentModelMeta,
+  type SkillPackEntry,
+} from '@clawville/shared';
+import { buildCharacterExport } from '@clawville/agent-runtime';
+import { requireAuth } from '../middleware/auth';
+import { createRateLimiter, getClientIp } from '../middleware/rate-limit';
+import type { AuthenticatedContext } from '../types';
+
+// Phase 3 audit C2 — `requireAuth` is a `createMiddleware<AuthenticatedContext>`
+// that validates the Lucia session AND sets `c.var.user` to a non-null `User`.
+// Typing the Hono instance as `AuthenticatedContext` lets `c.get('user')`
+// return `User` directly (no null guard), and we drop the redundant global
+// `sessionMiddleware` — it was validating the session twice per request
+// (once here, once inside `requireAuth`), burning an extra Lucia round-trip
+// on every hit. Per-route `requireAuth` is the single auth gate.
+export const agentExportRoutes = new Hono<AuthenticatedContext>();
+
+// 10 exports / IP / minute — spam-ceiling high enough that a human clicking
+// the "Take home" button in a loop can't trip it by accident, low enough that
+// a scraping client hammering the endpoint hits a wall fast.
+const exportRateLimiter = createRateLimiter({
+  maxPerWindow: 10,
+  windowMs: 60_000,
+});
+
+/**
+ * Default base URL of the user's local Milady HTTP API. Milady's dev
+ * server listens on port 2138 by default (see the CORS note in
+ * `apps/api/src/index.ts`: "Milady port 2138"). ClawVille's own API
+ * runs on port 4000 — emitting `curl http://localhost:4000/...` here
+ * would always 404 on a fresh Milady install, which is Phase 3 audit C4.
+ */
+const DEFAULT_MILADY_BASE_URL = 'http://localhost:2138';
+
+const exportSchema = z.object({
+  /** Pet UUID — must be owned by the session user. */
+  petId: z.string().uuid(),
+  /**
+   * Optional harness override — defaults to the pet's stored `harness` when
+   * omitted. Validated against the shared `AGENT_HARNESSES` tuple so the
+   * server stays in lockstep with the DB CHECK constraint
+   * `pets_harness_valid` (Phase 2).
+   */
+  targetHarness: z.enum(AGENT_HARNESSES).optional(),
+  /**
+   * Base URL of the user's local Milady HTTP API. Defaults to the
+   * standard Milady dev port (2138). Users running Milady on a non-
+   * default port can override here; the value flows through to the
+   * emitted `installCommand` curl one-liner.
+   */
+  miladyBaseUrl: z.string().url().optional(),
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Build a shell-safe `curl` one-liner that posts the Milady install
+ * payload to the user's local Milady API.
+ *
+ * Shell-escaping strategy: wrap the JSON body in single quotes and escape
+ * any embedded single quotes with the standard POSIX sequence `'\''`
+ * (close quote, literal quote, reopen). This is safe in bash, zsh, and
+ * the MinGW bash that Milady users on Windows tend to have. Pet names
+ * themselves are alphanumeric-only by Zod constraint, but archetype
+ * bio / lore / knowledge strings often contain apostrophes ("I'm",
+ * "O'Malley" — etc.) so defensive escaping is required.
+ *
+ * `miladyBaseUrl` is configurable via the request body (Phase 3 audit
+ * C4 — the previous hardcoded `http://localhost:4000` was ClawVille's
+ * own API port, not Milady's default of 2138, so the emitted curl was
+ * guaranteed to 404). The Zod schema validates that the override is a
+ * well-formed URL before it reaches this function.
+ */
+function buildInstallCommand(payload: unknown, miladyBaseUrl: string): string {
+  const json = JSON.stringify(payload);
+  // Replace every `'` with `'\''` so the single-quoted wrapper stays intact.
+  const escaped = json.replace(/'/g, `'\\''`);
+  // Trim trailing slash so concatenation stays well-formed regardless
+  // of what the caller passes (`http://localhost:2138` vs `.../`).
+  const base = miladyBaseUrl.replace(/\/+$/, '');
+  return `curl -X POST ${base}/api/plugins/install -H 'Content-Type: application/json' -d '${escaped}'`;
+}
+
+/**
+ * Pre-compute the (buildingId → KnowledgeBook[]) map from the KNOWLEDGE_BOOKS
+ * registry at module load. Every building maps to exactly 2 books in the
+ * current spec; the fully-learned check below uses `.every(...)` so 3+
+ * books per building would still work correctly (pet would need ALL of them).
+ */
+const BOOKS_BY_BUILDING: Readonly<Record<string, typeof KNOWLEDGE_BOOKS>> = (() => {
+  const m: Record<string, typeof KNOWLEDGE_BOOKS> = {};
+  for (const book of KNOWLEDGE_BOOKS) {
+    if (!m[book.building]) m[book.building] = [];
+    m[book.building].push(book);
+  }
+  // Freeze the index so test-time mutations of `KNOWLEDGE_BOOKS` (or any
+  // accidental write here) fail loudly instead of silently drifting.
+  return Object.freeze(m);
+})();
+
+/**
+ * Compose the SkillPack for a pet.
+ *
+ * "Fully learned" check — a building is learned when the pet's
+ * `characterConfig.knowledge` contains at least one entry from EACH
+ * book published at that building. This mirrors the existing gate in
+ * `apps/api/src/routes/items.ts:303-305` (the `export-skill/:buildingId`
+ * endpoint) verbatim so the Phase 3 bundle matches the in-game export
+ * flow exactly.
+ *
+ * IMPORTANT: we intentionally DO NOT check `pet_inventory` here. Books
+ * are consumed on `POST /api/items/learn` (items.ts:258-266), so any pet
+ * that has actually learned books will have an empty inventory for those
+ * book IDs — relying on inventory would silently emit zero skills for
+ * every fully-trained pet, which is the exact opposite of correct.
+ *
+ * Buildings that don't have a matching entry in `BUILDING_MILADY_SKILLS`
+ * are skipped silently — the Milady catalog is the source of truth for
+ * which buildings produce exportable skills.
+ *
+ * The `knowledge` field on each entry is sourced from the book's
+ * `knowledgeEntries` array (the canonical markdown-per-chunk data) in
+ * stable order: book-registry order, then entry order within each book.
+ * This is deterministic so re-exporting the same pet produces a
+ * byte-identical payload (useful once we add hashing in Phase 5).
+ */
+function buildSkillPack(
+  pet: { id: string; name: string },
+  petKnowledge: string[],
+): SkillPackEntry[] {
+  const knowledgeSet = new Set(petKnowledge);
+
+  const entries: SkillPackEntry[] = [];
+  for (const [buildingId, skill] of Object.entries(BUILDING_MILADY_SKILLS)) {
+    const buildingBooks = BOOKS_BY_BUILDING[buildingId] ?? [];
+    if (buildingBooks.length === 0) continue;
+
+    // Fully-learned check — every book assigned to this building must
+    // have at least one of its entries in the pet's knowledge set.
+    const fullyLearned = buildingBooks.every((book) =>
+      book.knowledgeEntries.some((entry) => knowledgeSet.has(entry)),
+    );
+    if (!fullyLearned) continue;
+
+    // Flatten all knowledge chunks from this building's books in stable
+    // order (book-registry order, then entry order within each book).
+    // We emit every chunk from the canonical registry rather than just
+    // the ones the pet currently carries — per spec §5, the pack ships
+    // the full building skill so Milady's RAG store sees the complete
+    // body of knowledge. This also matches `items.ts#export-skill`'s
+    // `const knowledge = characterConfig?.knowledge ?? []` approach but
+    // is more defensible: it's immune to users whose characterConfig
+    // somehow lost entries post-learn.
+    const knowledge: string[] = buildingBooks.flatMap(
+      (book) => book.knowledgeEntries,
+    );
+
+    entries.push({
+      skillId: skill.skillId,
+      name: skill.name,
+      description: skill.description,
+      category: skill.category,
+      buildingId,
+      knowledge,
+      source: 'clawville',
+      exportedFrom: { petId: pet.id, petName: pet.name },
+    });
+  }
+
+  return entries;
+}
+
+// ─── Route ──────────────────────────────────────────────────────────────────
+
+agentExportRoutes.post('/export-character', requireAuth, async (c) => {
+  // --- Rate limit (before any DB work) ---
+  const ip = getClientIp({
+    get: (name) => c.req.header(name) ?? null,
+  });
+  if (!exportRateLimiter.check(ip)) {
+    throw new HTTPException(429, {
+      message: 'Too many export requests. Try again in 1 minute.',
+    });
+  }
+
+  const user = c.get('user');
+
+  // --- Validate input ---
+  const body = await c.req.json().catch(() => null);
+  if (!body) {
+    throw new HTTPException(400, { message: 'Invalid JSON body' });
+  }
+  const parsed = exportSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new HTTPException(400, {
+      message: parsed.error.issues[0]?.message ?? 'Invalid request payload',
+    });
+  }
+
+  const { petId, targetHarness } = parsed.data;
+
+  // --- Look up pet ---
+  const pet = await db.query.pets.findFirst({
+    where: eq(pets.id, petId),
+  });
+
+  if (!pet) {
+    throw new HTTPException(404, { message: 'Pet not found' });
+  }
+
+  // Authorization: must belong to the session user. Distinct from 404 so the
+  // UI can surface a clear "not yours" error vs a generic not-found.
+  if (pet.userId !== user.id) {
+    throw new HTTPException(403, {
+      message: 'You do not own this pet',
+    });
+  }
+
+  // --- Resolve model metadata + target harness ---
+  // `pet.modelKey` should always be populated post-Phase-2 thanks to the
+  // NOT NULL DEFAULT + CHECK constraint, but a pet row that pre-dates the
+  // migration could theoretically arrive here with a stale value. Fall
+  // back to `DEFAULT_AGENT_MODEL` in that case rather than 500-ing —
+  // this keeps the export useful even on edge rows.
+  const modelMeta: AgentModelMeta =
+    (pet.modelKey ? getAgentModel(pet.modelKey) : undefined) ?? DEFAULT_AGENT_MODEL;
+
+  const harness: AgentHarness =
+    targetHarness ?? (pet.harness as AgentHarness | null) ?? DEFAULT_AGENT_HARNESS;
+
+  // --- Build skill pack from the pet's learned knowledge ---
+  // Books are consumed on `/api/items/learn`, so the only durable signal
+  // of "learned" is the pet's `characterConfig.knowledge[]` array.
+  const petKnowledge: string[] =
+    (pet.characterConfig as { knowledge?: string[] } | null)?.knowledge ?? [];
+
+  const skillPack = buildSkillPack(
+    { id: pet.id, name: pet.name },
+    petKnowledge,
+  );
+
+  // --- Build the character (pure, synchronous) ---
+  const character = buildCharacterExport(
+    { id: pet.id, name: pet.name, characterConfig: pet.characterConfig ?? null },
+    modelMeta,
+    { harness },
+  );
+
+  const exportedAt = new Date().toISOString();
+
+  // --- Compose Milady install payload + curl command ---
+  const miladyInstallPayload = {
+    plugin: '@clawville/app-clawville',
+    config: {
+      character,
+      skills: skillPack,
+      source: {
+        url: 'https://clawville.world',
+        petId: pet.id,
+        exportedAt,
+      },
+    },
+  } as const;
+
+  const miladyBaseUrl = parsed.data.miladyBaseUrl ?? DEFAULT_MILADY_BASE_URL;
+  const installCommand = buildInstallCommand(miladyInstallPayload, miladyBaseUrl);
+
+  // --- Summary — cheap client-side stats for the Phase 4a UI ---
+  // Post Fix 1 the character's `knowledge` field is deliberately empty
+  // (ElizaOS v2 would normalize string[] to filesystem paths, breaking RAG).
+  // The skill pack is the authoritative RAG carrier, so count knowledge
+  // chunks by summing per-skill chunks — matches what the user actually
+  // exports to Milady.
+  const knowledgeCount = skillPack.reduce(
+    (n, s) => n + s.knowledge.length,
+    0,
+  );
+
+  const agentCategory: AgentCategory =
+    (pet.agentCategory as AgentCategory | null) ?? modelMeta.category;
+
+  return c.json({
+    character,
+    skillPack,
+    miladyInstallPayload,
+    installCommand,
+    exportedAt,
+    summary: {
+      modelKey: pet.modelKey ?? modelMeta.key,
+      agentCategory,
+      harness,
+      skillsCount: skillPack.length,
+      knowledgeCount,
+    },
+  });
+});

--- a/apps/api/src/routes/agent-export.ts
+++ b/apps/api/src/routes/agent-export.ts
@@ -34,6 +34,7 @@ import {
   type AgentCategory,
   type AgentHarness,
   type AgentModelMeta,
+  type KnowledgeBook,
   type SkillPackEntry,
 } from '@clawville/shared';
 import { buildCharacterExport } from '@clawville/agent-runtime';
@@ -109,9 +110,17 @@ function buildInstallCommand(payload: unknown, miladyBaseUrl: string): string {
   // Replace every `'` with `'\''` so the single-quoted wrapper stays intact.
   const escaped = json.replace(/'/g, `'\\''`);
   // Trim trailing slash so concatenation stays well-formed regardless
-  // of what the caller passes (`http://localhost:2138` vs `.../`).
-  const base = miladyBaseUrl.replace(/\/+$/, '');
-  return `curl -X POST ${base}/api/plugins/install -H 'Content-Type: application/json' -d '${escaped}'`;
+  // of what the caller passes (`http://localhost:2138` vs `.../`), then
+  // shell-single-quote-escape. `z.string().url()` accepts shell meta-
+  // chars like `$(cmd)` and backticks — since Phase 4a will display
+  // this command in a copy-to-clipboard UI, an attacker-controlled
+  // `miladyBaseUrl` could otherwise smuggle a command substitution
+  // into the user's terminal. Wrap in single quotes + escape embedded
+  // apostrophes the same way we do for the JSON payload.
+  const trimmed = miladyBaseUrl.replace(/\/+$/, '');
+  const fullUrl = `${trimmed}/api/plugins/install`;
+  const urlQuoted = `'${fullUrl.replace(/'/g, `'\\''`)}'`;
+  return `curl -X POST ${urlQuoted} -H 'Content-Type: application/json' -d '${escaped}'`;
 }
 
 /**
@@ -120,14 +129,16 @@ function buildInstallCommand(payload: unknown, miladyBaseUrl: string): string {
  * current spec; the fully-learned check below uses `.every(...)` so 3+
  * books per building would still work correctly (pet would need ALL of them).
  */
-const BOOKS_BY_BUILDING: Readonly<Record<string, typeof KNOWLEDGE_BOOKS>> = (() => {
-  const m: Record<string, typeof KNOWLEDGE_BOOKS> = {};
+const BOOKS_BY_BUILDING: Readonly<Record<string, readonly KnowledgeBook[]>> = (() => {
+  const m: Record<string, KnowledgeBook[]> = {};
   for (const book of KNOWLEDGE_BOOKS) {
-    if (!m[book.building]) m[book.building] = [];
-    m[book.building].push(book);
+    (m[book.building] ??= []).push(book);
   }
-  // Freeze the index so test-time mutations of `KNOWLEDGE_BOOKS` (or any
-  // accidental write here) fail loudly instead of silently drifting.
+  // Deep-freeze: the outer Record AND each inner array. `Object.freeze` is
+  // shallow, and `KNOWLEDGE_BOOKS` is typed as `KnowledgeBook[]` (mutable),
+  // so without this loop a test helper that does `BOOKS_BY_BUILDING['x']
+  // .push(fakeBook)` would succeed silently and corrupt skill-pack output.
+  for (const arr of Object.values(m)) Object.freeze(arr);
   return Object.freeze(m);
 })();
 

--- a/apps/api/src/routes/agent-gateway.ts
+++ b/apps/api/src/routes/agent-gateway.ts
@@ -26,32 +26,19 @@ import type { ClawvilleServices } from '@clawville/agent-runtime';
 const agentGatewayRoutes = new Hono();
 
 // ---------------------------------------------------------------------------
-// Rate limiter for /connect — prevents unlimited bot registration spam
+// Rate limiter for /connect — prevents unlimited bot registration spam.
+// Phase 3 — migrated to the shared `createRateLimiter` + `getClientIp`
+// helpers so this route gets Cloudflare-safe IP resolution (cf-connecting-ip
+// preferred, LAST XFF token as fallback) and the same periodic cleanup as
+// /export-character. Previous inline implementation used first-XFF-token
+// which was trivially spoofable.
 // ---------------------------------------------------------------------------
-const connectRateMap = new Map<string, { count: number; resetAt: number }>();
-const CONNECT_MAX_PER_MIN = 10;
-const CONNECT_WINDOW_MS = 60_000;
+import { createRateLimiter, getClientIp } from '../middleware/rate-limit';
 
-function checkConnectRateLimit(ip: string): boolean {
-  const now = Date.now();
-  const entry = connectRateMap.get(ip);
-  if (!entry || now > entry.resetAt) {
-    connectRateMap.set(ip, { count: 1, resetAt: now + CONNECT_WINDOW_MS });
-    return true;
-  }
-  entry.count++;
-  if (entry.count > CONNECT_MAX_PER_MIN) return false;
-  return true;
-}
-// Lazy cleanup to prevent unbounded map growth
-function cleanupConnectRateMap() {
-  if (connectRateMap.size > 10_000) {
-    const now = Date.now();
-    for (const [k, v] of connectRateMap) {
-      if (now > v.resetAt) connectRateMap.delete(k);
-    }
-  }
-}
+const connectRateLimiter = createRateLimiter({
+  maxPerWindow: 10,
+  windowMs: 60_000,
+});
 
 // ---------------------------------------------------------------------------
 // POST /api/agent/connect  — Universal agent registration
@@ -120,12 +107,10 @@ const connectSchema = z.object({
 );
 
 agentGatewayRoutes.post('/connect', async (c) => {
-  // Rate limit by IP
-  const ip = c.req.header('x-forwarded-for')?.split(',')[0]?.trim()
-    ?? c.req.header('x-real-ip')
-    ?? 'unknown';
-  cleanupConnectRateMap();
-  if (!checkConnectRateLimit(ip)) {
+  // Rate limit by IP — getClientIp is Cloudflare-safe (cf-connecting-ip
+  // preferred, LAST XFF token as fallback so spoofed headers don't win).
+  const ip = getClientIp({ get: (name) => c.req.header(name) ?? null });
+  if (!connectRateLimiter.check(ip)) {
     return c.json({ error: 'Too many connection attempts. Try again in 1 minute.' }, 429);
   }
 

--- a/packages/agent-runtime/src/character-exporter.ts
+++ b/packages/agent-runtime/src/character-exporter.ts
@@ -1,0 +1,254 @@
+/**
+ * Phase 3 — pure Character bundle builder for the "take my agent home"
+ * export. Given a pet row + resolved `AgentModelMeta` + target
+ * `AgentHarness`, assemble a ready-to-import ElizaOS `Character` object.
+ *
+ * This module MUST stay side-effect-free:
+ *   - No DB access (Drizzle, raw pg, Supabase clients — none of it).
+ *   - No `async` — construction is synchronous.
+ *   - No ElizaRuntime instantiation. `createElizaRuntime` stays in
+ *     `eliza-runtime.ts`; this file only shapes the Character JSON the
+ *     caller will hand off to a different runtime (the user's local
+ *     Milady, typically).
+ *
+ * The skill pack derivation is NOT here because it requires a
+ * `pet_inventory` query. It lives inside the API route that owns the
+ * DB connection (see `apps/api/src/routes/agent-export.ts`). Keeping
+ * the character builder pure makes it trivially unit-testable and
+ * means a future consumer (e.g. a CLI) can reuse the same composition
+ * without dragging the DB in.
+ *
+ * See `.claude/plans/phase3-character-export-api.md` for the full spec.
+ */
+
+import { createCharacter, type Character, type CharacterInput } from '@elizaos/core';
+import type { AgentHarness, AgentModelMeta } from '@clawville/shared';
+
+export { type SkillPackEntry } from '@clawville/shared';
+
+/**
+ * Minimal subset of the pet `characterConfig` JSONB blob that the
+ * exporter needs. Declared locally — and NOT imported from
+ * `@clawville/database` — because `agent-runtime` does not depend on
+ * the database package (avoids a new package-graph edge). If the DB
+ * schema ever adds a required field the exporter needs, mirror it
+ * here; if it drops one, delete it here. The field names and types
+ * intentionally match `PetCharacterConfigJson` in
+ * `packages/database/src/schema/pets.ts` so assignment from a raw
+ * Drizzle row is a no-op.
+ */
+export interface PetCharacterConfigLike {
+  bio?: string[];
+  greeting?: string;
+  tone?: string;
+  topics?: string[];
+  adjectives?: string[];
+  rules?: string[];
+  style?: { all?: string[]; chat?: string[]; post?: string[] };
+  messageExamples?: Array<Array<{ user: string; content: string | { text: string } }>>;
+  lore?: string[];
+  knowledge?: string[];
+  system?: string;
+}
+
+/**
+ * Minimal pet shape required by `buildCharacterExport`. We key off
+ * `PetCharacterConfigJson` (from `@clawville/database`) so the type
+ * matches exactly what `db.query.pets.findFirst()` returns. Using a
+ * structural subset keeps this function callable with a raw Drizzle
+ * row, a fixture, or a plain object — no casts needed.
+ *
+ * `characterConfig` is nullable in the DB because older rows predate
+ * the Phase 1 migration that populated it. The builder handles nullish
+ * values by falling back to empty arrays, but a real export against a
+ * pet missing `characterConfig` will look sparse — callers should
+ * surface a warning in that case.
+ */
+export interface PetExportInput {
+  id: string;
+  name: string;
+  characterConfig: PetCharacterConfigLike | null;
+}
+
+export interface CharacterExportOptions {
+  /** Which harness the export targets — drives the plugin list */
+  harness: AgentHarness;
+}
+
+/**
+ * Harness → default plugin list. These lists are the "vanilla" wiring
+ * the Milady plugin / ElizaOS runtime expects. Users can edit the
+ * resulting character after install to add more plugins; we ship a
+ * minimum viable set so the character boots.
+ *
+ * - `milady`   — `@clawville/app-clawville` is the Milady app plugin
+ *                that itself provides ElizaOS-compatible actions/
+ *                providers. `plugin-sql` ships the memory adapter.
+ *                Anthropic/OpenAI are NOT preloaded — Milady's model
+ *                config owns LLM selection. Bootstrap lives in core
+ *                (CLAUDE.md ElizaOS note) so no need to list it.
+ * - `openclaw` /
+ *   `hermes`  — Vanilla ElizaOS runtime, just `plugin-sql` for
+ *                persistence. The user wires their own text + embed
+ *                provider.
+ * - `custom`  — Same as openclaw/hermes. The user wires everything.
+ *
+ * Edit these lists in lockstep with the upstream harness packages: if
+ * Milady changes the plugin it expects, this constant flips too.
+ */
+const HARNESS_PLUGIN_LIST: Record<AgentHarness, string[]> = {
+  milady: ['@elizaos/plugin-sql', '@clawville/app-clawville'],
+  openclaw: ['@elizaos/plugin-sql'],
+  hermes: ['@elizaos/plugin-sql'],
+  custom: ['@elizaos/plugin-sql'],
+};
+
+/**
+ * Build the default `system` prompt for an exported character. Uses
+ * the model's human-readable label (e.g. "Reef Lobster") instead of
+ * legacy `species` so the prompt describes what the 3D renderer
+ * actually draws. Mirrors the pattern in
+ * `apps/api/src/routes/pets.ts#buildCharacterConfig`.
+ *
+ * If the pet's `characterConfig.system` is already populated (older
+ * pets, or future overrides), we prefer that verbatim — the exporter
+ * never overrides an explicitly-set prompt.
+ */
+function buildSystemPrompt(petName: string, modelLabel: string): string {
+  return [
+    `You are ${petName}, a ${modelLabel} from the sea-themed world of ClawVille.`,
+    `You graduated ClawVille after learning agent-development skills from 10 buildings and are now running inside the user's own agent harness.`,
+    `Stay in character. Draw on your archetype's tone, topics, and knowledge; weave in ClawVille lore naturally when it fits.`,
+  ].join('\n');
+}
+
+/**
+ * Pure builder — construct a full ElizaOS `Character` from a pet row,
+ * resolved model metadata, and target harness. No DB, no async, no
+ * runtime. Caller is responsible for resolving `modelMeta` via
+ * `getAgentModel(pet.modelKey)` (or `DEFAULT_AGENT_MODEL` for
+ * pre-Phase-2 rows that somehow slipped through the CHECK constraint).
+ *
+ * We call `createCharacter(input)` to normalize the loose
+ * `CharacterInput` shape into ElizaOS v2's strict proto-backed
+ * `Character` (knowledge → `KnowledgeSourceItem[]`, messageExamples →
+ * `MessageExampleGroup[]`, style → `StyleGuides`). The exporter
+ * deliberately passes an EMPTY `knowledge` array to `createCharacter`
+ * — see the Phase 3 audit C1 note inside the function body for why.
+ * TL;DR: `normalizeKnowledgeItem` treats raw strings as filesystem
+ * paths, not inline markdown, so baking the pet's learned knowledge
+ * into `character.knowledge` would produce an import-time RAG loader
+ * failure on the Milady side. The skillPack emitted alongside this
+ * character is the authoritative RAG carrier — `@clawville/app-
+ * clawville` reads it on install.
+ */
+export function buildCharacterExport(
+  pet: PetExportInput,
+  modelMeta: AgentModelMeta,
+  options: CharacterExportOptions,
+): Character {
+  const config = pet.characterConfig ?? null;
+
+  // Pull all free-form character fields from the resolved
+  // characterConfig blob. Each one defaults to an empty array/string
+  // so the builder never emits `undefined` for a collection — the
+  // Milady plugin + ElizaOS core both prefer empty arrays over nullish.
+  const bio = config?.bio ?? [];
+  const topics = config?.topics ?? [];
+  const adjectives = config?.adjectives ?? [];
+  const lore = config?.lore ?? [];
+  // Phase 3 audit C1 — we intentionally do NOT thread pet knowledge
+  // into `character.knowledge`; the skillPack is the RAG carrier.
+  // See the `knowledge: []` line below for the full rationale.
+  const style = config?.style ?? { all: [], chat: [], post: [] };
+
+  // `messageExamples` in the pet config is
+  // `Array<Array<{ user; content: string | { text } }>>` — the legacy
+  // DB shape where `content` is usually a raw string. ElizaOS v2's
+  // `MessageExamplesInput` accepts `MessageExample[][]`, where a
+  // `MessageExample` is `{ name: string; content: Content }` and
+  // `Content.text` is the string payload. Convert per the same
+  // pattern used in `characters/index.ts` so the exported character
+  // loads cleanly into Milady's runtime without a reshape step.
+  //
+  // Phase 3 audit C7 — `PetCharacterConfigLike.messageExamples[].user`
+  // is typed as `string`, so the legacy `typeof msg.user === 'string'`
+  // guard is structurally redundant. We keep only the `startsWith('{{')`
+  // check that actually does work (rewrites `{{user1}}` → `User`).
+  const messageExamples = (config?.messageExamples ?? []).map((conversation) =>
+    conversation.map((msg) => ({
+      name: msg.user.startsWith('{{') ? 'User' : msg.user,
+      content: {
+        text:
+          typeof msg.content === 'string'
+            ? msg.content
+            : msg.content?.text ?? '',
+      },
+    })),
+  );
+
+  // Prefer a stored `system` prompt; otherwise rebuild using the
+  // model label so the export stays accurate for pets that were
+  // created with a since-changed modelKey (e.g. user swaps from
+  // lobster → priestess and re-exports).
+  const system = config?.system?.trim().length
+    ? config.system
+    : buildSystemPrompt(pet.name, modelMeta.label);
+
+  const plugins = HARNESS_PLUGIN_LIST[options.harness];
+
+  // ElizaOS v2 normalizes CharacterInput → Character via `createCharacter`.
+  // We hand it a `CharacterInput`-shaped blob (loose types — bio can be
+  // string[]) and let the core helper emit the strictly-typed `Character`
+  // (proto-backed: messageExamples becomes `MessageExampleGroup[]`,
+  // style becomes `StyleGuides`).
+  //
+  // This mirrors the exact pattern in `characters/index.ts` used for the
+  // 10 building characters, so the exporter produces the same shape the
+  // runtime already handles internally — no Milady-side parsing drift.
+  //
+  // `lore` is merged into `bio` since ElizaOS v2 has no dedicated lore
+  // field; same flattening the location characters use.
+  //
+  // ─── Phase 3 audit C1 — knowledge is deliberately empty here ───
+  // ElizaOS v2's `normalizeKnowledgeItem()` converts a bare string into
+  // `{ item: { case: 'path', value: string } }`, so Milady's RAG loader
+  // would attempt to read each markdown chunk as a FILESYSTEM PATH on
+  // the user's machine — every chunk fails silently, the pet loses all
+  // its learned knowledge on install. See the invariant comment in
+  // `packages/agent-runtime/src/characters/index.ts:43-46`:
+  //   "ElizaOS v2 treats knowledge strings as file paths, not inline
+  //    text. By putting them in bio, they become part of the character
+  //    context."
+  //
+  // We solve this upstream instead: the skillPack emitted alongside
+  // this character (via `buildSkillPack` in the API route) carries the
+  // full RAG payload in its own `knowledge: string[]` field, and
+  // `@clawville/app-clawville` (the Milady plugin in
+  // `HARNESS_PLUGIN_LIST.milady`) ingests from there at install time.
+  //
+  // If someone imports this character.json into a vanilla ElizaOS
+  // runtime WITHOUT the Milady plugin, they will still see the pet's
+  // bio/lore/topics/style intact — only the RAG channel requires the
+  // plugin or a manual "bio-folding" step per the characters/index.ts
+  // pattern.
+  const input: CharacterInput & { name: string } = {
+    name: pet.name,
+    system,
+    bio: [...bio, ...lore],
+    topics,
+    adjectives,
+    knowledge: [],
+    messageExamples,
+    postExamples: [],
+    style,
+    plugins,
+    // Phase 3 audit C8 — no hardcoded voice. The previous default
+    // ('en_US-male-medium') was gender-inaccurate for every non-male
+    // pet and most Milady runtimes apply their own TTS preference at
+    // load time anyway. Leaving `settings` undefined lets the host
+    // runtime pick.
+  };
+
+  return createCharacter(input);
+}

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -4,6 +4,18 @@ export { createOpenClawProviderPlugin } from './plugins/openclaw-provider';
 export type { OpenClawGatewayConfig } from './plugins/openclaw-provider';
 export { loadLocationTemplate, loadCharacter, mergeCustomizations } from './character-loader';
 
+// Character exporter (Phase 3 — "take my agent home" bundle builder)
+// The function is pure: given a Pet row + resolved model metadata +
+// target harness, it returns the ElizaOS Character JSON. No DB reads,
+// no async, no runtime start. The skill-pack builder that
+// accompanies it lives in the API route (needs DB access).
+export { buildCharacterExport } from './character-exporter';
+export type {
+  CharacterExportOptions,
+  PetExportInput,
+  SkillPackEntry,
+} from './character-exporter';
+
 // ElizaOS Project export — standard entry point for `elizaos start`
 export { default as project, project as clawvilleProject } from './project';
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -20,6 +20,7 @@ export * from './types/bounty';
 export * from './constants/article-seeds';
 export * from './constants/quest-seeds';
 export * from './types/collaboration';
+export * from './types/skill-pack';
 export * from './constants/milady-skills';
 // `agent-models` uses type + value dual exports; explicit re-exports
 // guarantee every symbol is public (the earlier `export *` worked but

--- a/packages/shared/src/types/skill-pack.ts
+++ b/packages/shared/src/types/skill-pack.ts
@@ -1,0 +1,56 @@
+/**
+ * Phase 3 — SkillPackEntry is one element of the "take my agent home"
+ * bundle emitted by `POST /api/agent/export-character`.
+ *
+ * A SkillPack is the list of Milady-compatible skills a pet has fully
+ * learned (i.e. it owns BOTH knowledge books at a given building and
+ * therefore merits the corresponding skill from `BUILDING_MILADY_SKILLS`).
+ *
+ * This type lives in `@clawville/shared` because it's consumed on both
+ * sides: the API composes it from DB rows, and Phase 4a's UI (+ the
+ * Milady plugin) reads it back. Keeping one source of truth prevents
+ * drift between emitter and consumer.
+ *
+ * The shape intentionally mirrors `MiladySkillDefinition` (from
+ * `constants/milady-skills.ts`) with two additions:
+ *   - `knowledge`: the markdown-per-chunk strings copied from the pet's
+ *     `characterConfig.knowledge[]` for the relevant buildings so the
+ *     Milady plugin can seed the newly installed character's RAG store
+ *     without another round-trip back to ClawVille.
+ *   - `exportedFrom`: provenance so the installing agent can display
+ *     "imported from <petName>" and honour any future attribution rules.
+ *
+ * We deliberately DO NOT sign or hash the entry in Phase 3; see §11 of
+ * the plan doc for the rationale. A future `signature` field can be
+ * added later without breaking existing consumers.
+ */
+export interface SkillPackEntry {
+  /** Stable skill id from `BUILDING_MILADY_SKILLS[buildingId].skillId` */
+  skillId: string;
+  /** Human-readable skill name (e.g. "Automation & Scheduling") */
+  name: string;
+  /** Short description copied verbatim from the skill definition */
+  description: string;
+  /** Milady skill category (e.g. "Automation & Workflows") */
+  category: string;
+  /** ClawVille building id that unlocked this skill */
+  buildingId: string;
+  /**
+   * Markdown-per-chunk knowledge the pet learned from this building's
+   * books. Each string is one RAG-sized chunk; Milady is expected to
+   * embed them on install. Order is stable: book order in
+   * `KNOWLEDGE_BOOKS`, then entry order within each book.
+   */
+  knowledge: string[];
+  /**
+   * Always `'clawville'` for Phase 3 exports. Leaves room for third
+   * parties to later emit SkillPackEntry-shaped payloads through the
+   * same install channel if the skill marketplace grows.
+   */
+  source: 'clawville';
+  /** Provenance — which pet (on which ClawVille instance) issued this entry */
+  exportedFrom: {
+    petId: string;
+    petName: string;
+  };
+}


### PR DESCRIPTION
## Summary

Phase 3 of the create-agent rollout — adds `POST /api/agent/export-character` which emits a Milady-installable bundle for any pet the caller owns. Primary consumer is Phase 4a's one-click deploy UI.

- **Route:** `POST /api/agent/export-character` accepts `{petId, targetHarness?, miladyBaseUrl?}` and returns `{character, skillPack, miladyInstallPayload, installCommand, exportedAt, summary}`.
- **Pure exporter:** `buildCharacterExport(pet, modelMeta, {harness})` in `@clawville/agent-runtime` — no DB, no async. Harness-specific plugin lists (Milady gets `['@elizaos/plugin-sql','@clawville/app-clawville']`, others get vanilla).
- **Extracted rate limiter:** `apps/api/src/middleware/rate-limit.ts` — `createRateLimiter` + `getClientIp`. 10 req/min/IP, `cf-connecting-ip` preferred so X-Forwarded-For spoofing no longer bypasses.
- **Empty character.knowledge by design:** ElizaOS v2 would normalize `knowledge: string[]` as filesystem paths. The skill pack is the authoritative RAG carrier for Milady install.

## Audit

2 passes by a 3-agent parallel ultrathink team. 13 pass-1 findings fixed. Key CRITICAL resolved: knowledge-as-paths bug that would have silently broken RAG on every install.

## Test plan

- [ ] `bun run build` passes (7/7 packages) — verified in worktree
- [ ] Deploy to Hetzner via Coolify
- [ ] `curl -X POST https://api.clawville.world/api/agent/export-character -H 'Content-Type: application/json' --cookie "$session" -d '{"petId":"<uuid>"}'` → returns 200 + bundle
- [ ] Cross-user petId → 403
- [ ] Unknown petId → 404
- [ ] Spray `x-forwarded-for` headers from same real IP → rate limit still triggers at 10/min (cf-connecting-ip wins)
- [ ] Paste the returned `installCommand` into a fresh bash on a box running Milady on localhost:2138 → plugin installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)