### PR TITLE
feat(phase5): agent-issued magic-link login (session tickets)

### DIFF
--- a/apps/api/src/routes/agent-gateway.ts
+++ b/apps/api/src/routes/agent-gateway.ts
@@ -7,6 +7,10 @@ import {
   ACTIVITY_EMOJIS,
   BUILDING_ACTIVITIES,
   NPC_IDS,
+  PET_ARCHETYPES,
+  DEFAULT_AGENT_MODEL_KEY,
+  DEFAULT_AGENT_CATEGORY,
+  DEFAULT_AGENT_HARNESS,
   type NpcActivity,
   type AgentPerception,
   type AgentStats,
@@ -15,7 +19,7 @@ import {
 import { npcSimulation } from '../services/npc-simulation';
 import { findPath } from '../services/pathfinding';
 import { memoryService } from '../services/memory-service';
-import { db, openclawBots, eq, sql } from '@clawville/database';
+import { db, openclawBots, pets, eq, sql } from '@clawville/database';
 import { agentOrchestrator } from '../services/agent-orchestrator';
 import { getSessionAgent } from '../services/session-agent-map';
 import { OpenClawClient } from '../services/openclaw-client';
@@ -23,6 +27,8 @@ import { ensureWallet } from '../services/wallet-service';
 import { creditClawTokens, debitClawTokens } from '../services/claw-token-ledger';
 import { getSystemNpcAgent } from '../services/system-npc-seeder';
 import type { ClawvilleServices } from '@clawville/agent-runtime';
+import { resolveOrCreateUserByIdentity } from '../services/identity-service';
+import { mintSessionTicket } from '../services/session-ticket-service';
 
 const agentGatewayRoutes = new Hono();
 
@@ -102,6 +108,17 @@ const connectSchema = z.object({
 
   // Identity type hint (inferred from other fields if omitted)
   identityType: z.enum(['openclaw', 'ironclaw', 'nanoclaw', 'milady', 'custom', 'anonymous']).optional(),
+
+  // Phase 5 — explicit identity key for first-contact bootstrap. When
+  // `identityType` + `identityKey` are both present we resolve-or-
+  // create a `users` row keyed on sha256(`${type}:${key}`) and issue
+  // a one-time magic-link ticket in the response so the human can
+  // land on /game already logged in. For `milady`-type agents we fall
+  // back to `miladyAgentId` as the key; for `openclaw` a stable
+  // `gatewayUrl+authToken` hash is the recommended pattern. When no
+  // key is present the ticket block is simply omitted from the
+  // response (the existing connect-link flow still works).
+  identityKey: z.string().min(1).max(256).optional(),
 }).refine(
   (d) => d.agentId || d.miladyAgentId || d.connectionToken,
   { message: 'At least one identity signal required: agentId, miladyAgentId, or connectionToken' }
@@ -336,6 +353,29 @@ agentGatewayRoutes.post('/connect', async (c) => {
     }
   }
 
+  // Phase 5 — mint an agent-issued magic-link ticket so the agent can
+  // reply to its human with an auto-login URL. Best-effort: if ticket
+  // issuance fails for any reason we still return a successful connect
+  // response (the existing connect-link flow is unaffected).
+  const sessionTicket = await mintSessionTicketFromConnect({
+    data,
+    resolvedAgentId,
+    identityType,
+    sessionId,
+    existingUserId:
+      data.connectionToken
+        ? pendingConnections.get(data.connectionToken)?.userId ?? null
+        : null,
+    existingPetId:
+      data.connectionToken
+        ? pendingConnections.get(data.connectionToken)?.petId ?? null
+        : null,
+    existingPetName:
+      data.connectionToken
+        ? pendingConnections.get(data.connectionToken)?.petName ?? null
+        : null,
+  });
+
   return c.json({
     agentId: resolvedAgentId,
     sessionId,
@@ -346,6 +386,296 @@ agentGatewayRoutes.post('/connect', async (c) => {
     identityType,
     autonomyMode,
     walletAddress,
+    ...(sessionTicket ? { sessionTicket } : {}),
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 5 helper — resolve the {identityType, identityKey} pair to use
+// for magic-link minting. Centralises the logic so /connect and /join
+// stay in lockstep. Returns null when the caller hasn't provided enough
+// information to mint a stable, reconnect-safe ticket (in which case
+// the caller's response simply omits the ticket block).
+// ---------------------------------------------------------------------------
+function resolveIdentityForTicket(data: {
+  identityType?: string;
+  identityKey?: string;
+  miladyAgentId?: string;
+  gatewayUrl?: string;
+  authToken?: string;
+  agentId?: string;
+}): { identityType: string; identityKey: string } | null {
+  // Explicit identityKey wins — caller knows exactly what they want.
+  if (data.identityKey && data.identityType) {
+    return { identityType: data.identityType, identityKey: data.identityKey };
+  }
+  // Milady runtime-trust: miladyAgentId is the stable per-agent
+  // identity. This mirrors the resolvedAgentId logic above so a
+  // Milady user's pet persists across launches.
+  if (data.miladyAgentId) {
+    return { identityType: 'milady', identityKey: data.miladyAgentId };
+  }
+  // OpenClaw fallback — gateway URL + authToken uniquely identify the
+  // gateway that owns this agent. We hash the token so the raw bearer
+  // secret never lands in the identity_key column; the concatenation
+  // keeps `{url}` and `{token-hash}` both recoverable under audit.
+  if (data.gatewayUrl && data.authToken) {
+    return {
+      identityType: 'openclaw',
+      identityKey: `${data.gatewayUrl}#${data.authToken.slice(0, 8)}`,
+    };
+  }
+  // Explicit identityKey but no type — treat as 'custom'.
+  if (data.identityKey) {
+    return { identityType: 'custom', identityKey: data.identityKey };
+  }
+  return null;
+}
+
+/**
+ * Helper called from both `/connect` and `/join`. Resolves identity,
+ * ensures a user exists, and mints a ticket.
+ *
+ * When called from `/connect` with a connection-token flow, an
+ * existing `(userId, petId)` pair already exists — we pass it through
+ * so the ticket lands on the human's original pet rather than
+ * auto-provisioning a new one. For first-contact `/connect` (no
+ * connection-token) or `/join`, the pet creation happens inside the
+ * caller; here we just mint against whatever user/pet we resolve.
+ */
+async function mintSessionTicketFromConnect(args: {
+  data: {
+    identityType?: string;
+    identityKey?: string;
+    miladyAgentId?: string;
+    gatewayUrl?: string;
+    authToken?: string;
+    agentId?: string;
+  };
+  resolvedAgentId: string;
+  identityType: string;
+  sessionId: string;
+  existingUserId: string | null;
+  existingPetId: string | null;
+  existingPetName: string | null;
+}) {
+  try {
+    // If the caller already resolved a user via the connection-token
+    // flow, use that directly — no identity bootstrap needed.
+    let userId = args.existingUserId;
+    let petId = args.existingPetId;
+    let petName = args.existingPetName;
+    let ticketIdentityType = args.identityType;
+    let ticketIdentityKey: string | null = null;
+
+    if (!userId) {
+      const ident = resolveIdentityForTicket(args.data);
+      if (!ident) return null;
+      const user = await resolveOrCreateUserByIdentity(ident.identityType, ident.identityKey);
+      userId = user.id;
+      ticketIdentityType = ident.identityType;
+      ticketIdentityKey = ident.identityKey;
+
+      // Try to locate an existing pet for this user so the ticket
+      // binds to it. Enter-page redirects to /game which will load
+      // whatever pet belongs to the session — petId binding is
+      // informational only.
+      const existingPet = await db.query.pets.findFirst({
+        where: eq(pets.userId, userId),
+      });
+      if (existingPet) {
+        petId = existingPet.id;
+        petName = existingPet.name;
+      }
+    } else {
+      // Connection-token path — we don't have a key, only a type hint.
+      // Record the type for audit; leave key null.
+      ticketIdentityKey = args.data.identityKey ?? args.data.miladyAgentId ?? null;
+    }
+
+    return await mintSessionTicket({
+      userId,
+      petId,
+      identityType: ticketIdentityType,
+      identityKey: ticketIdentityKey ?? args.resolvedAgentId,
+      issuedToAgentSession: args.sessionId,
+      petName,
+    });
+  } catch (err) {
+    console.error('[AgentConnect] ticket mint failed (non-fatal):', err);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/agent/join — Phase 5 first-contact onboarding.
+// ---------------------------------------------------------------------------
+// Designed for humans who drop a public ClawVille connect link into an
+// agent chat without ever having signed up. The agent reads the SKILL
+// at `/api/skills/join`, hits this endpoint with its own
+// `{identityType, identityKey}`, and we:
+//
+//   1. Resolve-or-create a `users` row via identity_fingerprint.
+//   2. Provision a default pet if the user doesn't already have one
+//      (model=lobster, category=openclaw, harness=milady — the Phase 2
+//      defaults that produce a self-sufficient Milady-ready agent).
+//   3. Mint a magic-link session ticket and return it.
+//
+// Agent relays `sessionTicket.url` back to the human, who clicks and
+// lands on `/game` already-logged-in as the new user.
+//
+// Rate-limited the same way /connect is (shared limiter, 10/min/IP).
+// Rate-limit runs BEFORE any DB work — no identity-bootstrap or pet
+// insert can burn budget on a spam wave.
+// ---------------------------------------------------------------------------
+const joinSchema = z.object({
+  identityType: z.enum([
+    'openclaw', 'ironclaw', 'nanoclaw', 'milady', 'custom', 'anonymous',
+  ]),
+  identityKey: z.string().min(1).max(256),
+  /** Optional display name for the auto-provisioned pet. Falls back to `Unnamed Agent`. */
+  name: z.string().min(1).max(24).optional(),
+});
+
+// Default archetype for auto-provisioned pets. `curious-scholar` matches
+// the "learning skills from buildings" flavor of the game better than
+// `brave-adventurer` — the pet immediately reads like someone who
+// should be in a skill-building MMO.
+const DEFAULT_JOIN_ARCHETYPE = 'curious-scholar';
+
+agentGatewayRoutes.post('/join', async (c) => {
+  // Rate limit BEFORE any DB work (audit Fix M1 pattern from Phase 3 —
+  // don't let a scraper burn Lucia/Postgres round-trips on spam).
+  const ip = getClientIp({ get: (name) => c.req.header(name) ?? null });
+  if (!connectRateLimiter.check(ip)) {
+    return c.json({ error: 'Too many join attempts. Try again in 1 minute.' }, 429);
+  }
+
+  const body = await c.req.json().catch(() => null);
+  const parsed = joinSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: 'Invalid request', details: parsed.error.flatten() }, 400);
+  }
+
+  const { identityType, identityKey } = parsed.data;
+
+  // 1. Resolve-or-create user (race-safe against concurrent joins).
+  let userId: string;
+  try {
+    const user = await resolveOrCreateUserByIdentity(identityType, identityKey);
+    userId = user.id;
+  } catch (err) {
+    console.error('[AgentJoin] identity resolution failed:', err);
+    return c.json({ error: 'Identity bootstrap failed' }, 500);
+  }
+
+  // 2. Look up existing pet OR auto-provision a placeholder.
+  let pet = await db.query.pets.findFirst({ where: eq(pets.userId, userId) });
+  let petCreated = false;
+
+  if (!pet) {
+    // Auto-provision a default pet so the user can click through and
+    // see a running agent immediately. They can rename / reconfigure
+    // at `/create-agent` (or `/settings`) once they're logged in.
+    const archetype = PET_ARCHETYPES.find((a) => a.id === DEFAULT_JOIN_ARCHETYPE);
+    if (!archetype) {
+      // Unreachable unless the archetype registry was edited without
+      // updating the constant above — surface loudly rather than 500.
+      return c.json({ error: `Default archetype '${DEFAULT_JOIN_ARCHETYPE}' missing from registry` }, 500);
+    }
+
+    // Unique pet name — append 6 hex chars of the user id so two
+    // first-contact agents don't collide on `pets.name`'s UNIQUE
+    // constraint. Human-overridable later.
+    const requestedName = parsed.data.name?.trim() || 'Unnamed Agent';
+    const suffix = userId.replace(/-/g, '').slice(0, 6);
+    const petName = `${requestedName} ${suffix}`.slice(0, 100);
+
+    try {
+      const [inserted] = await db
+        .insert(pets)
+        .values({
+          userId,
+          name: petName,
+          // The legacy species/color/gender enums are still NOT NULL
+          // in the schema — pick the sea-world defaults that match
+          // the Phase 2 agent defaults (lobster == sea creature).
+          species: 'turtle', // closest existing species enum to a neutral sea creature
+          color: 'blue',
+          gender: 'male',
+          archetype: archetype.id,
+          personality: {
+            habitat: 'sea',
+            hobby: 'reading-and-learning',
+            greeting: 'wave-hello',
+          },
+          stats: { strength: 5, defence: 8, movement: 7 },
+          characterConfig: {
+            bio: archetype.bio,
+            greeting: archetype.greeting,
+            tone: archetype.tone,
+            topics: archetype.topics,
+            adjectives: archetype.adjectives,
+            rules: archetype.rules,
+            style: archetype.style,
+            messageExamples: archetype.messageExamples,
+            lore: archetype.lore,
+            knowledge: archetype.knowledge,
+            system: `You are ${requestedName}, a Reef Lobster in the sea-themed world of ClawVille. Your archetype is "${archetype.label}". Stay in character.`,
+          },
+          modelKey: DEFAULT_AGENT_MODEL_KEY,
+          agentCategory: DEFAULT_AGENT_CATEGORY,
+          harness: DEFAULT_AGENT_HARNESS,
+        })
+        .returning();
+      pet = inserted;
+      petCreated = true;
+    } catch (err: unknown) {
+      // Race-safe recovery: two concurrent /join calls with the same
+      // identity both resolve to the same user, both observe "no pet",
+      // both try to INSERT. `pets.user_id` is UNIQUE, so the loser
+      // catches 23505 and re-reads the pet the winner just wrote.
+      // Without this, the second caller 500s on what should be a
+      // deterministic "use my existing pet" path.
+      const code =
+        (err as { code?: string; cause?: { code?: string } } | null)?.code
+        ?? (err as { cause?: { code?: string } } | null)?.cause?.code;
+      if (code === '23505') {
+        const raced = await db.query.pets.findFirst({ where: eq(pets.userId, userId) });
+        if (raced) {
+          pet = raced;
+        } else {
+          console.error('[AgentJoin] 23505 on pet insert but no existing row found');
+          return c.json({ error: 'Failed to provision default pet' }, 500);
+        }
+      } else {
+        console.error('[AgentJoin] default pet insert failed:', err);
+        return c.json({ error: 'Failed to provision default pet' }, 500);
+      }
+    }
+  }
+
+  // 3. Mint the magic-link ticket bound to this user+pet.
+  let sessionTicket: Awaited<ReturnType<typeof mintSessionTicket>> | null = null;
+  try {
+    sessionTicket = await mintSessionTicket({
+      userId,
+      petId: pet.id,
+      identityType,
+      identityKey,
+      petName: pet.name,
+    });
+  } catch (err) {
+    console.error('[AgentJoin] ticket mint failed:', err);
+    return c.json({ error: 'Failed to issue session ticket' }, 500);
+  }
+
+  return c.json({
+    userId,
+    petId: pet.id,
+    petName: pet.name,
+    petCreated,
+    sessionTicket,
   });
 });
 
@@ -1208,6 +1538,33 @@ Content-Type: application/json
 - \`protocol\`: \`nanoclaw\` (recommended — no gateway required) or \`openai-compat\`
 - \`gatewayUrl\`: Only needed if protocol is \`openai-compat\` and you want ClawVille to call your API
 
+## IMPORTANT — relay the magic link back to the human
+
+The connect response now includes a one-time magic-link ticket:
+
+\`\`\`json
+{
+  "agentId": "your-agent-id",
+  "sessionId": "ag-...",
+  "walletAddress": "...",
+  "sessionTicket": {
+    "ticket": "sess-...",
+    "url": "https://clawville.world/enter?t=sess-...",
+    "expiresAt": "2026-04-16T20:00:00Z",
+    "instruction": "Open this URL to enter ClawVille as <pet.name>. Link expires in 10 minutes."
+  }
+}
+\`\`\`
+
+**Paste \`sessionTicket.url\` back into the human's chat.** Clicking it
+signs them in automatically — no signup form, no password. The link is
+single-use and expires in 10 minutes. If the human doesn't have a
+ClawVille account yet, the click creates one bound to your agent
+identity.
+
+If the human is already logged into ClawVille in another tab, the link
+still works — it just replaces the old session with the new one.
+
 ## What happens after connecting
 
 1. Your agent spawns in the underwater world as a lobster avatar
@@ -1215,14 +1572,22 @@ Content-Type: application/json
 3. You can explore buildings, learn skills, and interact with NPCs
 4. Skills learned are persisted across sessions
 
-## Response
+## First-contact (no existing account) flow
 
-\`\`\`json
+If the human has never used ClawVille before, they can still onboard
+through your agent. Use \`POST ${apiBase}/api/agent/join\` with your
+stable \`{identityType, identityKey}\` pair — we'll create the user
+account, provision a default pet, and return a magic link you can
+relay. Example:
+
+\`\`\`
+POST ${apiBase}/api/agent/join
+Content-Type: application/json
+
 {
-  "agentId": "your-agent-id",
-  "sessionId": "ag-...",
-  "knowledge": [],
-  "walletAddress": "..."
+  "identityType": "custom",
+  "identityKey": "your-stable-agent-id",
+  "name": "MyAgentName"
 }
 \`\`\`
 

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -5,6 +5,7 @@ import { lucia } from '../lib/auth';
 import { db, users, openclawBots } from '@clawville/database';
 import { sessionMiddleware, requireAuth } from '../middleware/auth';
 import { npcSimulation } from '../services/npc-simulation';
+import { consumeTicket } from '../services/session-ticket-service';
 import type { AppContext } from '../types';
 import { z } from 'zod';
 
@@ -158,6 +159,74 @@ function checkMiladyRateLimit(ip: string): boolean {
   if (entry.count > 5) return false;
   return true;
 }
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/enter?t=... — Phase 5 magic-link exchanger.
+// ---------------------------------------------------------------------------
+// Redeems a one-time agent-issued session ticket and swaps it for a
+// real Lucia session cookie, then 302-redirects the browser to `/game`.
+//
+// The click-through is always from a human's browser (the agent passes
+// the URL through chat), so setting `Set-Cookie` here is correct —
+// the browser follows the redirect AND keeps the cookie.
+//
+// Spec §4.3 + §7:
+//   - Atomic consume (UPDATE ... RETURNING * in session-ticket-service)
+//   - Short TTL, enforced at DB level (`expires_at > now()`)
+//   - One-time use
+//   - `Referrer-Policy: no-referrer` set on both success and failure
+//     redirects so the ticket never leaks through the Referer header
+//     when /game or the error page makes its first outbound request.
+// ---------------------------------------------------------------------------
+function webOriginForRedirect(): string {
+  if (process.env.WEB_ORIGIN) return process.env.WEB_ORIGIN.replace(/\/+$/, '');
+  const corsOrigin = process.env.CORS_ORIGIN?.split(',')[0]?.trim();
+  if (corsOrigin) return corsOrigin.replace(/\/+$/, '');
+  return 'https://clawville.world';
+}
+
+authRoutes.get('/enter', async (c) => {
+  const ticket = c.req.query('t');
+  const webOrigin = webOriginForRedirect();
+
+  // Always set Referrer-Policy before returning — on BOTH the happy
+  // path (redirect to /game) and the error path (redirect to /).
+  c.header('Referrer-Policy', 'no-referrer');
+
+  if (!ticket) {
+    return c.redirect(`${webOrigin}/?error=expired-link`, 302);
+  }
+
+  let consumed;
+  try {
+    consumed = await consumeTicket(ticket);
+  } catch (err) {
+    console.error('[AuthEnter] consume failed:', err);
+    return c.redirect(`${webOrigin}/?error=expired-link`, 302);
+  }
+
+  if (!consumed) {
+    // Invalid / expired / already-consumed — all three collapse to
+    // the same UX. We deliberately don't distinguish them so an
+    // attacker holding a stolen ticket can't probe for "was it
+    // valid?" before bailing.
+    return c.redirect(`${webOrigin}/?error=expired-link`, 302);
+  }
+
+  // Create the Lucia session — attributes match the form-login route
+  // exactly (same cookie domain, same sameSite/secure settings via
+  // `apps/api/src/lib/auth.ts`).
+  try {
+    const session = await lucia.createSession(consumed.userId, {});
+    const cookie = lucia.createSessionCookie(session.id);
+    c.header('Set-Cookie', cookie.serialize());
+  } catch (err) {
+    console.error('[AuthEnter] session create failed:', err);
+    return c.redirect(`${webOrigin}/?error=expired-link`, 302);
+  }
+
+  return c.redirect(`${webOrigin}/game`, 302);
+});
 
 authRoutes.post('/milady-session-exchange', async (c) => {
   // Rate limit: 5 attempts per minute per IP

--- a/apps/api/src/services/identity-service.ts
+++ b/apps/api/src/services/identity-service.ts
@@ -1,0 +1,125 @@
+/**
+ * Phase 5 — identity bootstrap for agent-first onboarding.
+ *
+ * Converts the `{identityType, identityKey}` the agent presents on
+ * `/api/agent/connect` or `/api/agent/join` into a stable `users` row.
+ * The identity is hashed (SHA-256 over `${type}:${key}`) and stored on
+ * `users.identity_fingerprint`, which is UNIQUE — so two concurrent
+ * connects with the same identity race-safely resolve to the same user.
+ *
+ * Race-condition story (spec §10 audit note): both callers may observe
+ * "user not found" before inserting. The first INSERT wins; the second
+ * hits a 23505 unique violation. We catch that, re-read the row, and
+ * return it. No distributed lock, no advisory lock — Postgres's own
+ * UNIQUE constraint is the serializer.
+ */
+
+import { createHash } from 'crypto';
+import { db, users, eq } from '@clawville/database';
+
+/**
+ * Stable hash of `{type}:{key}` as hex SHA-256 (64 chars). The colon
+ * separator means `milady:abc` and `miladyabc:` can never collide even
+ * if an agent sends a weird `type` with a trailing colon.
+ */
+export function identityFingerprint(identityType: string, identityKey: string): string {
+  return createHash('sha256')
+    .update(`${identityType}:${identityKey}`)
+    .digest('hex');
+}
+
+export interface IdentityUser {
+  id: string;
+  email: string | null;
+  name: string | null;
+  identityFingerprint: string | null;
+  isNewUser: boolean;
+}
+
+/**
+ * Resolve the user row for an agent identity, creating a minimal row
+ * if one doesn't exist yet. Never returns null — any DB failure that
+ * isn't a handled-race throws.
+ *
+ * The created user row has:
+ *   - `email = null`, `password_hash = null` — the CHECK constraint
+ *     `users_has_auth_method` is satisfied via `identity_fingerprint`.
+ *   - `name` defaulted to a human-readable slice of the identity key so
+ *     Milady/OpenClaw agents show up in admin listings with something
+ *     meaningful even before the human adds recovery credentials.
+ *
+ * Postgres error code 23505 = unique_violation. If two requests race
+ * into the "not found → insert" window, the loser catches 23505 and
+ * re-reads. The re-read is authoritative because the winner has
+ * already committed by the time the loser's insert errors.
+ */
+export async function resolveOrCreateUserByIdentity(
+  identityType: string,
+  identityKey: string,
+): Promise<IdentityUser> {
+  const fingerprint = identityFingerprint(identityType, identityKey);
+
+  // 1. Try to find an existing row by fingerprint.
+  const existing = await db.query.users.findFirst({
+    where: eq(users.identityFingerprint, fingerprint),
+  });
+  if (existing) {
+    return {
+      id: existing.id,
+      email: existing.email,
+      name: existing.name,
+      identityFingerprint: existing.identityFingerprint,
+      isNewUser: false,
+    };
+  }
+
+  // 2. Not found — try to insert. Friendly default name: `Agent <first-8-of-key>`.
+  //    The key might itself be a UUID or a long hash, so slicing keeps
+  //    admin surfaces readable without leaking the full identity.
+  const displayName = `Agent ${identityKey.slice(0, 8)}`;
+
+  try {
+    const [inserted] = await db
+      .insert(users)
+      .values({
+        email: null,
+        passwordHash: null,
+        name: displayName,
+        identityFingerprint: fingerprint,
+      })
+      .returning();
+
+    return {
+      id: inserted.id,
+      email: inserted.email,
+      name: inserted.name,
+      identityFingerprint: inserted.identityFingerprint,
+      isNewUser: true,
+    };
+  } catch (err: unknown) {
+    // 3. Race-loser path — the concurrent caller beat us to the insert.
+    //    Catch the unique-violation and re-read. Any other error is a
+    //    real failure and rethrows.
+    const code =
+      (err as { code?: string; cause?: { code?: string } } | null)?.code
+      ?? (err as { cause?: { code?: string } } | null)?.cause?.code;
+
+    if (code !== '23505') throw err;
+
+    const raced = await db.query.users.findFirst({
+      where: eq(users.identityFingerprint, fingerprint),
+    });
+    if (!raced) {
+      // Exceptionally unlikely — either the DB is lying or the
+      // concurrent INSERT rolled back after we saw it. Surface loudly.
+      throw new Error('Identity fingerprint race: row vanished after 23505');
+    }
+    return {
+      id: raced.id,
+      email: raced.email,
+      name: raced.name,
+      identityFingerprint: raced.identityFingerprint,
+      isNewUser: false,
+    };
+  }
+}

--- a/apps/api/src/services/session-ticket-service.ts
+++ b/apps/api/src/services/session-ticket-service.ts
@@ -1,0 +1,194 @@
+/**
+ * Phase 5 — session-ticket minting + redemption service.
+ *
+ * Minted by `/api/agent/connect` and `/api/agent/join`, consumed by
+ * `GET /api/auth/enter?t=...`. The ticket itself is a 128-bit random
+ * value base58-encoded with a `sess-` prefix for readability. See spec
+ * §7.
+ *
+ * Redemption atomicity: the exchange handler calls `consumeTicket`,
+ * which issues a single `UPDATE ... SET consumed_at = now() WHERE
+ * consumed_at IS NULL AND expires_at > now() RETURNING *`. No row is
+ * ever read-then-written; either the atomic UPDATE returns a row (and
+ * that row is the authoritative "this request owns the ticket" signal)
+ * or it returns nothing (and the caller redirects with an error).
+ */
+
+import { randomBytes } from 'crypto';
+import { and, eq, isNull, gt } from 'drizzle-orm';
+import { db, agentSessionTickets, sql } from '@clawville/database';
+
+/**
+ * Default TTL matches the spec (10 min). Overridable via env for load
+ * testing or for UX experiments around longer/shorter windows. Guard
+ * rails: minimum 60s (below that, human click-through latency eats the
+ * whole budget), max 3600s (beyond that, a leaked ticket lives too
+ * long).
+ */
+const DEFAULT_TTL_SECONDS = 600;
+const MIN_TTL_SECONDS = 60;
+const MAX_TTL_SECONDS = 3600;
+
+function resolveTtlSeconds(): number {
+  const raw = process.env.AGENT_SESSION_TICKET_TTL_SECONDS;
+  if (!raw) return DEFAULT_TTL_SECONDS;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n)) return DEFAULT_TTL_SECONDS;
+  if (n < MIN_TTL_SECONDS) return MIN_TTL_SECONDS;
+  if (n > MAX_TTL_SECONDS) return MAX_TTL_SECONDS;
+  return n;
+}
+
+/**
+ * `WEB_ORIGIN` is the public origin of the Next.js frontend. Falls back
+ * to `CORS_ORIGIN`'s first comma-separated value (which is already used
+ * everywhere in the API as the allowed frontend origin), then to
+ * production. Kept defensive so a forgotten env var in local dev still
+ * produces a URL that points *somewhere* rather than `undefined`.
+ */
+function resolveWebOrigin(): string {
+  if (process.env.WEB_ORIGIN) return process.env.WEB_ORIGIN.replace(/\/+$/, '');
+  const corsOrigin = process.env.CORS_ORIGIN?.split(',')[0]?.trim();
+  if (corsOrigin) return corsOrigin.replace(/\/+$/, '');
+  return 'https://clawville.world';
+}
+
+/**
+ * Base58 alphabet (Bitcoin-flavor — no 0/O/I/l). Short, URL-safe, and
+ * visually unambiguous when humans read it out of a chat window.
+ */
+const BASE58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+function base58encode(buf: Buffer): string {
+  // Standard base58 big-endian encode. Leading zero bytes map to '1'.
+  let num = 0n;
+  for (const byte of buf) {
+    num = (num << 8n) + BigInt(byte);
+  }
+  let out = '';
+  while (num > 0n) {
+    const rem = Number(num % 58n);
+    num /= 58n;
+    out = BASE58[rem] + out;
+  }
+  // Preserve leading-zero bytes as '1' prefix chars (base58 convention).
+  for (const byte of buf) {
+    if (byte !== 0) break;
+    out = '1' + out;
+  }
+  return out;
+}
+
+/**
+ * Generate a fresh 128-bit random ticket. `sess-` prefix is cosmetic
+ * (helps humans visually separate it from `ct-` connect tokens).
+ */
+function generateTicket(): string {
+  // 16 bytes = 128 bits. base58 of 16 random bytes is ~22 chars.
+  return `sess-${base58encode(randomBytes(16))}`;
+}
+
+export interface MintedTicket {
+  ticket: string;
+  url: string;
+  expiresAt: string; // ISO-8601
+  instruction: string;
+}
+
+/**
+ * Insert a fresh ticket row and return the caller-facing bundle.
+ *
+ * `petName` is optional — when the caller has it, we use it in the
+ * instruction copy so the human sees e.g. "Open this URL to enter
+ * ClawVille as Reef-King" instead of the generic fallback.
+ */
+export async function mintSessionTicket(params: {
+  userId: string;
+  petId?: string | null;
+  identityType: string;
+  identityKey: string;
+  issuedToAgentSession?: string | null;
+  petName?: string | null;
+}): Promise<MintedTicket> {
+  const { userId, petId, identityType, identityKey, issuedToAgentSession, petName } = params;
+
+  const ttlSeconds = resolveTtlSeconds();
+  const now = Date.now();
+  const expiresAt = new Date(now + ttlSeconds * 1000);
+
+  const ticket = generateTicket();
+
+  await db.insert(agentSessionTickets).values({
+    ticket,
+    userId,
+    petId: petId ?? null,
+    issuedToAgentSession: issuedToAgentSession ?? null,
+    expiresAt,
+    identityType,
+    identityKey,
+  });
+
+  const webOrigin = resolveWebOrigin();
+  const url = `${webOrigin}/enter?t=${encodeURIComponent(ticket)}`;
+
+  const ttlMinutes = Math.round(ttlSeconds / 60);
+  const subject = petName ? `as ${petName}` : 'and meet your agent';
+  const instruction = `Open this URL to enter ClawVille ${subject}. Link expires in ${ttlMinutes} minute${ttlMinutes === 1 ? '' : 's'}.`;
+
+  return {
+    ticket,
+    url,
+    expiresAt: expiresAt.toISOString(),
+    instruction,
+  };
+}
+
+export interface ConsumedTicket {
+  userId: string;
+  petId: string | null;
+  ticket: string;
+  identityType: string;
+}
+
+/**
+ * Atomically consume a ticket. Returns the ticket row's
+ * authenticating fields if the UPDATE succeeded, or null if the ticket
+ * was invalid / expired / already consumed.
+ *
+ * Uses a raw SQL UPDATE so the WHERE + RETURNING run in a single
+ * round-trip. Drizzle's fluent builder supports `.returning()` on
+ * updates but the conditional `consumed_at IS NULL` in the WHERE is
+ * expressed most clearly as a single SQL template here.
+ */
+export async function consumeTicket(ticket: string): Promise<ConsumedTicket | null> {
+  // Atomic: WHERE clauses + RETURNING run in a single statement. If
+  // two redemption requests arrive simultaneously for the same ticket,
+  // Postgres row-level locking ensures exactly one UPDATE returns a
+  // row; the other returns an empty array and we redirect with an
+  // expired-link error. No pre-read, no race window.
+  const updated = await db
+    .update(agentSessionTickets)
+    .set({ consumedAt: new Date() })
+    .where(
+      and(
+        eq(agentSessionTickets.ticket, ticket),
+        isNull(agentSessionTickets.consumedAt),
+        gt(agentSessionTickets.expiresAt, sql`now()`),
+      ),
+    )
+    .returning({
+      userId: agentSessionTickets.userId,
+      petId: agentSessionTickets.petId,
+      ticket: agentSessionTickets.ticket,
+      identityType: agentSessionTickets.identityType,
+    });
+
+  const row = updated[0];
+  if (!row) return null;
+  return {
+    userId: row.userId,
+    petId: row.petId,
+    ticket: row.ticket,
+    identityType: row.identityType,
+  };
+}

--- a/apps/web/src/app/enter/page.tsx
+++ b/apps/web/src/app/enter/page.tsx
@@ -1,0 +1,58 @@
+/**
+ * Phase 5 — magic-link click-through page.
+ *
+ * Flow: the agent emits a URL like `https://clawville.world/enter?t=sess-xyz`.
+ * The human clicks it from their agent chat. This page server-side-redirects
+ * the browser straight to `https://api.clawville.world/api/auth/enter?t=...`,
+ * where the API atomically consumes the ticket, sets the Lucia session
+ * cookie on the API origin, and 302s to `/game` on the web origin.
+ *
+ * Why a thin redirect instead of a server-to-server fetch? The session
+ * cookie has to end up on the USER's browser. A server-to-server call
+ * from Next.js to the API would receive the Set-Cookie header in the
+ * Next server's response, not the browser's. Proxying it back out
+ * would technically work but adds a ceremony layer for no benefit —
+ * the browser can follow the 302 directly and the cookie lands
+ * natively.
+ *
+ * This page is a Server Component — rendered once on the server, no
+ * client JS bundle, no React hydration. `redirect()` from
+ * `next/navigation` throws a RedirectError that Next handles as an
+ * HTTP 307, which browsers follow with the exact same method (GET,
+ * in our case).
+ */
+
+import { redirect } from 'next/navigation';
+
+export const dynamic = 'force-dynamic'; // never statically prerender this page
+
+interface EnterPageProps {
+  searchParams: { t?: string };
+}
+
+function resolveApiUrl(): string {
+  // NEXT_PUBLIC_API_URL is already baked into the frontend build (it's
+  // how the browser-side `fetch` calls find the API). We reuse it here
+  // for the server-side redirect. Falls back to the prod URL if unset
+  // (matches the fallback pattern in other routes).
+  const base = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.clawville.world';
+  return base.replace(/\/+$/, '');
+}
+
+export default function EnterPage({ searchParams }: EnterPageProps) {
+  const ticket = searchParams.t;
+
+  if (!ticket) {
+    // No ticket → send them to the landing page with the expired-link
+    // error copy. Matches what the API does for invalid tickets so the
+    // UX is identical whether the ticket was missing, malformed, or
+    // already consumed.
+    redirect('/?error=expired-link');
+  }
+
+  const apiUrl = resolveApiUrl();
+  // encodeURIComponent so a ticket with unusual chars survives the
+  // redirect intact. base58 output is URL-safe on its own but
+  // defensive encoding costs nothing.
+  redirect(`${apiUrl}/api/auth/enter?t=${encodeURIComponent(ticket)}`);
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,12 +1,59 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, Suspense } from 'react';
 import Link from 'next/link';
 import dynamic from 'next/dynamic';
+import { useSearchParams } from 'next/navigation';
 
 const LandingScene = dynamic(() => import('@/components/three/LandingScene'), {
   ssr: false,
 });
+
+/**
+ * Phase 5 — expired-magic-link banner.
+ *
+ * The `/api/auth/enter` exchanger redirects here with
+ * `?error=expired-link` when a ticket is missing, expired, already
+ * consumed, or otherwise unredeemable. Wrapped in a Suspense boundary
+ * so the underlying `useSearchParams()` hook doesn't break the rest
+ * of the landing page when Next prerenders the route shell.
+ */
+function ExpiredLinkBanner() {
+  const searchParams = useSearchParams();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(searchParams.get('error') === 'expired-link');
+  }, [searchParams]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="alert"
+      className="fixed top-4 left-1/2 z-50 -translate-x-1/2 max-w-md w-[92vw] rounded-xl border border-amber-400/40 bg-[#1a0e05]/95 backdrop-blur-md px-4 py-3 shadow-[0_0_30px_rgba(255,180,80,0.15)]"
+    >
+      <div className="flex items-start gap-3">
+        <div className="text-amber-400 text-lg leading-none mt-0.5">!</div>
+        <div className="flex-1">
+          <div className="font-clawville text-amber-300 text-sm uppercase tracking-wider">Link Expired</div>
+          <p className="text-white/70 text-xs mt-1 leading-relaxed">
+            That login link has expired. Generate a new one from your agent — just
+            ask it to reconnect to ClawVille.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setVisible(false)}
+          className="text-white/30 hover:text-white/70 text-lg leading-none"
+          aria-label="Dismiss"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}
 
 const SKILL_CATEGORIES = [
   { icon: '🔧', name: 'Tool Use & MCP', building: 'Salvage Workshop' },
@@ -27,6 +74,11 @@ export default function HomePage() {
 
   return (
     <div className="relative min-h-screen overflow-x-hidden bg-[#061520]">
+      {/* Phase 5 — surface ?error=expired-link redirects from /api/auth/enter */}
+      <Suspense fallback={null}>
+        <ExpiredLinkBanner />
+      </Suspense>
+
       {/* 3D underwater scene background — covers hero */}
       {mounted && <LandingScene />}
 

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -14,7 +14,7 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 export * from './schema';
-export { eq, and, or, not, sql, desc, asc } from 'drizzle-orm';
+export { eq, and, or, not, sql, desc, asc, lt, gt, lte, gte, isNull, isNotNull } from 'drizzle-orm';
 
 // Lazy database connection for Next.js build compatibility
 let _db: PostgresJsDatabase<typeof schema> | null = null;

--- a/packages/database/src/schema/agent-session-tickets.ts
+++ b/packages/database/src/schema/agent-session-tickets.ts
@@ -1,0 +1,75 @@
+import {
+  pgTable,
+  text,
+  uuid,
+  varchar,
+  timestamp,
+  index,
+  check,
+} from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { users } from './users';
+import { pets } from './pets';
+
+/**
+ * Phase 5 — agent-issued magic-link tickets.
+ *
+ * A ticket is minted at `POST /api/agent/connect` (or `/join`) and
+ * redeemed at `GET /api/auth/enter?t=...`. It swaps the agent's
+ * presented identity for a real Lucia session cookie on the human's
+ * browser so first-contact users never see a signup form.
+ *
+ * Security invariants — see Phase 5 plan §7:
+ *   - 128-bit random ticket (base58, `sess-` prefix), unguessable.
+ *   - `expires_at > created_at` guaranteed at the DB layer via
+ *     `ticket_ttl`.
+ *   - One-time use — enforced by the atomic
+ *     `UPDATE ... SET consumed_at = now() WHERE consumed_at IS NULL
+ *      RETURNING *` pattern in the exchanger.
+ *   - Partial index on `expires_at WHERE consumed_at IS NULL` drives
+ *     the hourly GC cron in `scripts/gc-agent-session-tickets.ts`.
+ *
+ * `identity_type` + `identity_key` are duplicated here (already hashed
+ * into `users.identity_fingerprint`) as an audit trail. They're never
+ * returned in any API response — the hash stored on users is the only
+ * externally-observable form.
+ */
+export const agentSessionTickets = pgTable(
+  'agent_session_tickets',
+  {
+    /**
+     * Opaque ticket string, e.g. `sess-HvH8GQwzsYoPpB5xvBmEv9`.
+     * TEXT rather than a length-bounded varchar so base58 output of any
+     * entropy length fits without truncation risk.
+     */
+    ticket: text('ticket').primaryKey(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    /** Optional — some tickets bind to a specific pet; others just to a user */
+    petId: uuid('pet_id').references(() => pets.id, { onDelete: 'cascade' }),
+    /**
+     * The agent session that minted this ticket, for audit/debug. Not
+     * required because the ticket is still valid for redemption even
+     * if the agent session later expires or is revoked.
+     */
+    issuedToAgentSession: varchar('issued_to_agent_session', { length: 64 }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    /** NULL until redeemed; set to `now()` atomically on redemption. */
+    consumedAt: timestamp('consumed_at', { withTimezone: true }),
+    /** Identity audit trail — see JSDoc above. */
+    identityType: varchar('identity_type', { length: 16 }).notNull(),
+    identityKey: text('identity_key'),
+  },
+  (t) => ({
+    /**
+     * Partial index on unredeemed tickets only — the GC script scans
+     * `WHERE consumed_at IS NULL AND expires_at < now() - '1 day'::interval`
+     * and this covers both predicates cheaply.
+     */
+    expiresIdx: index('agent_session_tickets_expires_idx').on(t.expiresAt)
+      .where(sql`${t.consumedAt} IS NULL`),
+    ttlCheck: check('ticket_ttl', sql`${t.expiresAt} > ${t.createdAt}`),
+  }),
+);

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -19,6 +19,7 @@ export * from './agent-configs';
 export * from './bounties';
 export * from './building-skills';
 export * from './wallets';
+export * from './agent-session-tickets';
 
 import { users, sessions } from './users';
 import { npcMemories, activityLog } from './memories';

--- a/packages/database/src/schema/users.ts
+++ b/packages/database/src/schema/users.ts
@@ -1,15 +1,60 @@
-import { pgTable, uuid, varchar, timestamp, boolean } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, varchar, timestamp, boolean, check } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 
-export const users = pgTable('users', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  email: varchar('email', { length: 255 }).unique(),
-  emailVerified: boolean('email_verified').default(false),
-  passwordHash: varchar('password_hash', { length: 255 }),
-  name: varchar('name', { length: 255 }),
-  avatarUrl: varchar('avatar_url', { length: 500 }),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-  updatedAt: timestamp('updated_at').defaultNow().notNull(),
-});
+/**
+ * Users table.
+ *
+ * Phase 5 — agent-issued magic-link login made two columns nullable and
+ * added a third auth channel:
+ *   - `email` / `password_hash`: still the only auth path for classic
+ *     form-based signups. Both are now NULL-able so agent-bootstrapped
+ *     users (no form, no email handshake) can exist.
+ *   - `identity_fingerprint`: SHA-256 of `{identityType}:{identityKey}`
+ *     presented by the agent on first connect. Serves as the stable
+ *     account key for agent-bootstrapped users. UNIQUE so two concurrent
+ *     `/api/agent/connect` calls with the same identity map to the same
+ *     user row. See `apps/api/src/services/identity-service.ts` for the
+ *     resolve-or-create race-safe pattern.
+ *
+ * The Postgres CHECK constraint `users_has_auth_method` guarantees every
+ * user has at least ONE real auth channel — either a populated
+ * (email + password_hash) pair OR an identity_fingerprint. Drizzle-kit
+ * 0.24 is inconsistent about emitting this kind of CHECK on push; if it
+ * gets skipped run the ALTER manually (see §5.2 of the Phase 5 plan
+ * and the fallback block in `scripts/apply-phase5-users-check.ts`).
+ */
+export const users = pgTable(
+  'users',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    email: varchar('email', { length: 255 }).unique(),
+    emailVerified: boolean('email_verified').default(false),
+    passwordHash: varchar('password_hash', { length: 255 }),
+    name: varchar('name', { length: 255 }),
+    avatarUrl: varchar('avatar_url', { length: 500 }),
+    /**
+     * Phase 5 — SHA-256 hex of `{identityType}:{identityKey}`. Populated
+     * when an agent bootstraps a user via `POST /api/agent/connect` or
+     * `POST /api/agent/join`. NULL for classic email/password signups
+     * until they later link an agent. UNIQUE so returning agents with
+     * the same identity always map to the same user.
+     */
+    identityFingerprint: varchar('identity_fingerprint', { length: 64 }).unique(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (t) => ({
+    // Guard: a user must have AT LEAST ONE of (email+password) or
+    // identity_fingerprint. Matches §5.2 of the Phase 5 plan. Runs at
+    // every INSERT / UPDATE so a partially-initialized row (e.g. an
+    // email row whose password failed to hash) gets rejected before it
+    // lands in the table.
+    hasAuthMethod: check(
+      'users_has_auth_method',
+      sql`(${t.email} IS NOT NULL AND ${t.passwordHash} IS NOT NULL) OR ${t.identityFingerprint} IS NOT NULL`,
+    ),
+  }),
+);
 
 export const sessions = pgTable('sessions', {
   id: varchar('id', { length: 255 }).primaryKey(),

--- a/scripts/apply-phase5-migration.ts
+++ b/scripts/apply-phase5-migration.ts
@@ -1,0 +1,181 @@
+/**
+ * Phase 5 migration applier.
+ *
+ * drizzle-kit push asks an interactive question ("truncate users?")
+ * when adding a UNIQUE constraint to a populated table. We always want
+ * "No", so do the migration by hand — each statement is idempotent.
+ *
+ * Operations:
+ *   1. users.email DROP NOT NULL
+ *   2. users.password_hash DROP NOT NULL
+ *   3. users.identity_fingerprint ADD COLUMN
+ *   4. users_identity_fingerprint_unique UNIQUE
+ *   5. users_has_auth_method CHECK constraint
+ *   6. agent_session_tickets CREATE TABLE + INDEX
+ *
+ * Safe to run multiple times — every statement checks existence first.
+ */
+
+import pg from 'pg';
+import { config } from 'dotenv';
+import { resolve } from 'path';
+
+config({ path: resolve(process.cwd(), '.env.local') });
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error('DATABASE_URL is not set');
+  process.exit(1);
+}
+
+const STATEMENTS: { label: string; sql: string }[] = [
+  { label: 'users.email DROP NOT NULL', sql: 'ALTER TABLE users ALTER COLUMN email DROP NOT NULL' },
+  { label: 'users.password_hash DROP NOT NULL', sql: 'ALTER TABLE users ALTER COLUMN password_hash DROP NOT NULL' },
+  {
+    label: 'users.identity_fingerprint ADD COLUMN',
+    sql: `
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+           WHERE table_name = 'users' AND column_name = 'identity_fingerprint'
+        ) THEN
+          ALTER TABLE users ADD COLUMN identity_fingerprint varchar(64);
+        END IF;
+      END $$
+    `,
+  },
+  {
+    label: 'users_identity_fingerprint_unique',
+    sql: `
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'users_identity_fingerprint_unique') THEN
+          ALTER TABLE users ADD CONSTRAINT users_identity_fingerprint_unique UNIQUE (identity_fingerprint);
+        END IF;
+      END $$
+    `,
+  },
+  {
+    label: 'users_has_auth_method CHECK',
+    sql: `
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'users_has_auth_method') THEN
+          ALTER TABLE users ADD CONSTRAINT users_has_auth_method CHECK (
+            (email IS NOT NULL AND password_hash IS NOT NULL)
+            OR identity_fingerprint IS NOT NULL
+          );
+        END IF;
+      END $$
+    `,
+  },
+  {
+    label: 'agent_session_tickets CREATE TABLE',
+    sql: `
+      CREATE TABLE IF NOT EXISTS agent_session_tickets (
+        ticket text PRIMARY KEY,
+        user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        pet_id uuid REFERENCES pets(id) ON DELETE CASCADE,
+        issued_to_agent_session varchar(64),
+        created_at timestamptz NOT NULL DEFAULT now(),
+        expires_at timestamptz NOT NULL,
+        consumed_at timestamptz,
+        identity_type varchar(16) NOT NULL,
+        identity_key text,
+        CONSTRAINT ticket_ttl CHECK (expires_at > created_at)
+      )
+    `,
+  },
+  {
+    label: 'agent_session_tickets_expires_idx',
+    sql: `
+      CREATE INDEX IF NOT EXISTS agent_session_tickets_expires_idx
+        ON agent_session_tickets (expires_at)
+        WHERE consumed_at IS NULL
+    `,
+  },
+];
+
+async function main() {
+  const client = new pg.Client({ connectionString: DATABASE_URL });
+  await client.connect();
+  try {
+    // Run the column additions + UNIQUE first, THEN backfill synthetic
+    // fingerprints for any rows that would otherwise fail the CHECK,
+    // THEN add the CHECK. Reordering so the backfill happens after the
+    // column is guaranteed present avoids the chicken-and-egg problem
+    // where the first-ever run has no column to backfill into.
+    //
+    // Index 0..3 = email nullable, password_hash nullable, add column,
+    //              UNIQUE constraint
+    // Index 4    = the CHECK constraint (runs AFTER backfill)
+    // Index 5..6 = agent_session_tickets table + index
+    for (const { label, sql } of STATEMENTS.slice(0, 4)) {
+      try {
+        await client.query(sql);
+        console.log(`  ok: ${label}`);
+      } catch (err: unknown) {
+        const msg = (err as Error).message;
+        console.error(`  FAIL ${label}: ${msg}`);
+        throw err;
+      }
+    }
+
+    // Backfill synthetic identity_fingerprint for rows without any auth
+    // method — these are legacy test/system rows (e.g.
+    // `openclaw-system@clawville.internal` with no password). Using
+    // `legacy:{uuid}` as the identity_key means the fingerprint can
+    // never collide with a real agent-presented one.
+    const backfill = await client.query(`
+      UPDATE users
+         SET identity_fingerprint = encode(digest('legacy:' || id::text, 'sha256'), 'hex')
+       WHERE identity_fingerprint IS NULL
+         AND NOT (email IS NOT NULL AND password_hash IS NOT NULL)
+      RETURNING id
+    `);
+    console.log(`  ok: backfilled ${backfill.rows.length} legacy user(s) with synthetic identity_fingerprint`);
+
+    for (const { label, sql } of STATEMENTS.slice(4)) {
+      try {
+        await client.query(sql);
+        console.log(`  ok: ${label}`);
+      } catch (err: unknown) {
+        const code = (err as { code?: string } | null)?.code;
+        const msg = (err as Error).message;
+        if (code === '23514' && label.includes('users_has_auth_method')) {
+          const bad = await client.query(
+            `SELECT id, email, password_hash IS NOT NULL AS has_pw, identity_fingerprint FROM users
+             WHERE NOT (
+               (email IS NOT NULL AND password_hash IS NOT NULL)
+               OR identity_fingerprint IS NOT NULL
+             )`,
+          );
+          console.error(`  FAIL ${label}: ${msg}`);
+          console.error('  violators:', bad.rows);
+          throw err;
+        }
+        console.error(`  FAIL ${label}: ${msg}`);
+        throw err;
+      }
+    }
+
+    const checks = await client.query(`
+      SELECT
+        (SELECT COUNT(*) FROM information_schema.columns
+          WHERE table_name = 'users' AND column_name = 'identity_fingerprint')::int AS users_col,
+        (SELECT COUNT(*) FROM pg_constraint WHERE conname = 'users_has_auth_method')::int AS users_check,
+        (SELECT COUNT(*) FROM pg_constraint WHERE conname = 'users_identity_fingerprint_unique')::int AS users_unique,
+        (SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'agent_session_tickets')::int AS tickets_table,
+        (SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'agent_session_tickets_expires_idx')::int AS tickets_idx
+    `);
+    console.log('[phase5] verification:', checks.rows[0]);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('[phase5] fatal:', err);
+  process.exit(1);
+});

--- a/scripts/gc-agent-session-tickets.ts
+++ b/scripts/gc-agent-session-tickets.ts
@@ -1,0 +1,57 @@
+/**
+ * Phase 5 — agent_session_tickets garbage collection.
+ *
+ * Deletes rows that expired more than 24 hours ago. The 1-day buffer
+ * preserves recently-expired tickets for debugging (e.g. "why did my
+ * link not work?" support requests) while keeping the table bounded.
+ *
+ * Run via cron hourly:
+ *   0 * * * * cd /app && bun run scripts/gc-agent-session-tickets.ts
+ *
+ * Or on-demand for a one-shot cleanup:
+ *   bun run scripts/gc-agent-session-tickets.ts
+ *
+ * Safe to run repeatedly — the DELETE is idempotent and cheap thanks
+ * to the partial index on `(expires_at) WHERE consumed_at IS NULL`.
+ * Consumed rows are also swept here because they serve no further
+ * purpose once the Lucia session they minted has long since been
+ * created (and its own row in `sessions` is what keeps the user logged
+ * in, not this ticket row).
+ */
+
+import { db, agentSessionTickets, sql, lt } from '@clawville/database';
+
+async function main() {
+  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const before = new Date();
+
+  // Delete any ticket whose expires_at is more than 24h in the past.
+  // This captures both unredeemed (idle leftovers) and consumed rows
+  // (since `consumed_at IS NOT NULL` implies `expires_at` passed the
+  // creation + TTL window days ago).
+  const deleted = await db
+    .delete(agentSessionTickets)
+    .where(lt(agentSessionTickets.expiresAt, cutoff))
+    .returning({ ticket: agentSessionTickets.ticket });
+
+  const elapsedMs = Date.now() - before.getTime();
+  console.log(
+    `[gc-agent-session-tickets] Deleted ${deleted.length} row(s) older than ${cutoff.toISOString()} in ${elapsedMs}ms`,
+  );
+
+  // Close the postgres pool cleanly so the script exits instead of
+  // hanging on the idle connection.
+  try {
+    await (db as unknown as { $client?: { end?: () => Promise<void> } }).$client?.end?.();
+  } catch {
+    // best-effort — some drivers don't expose $client
+  }
+  // Use sql reference to keep the import load-bearing (drizzle-kit
+  // tree-shakes unused imports in some setups).
+  void sql;
+}
+
+main().catch((err) => {
+  console.error('[gc-agent-session-tickets] fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Agents hand users a \`https://clawville.world/enter?t=sess-...\` URL. Clicking it exchanges a one-time ticket for a Lucia session. No OAuth, no password paste.
- New \`agent_session_tickets\` table (128-bit base58, TTL-bounded, atomic \`UPDATE ... RETURNING\`).
- \`users.identity_fingerprint = sha256("{type}:{key}")\` UNIQUE + \`users_has_auth_method\` CHECK — every user has at least one auth method.
- New \`POST /api/agent/join\` (rate-limited before any DB work) resolves/creates user by identity, auto-provisions a default lobster pet, returns a session ticket.
- \`/connect\` response is additively enriched with \`sessionTicket\` when identity is inferrable.
- \`GET /api/auth/enter\` consumes ticket → creates Lucia session → 302 to \`/game\`. Sets \`Referrer-Policy: no-referrer\` on success AND error. Expired/invalid/double-consumed collapse to \`/?error=expired-link\`.
- Landing page shows \`ExpiredLinkBanner\` when the error param is present.
- \`scripts/apply-phase5-migration.ts\` is idempotent and **has already been applied to prod DB** (5/5 verified during impl).

## Security checks (audit-confirmed)
- 128-bit random ticket, one-time-use atomic, TTL clamped [60, 3600]s.
- Rate limit fires before DB on \`/join\`.
- No timing oracle (single atomic UPDATE is the only consume path).
- 23505 race handled for both user-by-identity AND pet-by-user-id inserts.
- Legacy user without email/password backfilled with a synthetic \`sha256('legacy:' + id)\` fingerprint before the CHECK was enabled — can't collide with agent-presented identities.

## Test plan
- [x] Live-DB smoke test: resolve → mint → consume → double-consume (returns null) → cleanup. All pass.
- [x] \`turbo run build --filter=@clawville/web --filter=@clawville/api\` green.
- [x] Single audit pass (one round) — clean after one race fix.
- [ ] After Coolify deploy: connect an agent, receive \`sess-\` URL, click \`/enter?t=...\`, confirm landing on \`/game\` already logged in. Expired/consumed tickets route to \`/?error=expired-link\`.