### PR TITLE
fix(create-agent): remove Hermes+Milady tabs + fix lobster visibility

### DIFF
--- a/apps/web/src/app/create-agent/page.tsx
+++ b/apps/web/src/app/create-agent/page.tsx
@@ -175,11 +175,13 @@ export default function CreateAgentPage() {
   // handlers. Do NOT make this async — an `await` between the two setters
   // breaks batching and would cause one render with the new category + stale
   // model, sending a mismatched modelKey to SelectAgentCanvas.
-  // CATEGORY_DEFAULT_MODEL is now typed via `as const satisfies` (Fix H) so
-  // the values are already ModelKey literals — no cast needed.
+  // CATEGORY_DEFAULT_MODEL is Partial<Record<AgentCategory, ModelKey>> since
+  // 2026-04-16 (hermes/milady tabs removed) — fall back to 'lobster' for any
+  // category that is no longer in the picker so the state can never be
+  // undefined even if stale sessionStorage pushes a retired category in.
   const handleCategoryChange = useCallback((cat: AgentCategory) => {
     setSelectedCategory(cat);
-    setSelectedModel(CATEGORY_DEFAULT_MODEL[cat]);
+    setSelectedModel(CATEGORY_DEFAULT_MODEL[cat] ?? 'lobster');
   }, []);
 
   // ── Thumbnail capture with bounded rAF poll (audit Fix F) ────────────────
@@ -293,6 +295,10 @@ export default function CreateAgentPage() {
         </p>
 
         {/* ── Category tabs ─────────────────────────────────────────────── */}
+        {/* CATEGORY_META is now Partial<Record<...>> — `cat` here is always
+            drawn from CATEGORY_ORDER which is guaranteed to have a matching
+            meta entry, but TS doesn't know that so we fall back on `cat`
+            itself as the label text. */}
         <div className="flex gap-1 bg-black/40 backdrop-blur-sm rounded-xl p-1 mb-4 border border-white/10">
           {CATEGORY_ORDER.map((cat) => (
             <button
@@ -304,7 +310,7 @@ export default function CreateAgentPage() {
                   : 'text-white/40 hover:text-white/70 hover:bg-white/5'
               }`}
             >
-              {CATEGORY_META[cat].label}
+              {CATEGORY_META[cat]?.label ?? cat}
             </button>
           ))}
         </div>
@@ -333,7 +339,7 @@ export default function CreateAgentPage() {
             ))}
           </div>
           <p className="text-white/30 text-[10px] text-center mt-1.5 font-mono">
-            {CATEGORY_META[selectedCategory].description}
+            {CATEGORY_META[selectedCategory]?.description ?? ''}
           </p>
         </div>
 

--- a/apps/web/src/components/three/SelectAgentCanvas.tsx
+++ b/apps/web/src/components/three/SelectAgentCanvas.tsx
@@ -360,16 +360,20 @@ const SceneContents = memo(function SceneContents({
 }) {
   return (
     <>
-      {/* Camera controls — limited rotation, no pan */}
+      {/* Camera controls — limited rotation, no pan.
+          Camera is positioned high and aimed steeply downward so the model
+          appears in the upper ~25% of the viewport, above the config modal.
+          target Y=3 (below model center) steepens the look-down angle so the
+          character sits in the clear header zone rather than behind the UI. */}
       <OrbitControls
         makeDefault
         enablePan={false}
         enableZoom={true}
-        minDistance={25}
-        maxDistance={80}
-        minPolarAngle={Math.PI * 0.3}
-        maxPolarAngle={Math.PI * 0.55}
-        target={[0, 8, 0]}
+        minDistance={30}
+        maxDistance={90}
+        minPolarAngle={Math.PI * 0.28}
+        maxPolarAngle={Math.PI * 0.50}
+        target={[0, 3, 0]}
       />
 
       {/* Dramatic underwater lighting */}
@@ -437,7 +441,7 @@ export default function SelectAgentCanvas({
     <div id="select-agent-canvas" className="fixed inset-0 z-0 pointer-events-none">
       <Canvas
         className="w-full h-full pointer-events-auto"
-        camera={{ position: [0, 18, 55], fov: 45 }}
+        camera={{ position: [0, 40, 70], fov: 42 }}
         // WebGL-only: preserveDrawingBuffer enables toDataURL thumbnail capture
         // in create-agent/page.tsx. If this Canvas ever switches to
         // WebGPURenderer, replace thumbnail capture with a RenderTarget +

--- a/apps/web/src/lib/three/agent-model-registry.ts
+++ b/apps/web/src/lib/three/agent-model-registry.ts
@@ -28,31 +28,35 @@ export const MODEL_REGISTRY = {
   lobster_plush: { path: '/models/lobster_plush.glb',              scale: 10, label: 'Lobster Plush',   category: 'openclaw' },
   hermitcrab:    { path: '/models/hermitcrab.glb',                 scale: 10, label: 'Hermit Crab',     category: 'openclaw' },
 
-  // ── Hermes (anime — single representative) ────────────────────────────────
-  chihiro:       { path: '/models/spirited_away_senchihiro.glb',   scale: 10, label: 'Chihiro',         category: 'hermes' },
-
-  // ── Milady (anime — placeholder until Milady-branded GLBs ship) ───────────
-  priestess:     { path: '/models/young_priestess.glb',            scale: 10, label: 'Young Priestess', category: 'milady' },
-  chibi_goku:    { path: '/models/chibi_goku.glb',                 scale: 11, label: 'Chibi Goku',      category: 'milady' },
-
   // ── Other (sea creatures) ─────────────────────────────────────────────────
   jellyfish:     { path: '/models/jellyfish.glb',                  scale: 10, label: 'Jellyfish',       category: 'other', yOffset: 1.5 },
   octopus:       { path: '/models/octopus_toy.glb',                scale: 10, label: 'Octopus',         category: 'other' },
   seahorse:      { path: '/models/sea_horse.glb',                  scale: 8,  label: 'Sea Horse',       category: 'other' },
+
+  // NOTE: Hermes/Milady anime GLBs (chihiro / priestess / chibi_goku) were
+  // removed from the picker 2026-04-16 — those source meshes rendered poorly
+  // (pivot-not-at-feet Y offset + SkinnedMesh scale explosion). The anime
+  // GLB files still ship under /public/models/ and `arena-npcs.tsx` retains
+  // lookup entries for any legacy DB rows; new agents simply cannot choose
+  // them.
 } as const satisfies Record<string, ModelRegistryEntry>;
 
 export type ModelKey = keyof typeof MODEL_REGISTRY;
 
 // Category metadata for the picker UI tabs.
-export const CATEGORY_META: Record<AgentCategory, { label: string; description: string }> = {
+// Only categories that appear in CATEGORY_ORDER need an entry here; hermes
+// and milady were removed from the picker 2026-04-16 so they are typed as
+// optional. The agent HARNESS radio still offers all 4 harness options
+// (openclaw / hermes / milady / custom) — that's a separate control.
+export const CATEGORY_META: Partial<Record<AgentCategory, { label: string; description: string }>> = {
   openclaw: { label: 'OpenClaw',  description: 'Crustacean agents — external gateway or OpenClaw framework' },
-  hermes:   { label: 'Hermes',    description: 'Anime-style agents — Hermes framework' },
-  milady:   { label: 'Milady',    description: 'Milady AI runtime — Eliza-powered, app store native' },
   other:    { label: 'Other',     description: 'Sea-creature agents — any framework' },
 };
 
-// Ordered list of categories for tab rendering.
-export const CATEGORY_ORDER: AgentCategory[] = ['openclaw', 'hermes', 'milady', 'other'];
+// Ordered list of categories for tab rendering. Reduced to 2 tabs
+// (openclaw + other) 2026-04-16 — the anime GLBs in hermes/milady weren't
+// picker-quality. See MODEL_REGISTRY note above.
+export const CATEGORY_ORDER: AgentCategory[] = ['openclaw', 'other'];
 
 // Color presets — aligned with COLOR_TINTS hex values in SelectAgentCanvas so
 // the button background matches the actual GLB tint applied.
@@ -66,15 +70,17 @@ export const PICKER_COLORS = [
 export type PickerColorId = typeof PICKER_COLORS[number]['id'];
 
 // Default model per category — used when the user switches tabs.
-// `as const satisfies` keeps the exact ModelKey literals in the type so
-// typos like 'lobstar' fail at compile time, and downstream consumers can
-// drop the `as ModelKey` cast.
-export const CATEGORY_DEFAULT_MODEL = {
+// Typed as `Partial<Record<AgentCategory, ModelKey>>` because the picker
+// no longer exposes hermes/milady tabs (those AgentCategory values still
+// exist — the harness radio and DB CHECK constraint enforce them — but a
+// tab-switch will never fire for them). The explicit annotation (not
+// `as const satisfies`) lets consumers index by AgentCategory without a
+// literal-narrowing error; the consumer's `?? 'lobster'` fallback handles
+// the undefined case cleanly.
+export const CATEGORY_DEFAULT_MODEL: Partial<Record<AgentCategory, ModelKey>> = {
   openclaw: 'lobster',
-  hermes:   'chihiro',
-  milady:   'priestess',
   other:    'jellyfish',
-} as const satisfies Record<AgentCategory, ModelKey>;
+};
 
 // Agent harness options — controls which export format Phase 3 uses.
 export const HARNESS_OPTIONS = [
@@ -115,9 +121,6 @@ export const MODEL_KEY_TO_LEGACY_SPECIES: Record<ModelKey, LegacySpecies> = {
   sweet_crab:    'dragon',   // armored/fierce → dragon
   lobster_plush: 'bunny',    // cute/plush → bunny
   hermitcrab:    'turtle',   // shell-bearing → turtle
-  chihiro:       'fox',      // nimble/graceful → fox
-  priestess:     'owl',      // wise/gentle → owl
-  chibi_goku:    'wolf',     // strong/spirited → wolf
   jellyfish:     'phoenix',  // translucent/flowing → phoenix (residual bucket for sea creatures)
   octopus:       'phoenix',
   seahorse:      'phoenix',

--- a/packages/shared/src/constants/agent-models.ts
+++ b/packages/shared/src/constants/agent-models.ts
@@ -68,21 +68,16 @@ export const AGENT_MODELS = [
   { key: 'lobster_plush', label: 'Lobster Plush',   category: 'openclaw' },
   { key: 'hermitcrab',    label: 'Hermit Crab',     category: 'openclaw' },
 
-  // ── Hermes (anime — single representative) ──
-  { key: 'chihiro',       label: 'Chihiro',         category: 'hermes' },
-
-  // ── Milady (anime — placeholder until Milady-branded GLBs ship) ──
-  // Matches phase1-create-agent-3d.md §7.5 which placed both anime-style
-  // non-hermes models in this category so Milady has meaningful content
-  // while Hermes reduces to `chihiro` alone. Must stay in sync with the
-  // web-side `agent-model-registry.ts` category assignments.
-  { key: 'priestess',     label: 'Young Priestess', category: 'milady' },
-  { key: 'chibi_goku',    label: 'Chibi Goku',      category: 'milady' },
-
   // ── Other (sea creatures) ──
   { key: 'jellyfish',     label: 'Jellyfish',       category: 'other' },
   { key: 'octopus',       label: 'Octopus',         category: 'other' },
   { key: 'seahorse',      label: 'Sea Horse',       category: 'other' },
+
+  // NOTE: Hermes/Milady anime GLB entries (chihiro / priestess / chibi_goku)
+  // were removed 2026-04-16 because the source meshes didn't render reliably
+  // in the agent picker. The `AgentCategory` type keeps 'hermes' and 'milady'
+  // because the agent-HARNESS radio and DB CHECK constraint still use them
+  // — this change scopes strictly to the visual avatar picker content.
 ] as const satisfies readonly AgentModelMeta[];
 
 /** Union of every valid model `key` — e.g. `'lobster' | 'crayfish' | ...` */
@@ -134,7 +129,7 @@ export function getAgentModel(key: string): AgentModelMeta | undefined {
  * Returns the expected category for a `modelKey`, or undefined if the key
  * is unknown. Used server-side to cross-validate client-supplied
  * `(modelKey, agentCategory)` pairs so a mismatched payload (e.g.
- * `modelKey: 'priestess'` in category `'openclaw'`) is rejected early
+ * `modelKey: 'jellyfish'` in category `'openclaw'`) is rejected early
  * instead of drifting into the DB.
  */
 export function getAgentCategoryForModel(modelKey: string): AgentCategory | undefined {


### PR DESCRIPTION
## Summary

Two coordinated fixes under a 2hr deadline:

1. **Remove Hermes + Milady avatar tabs** — the 3D models in those categories (chihiro, priestess, chibi_goku) didn't render well. Keep only OpenClaw (5 crustaceans) and Other (3 sea creatures). The `AgentHarness` radio keeps all 4 harness options unchanged — Milady is still the recommended deployment target per Priority #1.
2. **Fix lobster visibility** — previous camera pinned the pedestal behind the config modal. User could only see stray claws. New camera sits higher (y=40) and further back (z=70) with a 28° downward pitch, so the model renders in the clear zone above the form card.

## Before / after

See the production screenshot in session context — hermit crab filled the entire viewport with the modal covering 80% of it. After: model lives in the upper ~30% of the screen, modal sits cleanly below.

## Team

Parallel collaborative team (strict file-ownership split):
- 3da (ultrathink) → `SelectAgentCanvas.tsx` camera reposition + polar-angle tighten
- general-purpose (ultrathink) → `agent-models.ts` + `agent-model-registry.ts` + `page.tsx` registry edits

3da caught + fixed 3 latent TS/runtime bugs in page.tsx from the Partial Record retyping.

## Test plan

- [ ] `bun run build` passes — verified locally (7/7 packages, 24 routes, 0 TS errors)
- [ ] Deploy to Hetzner via Coolify
- [ ] Open `https://clawville.world/create-agent` — verify only 2 tabs (OpenClaw, Other)
- [ ] Lobster clearly visible above the form card, not occluded by modal
- [ ] All 5 OpenClaw models + 3 Other models render without floor-clip / viewport-cutoff
- [ ] Harness radio still shows all 4 options (OpenClaw / Hermes / Milady / Custom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)