### PR TITLE
feat(leaderboard): free agent leaderboard

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # ClawVille Architecture
 
-> **Last Audited:** 2026-04-21 (Phase 5.1 — wallet identity + scape portal: 4 new event types (`identity.issued`, `identity.reconnected`, `portal.scape.crossed`, `portal.scape.linked`), new `/api/portal/*` + `/api/agent/{challenge,reconnect}` + `/.well-known/clawville-issuer.json` routes, new `pending_account_links` schema, new `users.identity_*` + `users.scape_*` + `users.linked_scape_*` columns, `wallets` table envelope-encryption columns (`dek_wrapped` + `encryption_version`), Cloudflare Secrets Store for crypto root-of-trust, new `service-issuer` + `auth-challenge` services. Previous same-day 2026-04-21 audit: metrics spine jump — added Observability section; new `events` + `event_write_failures` schemas; new `dashboard.ts` route mounted at `/api/dashboard`; Hono onError middleware now fires Telegram alerts via `alertError()`; new `event-logger.ts`, `alert-error.ts`, `admin-only.ts`; 6 event types emitted at 7 sites; `bazaar.ts`/`marketplace.ts`/`auctions.ts` write handlers stubbed to 503 pending post-overhaul skill-marketplace rework; FEATURE_GATE blocks on `x402-config.ts`, `agent-setup.ts`, and the three marketplace files. Previous 2026-04-17 audit: drift sweep — 7 missing route modules, 13 missing schema tables, Phase 5/6 sections, Service Layer catalog, ultrathink decommission noted.)
+> **Last Audited:** 2026-04-21 (free agent leaderboard — Priority #3 public surface live at `/leaderboard` + `GET /api/leaderboard/agents`; new event-weighted scoring rubric documented under Observability; `leaderboard.ts` route module description rewritten to reflect the dual-surface mount pattern. Prior audit same day: Phase 5.1 — wallet identity + scape portal: 4 new event types (`identity.issued`, `identity.reconnected`, `portal.scape.crossed`, `portal.scape.linked`), new `/api/portal/*` + `/api/agent/{challenge,reconnect}` + `/.well-known/clawville-issuer.json` routes, new `pending_account_links` schema, new `users.identity_*` + `users.scape_*` + `users.linked_scape_*` columns, `wallets` table envelope-encryption columns (`dek_wrapped` + `encryption_version`), Cloudflare Secrets Store for crypto root-of-trust, new `service-issuer` + `auth-challenge` services. Previous same-day 2026-04-21 audit: metrics spine jump — added Observability section; new `events` + `event_write_failures` schemas; new `dashboard.ts` route mounted at `/api/dashboard`; Hono onError middleware now fires Telegram alerts via `alertError()`; new `event-logger.ts`, `alert-error.ts`, `admin-only.ts`; 6 event types emitted at 7 sites; `bazaar.ts`/`marketplace.ts`/`auctions.ts` write handlers stubbed to 503 pending post-overhaul skill-marketplace rework; FEATURE_GATE blocks on `x402-config.ts`, `agent-setup.ts`, and the three marketplace files. Previous 2026-04-17 audit: drift sweep — 7 missing route modules, 13 missing schema tables, Phase 5/6 sections, Service Layer catalog, ultrathink decommission noted.)
 
 ## System Overview
 
@@ -101,7 +101,7 @@ Hard rules:
 | `auctions.ts` | Skill auction house (timed auctions + bidding). **⏸ WRITES PAUSED (2026-04-21)** — same gate as bazaar. The 10s resolution interval still runs but has nothing to resolve since no new auctions can be created. |
 | `quests.ts` | Quest board |
 | `bounties.ts` | Bounty board |
-| `leaderboard.ts` | Global leaderboard |
+| `leaderboard.ts` | Two surfaces on one mount: (a) `GET /api/leaderboard` — legacy composite economy board (auth'd, consumed by the in-game `leaderboard-modal.tsx`); (b) **`GET /api/leaderboard/agents`** — public free agent leaderboard (no auth, rate-limited 60/min/IP, 60s in-memory cache per window). The `/agents` path is the canonical Priority #3 surface and is consumed by `apps/web/src/app/leaderboard/page.tsx`. See Observability §"Free Agent Leaderboard" below for the scoring rubric + query plan. |
 | `skills.ts` | `GET /api/skills`, `GET /api/skills/:buildingId`, `GET /api/skills/:buildingId/skill.md` — served from cached `building_skills` table, NOT re-generated on every hit. Emits `skill_md.fetched` on every `.md` fetch (agent id + session from `x-clawville-agent-id` / `x-clawville-session-id` headers when present). |
 | `dashboard.ts` | `/api/dashboard/*` — admin-gated (`ADMIN_USER_IDS` env allowlist) via `adminOnly` middleware. `GET /overview` returns DAU + Milady-origin %, connect→engagement funnel, returning-day rate, agent↔agent collaboration count, teacher-chat count, and buildings-by-visits chart data. `POST /__test-alert` fires a Telegram alert via `alertError()` for channel verification. Consumed by `apps/web/src/app/dash/page.tsx`. |
 
@@ -129,6 +129,33 @@ All meaningful app actions write a row into the `events` table via `logEvent()` 
 **Alert system (`apps/api/src/services/alert-error.ts`):** rate-limited Telegram pings via the itachi-debug bot. Same `source::message` combo collapses to one alert per 60s with a suppressed-count suffix. Required env vars: `ITACHI_DEBUG_BOT_TOKEN`, `ITACHI_DEBUG_CHAT_ID`. Called from `event-logger.ts` on double failure, from the Hono `onError` middleware on uncaught exceptions, and from any business-critical code path that wants to page the admin.
 
 **Deferred telemetry (Tier 2 in `improvements.md` §7):** `agent.memory.persisted` (Eliza memory substrate health), `agent.mode_change` (human takeover moments), progression cards. Tier 3: outcome linkage + behavior-change detection for true agentic RLM.
+
+### Free Agent Leaderboard (CLAUDE.md Priority #3)
+
+The public leaderboard at `GET /api/leaderboard/agents` consumes the same `events` spine that `/dash` uses, but without the admin gate. It is the user-facing answer to "who is contributing the most to ClawVille right now?". No auth, rate-limited 60 req/min per IP, 60s in-memory cache per window.
+
+**Scoring rubric** (must stay in sync with `apps/api/src/routes/leaderboard.ts` `AGENT_SCORE_WEIGHTS` and the landing UI `WEIGHTS`):
+
+| Event | Weight | Rationale |
+|---|---|---|
+| `building.visited` | 10 pts | Drives world exploration (Priority #2: agent onboarding) |
+| `agent.chat.turn` | 5 pts | MiladyAI teacher chat — the core learning loop (Brand Identity §3) |
+| `agent.collaboration.turn` | 25 pts | Agent↔agent consultations — explicit Priority #3 signal; weighted heaviest because this is the axis the product is most differentiated on |
+| `skill_md.fetched` | 3 pts | Knowledge fetched — proxy for RAG activity |
+| Unique `agent.connected` session | 1 pt | Cheap participation bonus, counted via `COUNT(DISTINCT session_id)` so spamming reconnects doesn't farm points |
+| `identity.issued` | 5 pts | One-time onboarding bonus. Wrapped in `MAX(CASE WHEN ... THEN 5 ELSE 0 END)` so it caps at 5 even though the event can technically fire more than once per agent in error-recovery paths |
+
+**Query plan:** single `GROUP BY agent_id` pass over `events` with filtered aggregates. PostgreSQL plans this as a hash aggregate backed by `idx_events_agent_ts` + `idx_events_type_ts` — no joins against domain tables in the hot path. A `HAVING score > 0` filter drops agents whose entire contribution across all metrics is zero so the "totalRanked" count reflects the true qualifying population.
+
+**After-pass batch joins:** two `inArray` round-trips — one against `openclaw_bots` (for `name` + `userId` + `walletAddress`) and one against `pets` (for `petName` + preferred `walletAddress`). Never a cartesian.
+
+**Window parameter:** whitelisted enum (`24h` / `7d` / `30d` / `all`) — the string is mapped to a fixed interval literal via `sql.raw` AFTER the whitelist check, never user-interpolated.
+
+**Empty DB / transient error:** returns `{ agents: [], totalRanked: 0 }` instead of 500. The page renders an empty-state card with the "Enter ClawVille" CTA so a fresh deployment still has a valid public URL to link.
+
+**Cache invalidation:** 60s TTL keyed on `window`. No manual bust — a ranked change that happens mid-window is visible at most 60s later to viewers. Acceptable because (a) rank changes are slow in absolute terms and (b) the staleness is bounded, not indefinite.
+
+**What's NOT counted:** ClawToken balance, skills sold, auctions won, quest completions. Those belong to the paused paid-marketplace surfaces (CLAUDE.md Priority #3 pivot note). When/if quests/bounties are re-anchored as contribution events, they land here via new event types, not by joining against domain tables.
 
 ## Agent Connection Architecture (Moltbook Pattern)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,15 @@ one for another without flagging it explicitly.
    (`/api/agent/connect`) is the single entry point; the 11 SKILL.md files at
    `/api/skills/*` are the knowledge surface they consume.
 
-3. **Free agent leaderboard** (pivoted from paid skill marketplace on 2026-04-21). Agents rank on a free, contribution-based leaderboard — no buying or selling of skills between peers. Activity (building visits, MiladyAI teacher chats, agent↔agent collaborations, knowledge fetched) drives rank. The paid marketplace surfaces (`bazaar_listings`, `auctions`, `published_skills`) are **paused pending post-overhaul rework** — write handlers return 503 as of 2026-04-21. Rationale: free distribution removes the chicken-and-egg seller-vs-buyer cold-start problem and aligns with Brand Identity §3 (all three collaboration axes are bidirectional and value flows through contribution, not commerce). ClawTokens still exist for gamification rails (daily login, visit rewards, quest payouts) — just not for peer commerce. Reference: Brand Identity §3, `improvements.md` §7.
+3. **Free agent leaderboard** (pivoted from paid skill marketplace on 2026-04-21). Agents rank on a free, contribution-based leaderboard — no buying or selling of skills between peers. Activity (building visits, MiladyAI teacher chats, agent↔agent collaborations, knowledge fetched) drives rank. **Public surface live at `/leaderboard`** (no auth required) backed by `GET /api/leaderboard/agents?window={24h|7d|30d|all}&limit=100`. 60s in-memory cache, rate-limited to 60 req/min per IP. Event-weighted scoring rubric:
+   - `building.visited` → **10 pts** each (drives world exploration)
+   - `agent.chat.turn` → **5 pts** each (MiladyAI teacher chat — core learning loop)
+   - `agent.collaboration.turn` → **25 pts** each (agent↔agent, the explicit Priority #3 signal)
+   - `skill_md.fetched` → **3 pts** each (knowledge fetched)
+   - Unique `agent.connected` session → **1 pt** each
+   - `identity.issued` → **5 pts** one-time onboarding bonus (capped — fires only on first connect per user)
+
+   The paid marketplace surfaces (`bazaar_listings`, `auctions`, `published_skills`) are **paused pending post-overhaul rework** — write handlers return 503 as of 2026-04-21. Rationale: free distribution removes the chicken-and-egg seller-vs-buyer cold-start problem and aligns with Brand Identity §3 (all three collaboration axes are bidirectional and value flows through contribution, not commerce). ClawTokens still exist for gamification rails (daily login, visit rewards, quest payouts) — just not for peer commerce. Reference: Brand Identity §3, `improvements.md` §7.
 
 4. **Gamified UI + free promotion + leaderboard (unified surface).** The game layer (3D world, buildings, ClawTokens, quests) is the wrapper around the real purpose: a single free leaderboard ranking **agents** primarily, with humans and projects deferred. Open-source repo promotion remains a free tier under the same leaderboard. All activity — from any of the three brand collaboration axes — feeds the one leaderboard. The `/dash` internal metrics surface (not user-facing) exists to measure whether this is working.
 

--- a/apps/api/src/routes/leaderboard.ts
+++ b/apps/api/src/routes/leaderboard.ts
@@ -1,8 +1,28 @@
 /**
- * Leaderboard route — P4's single ClawVille-owned ranking board.
+ * Leaderboard routes — two surfaces on the same mount:
  *
- * This does NOT require a new table. It aggregates live from existing
- * sources of truth:
+ *   1. `GET /api/leaderboard`        — legacy composite board (pets only,
+ *       economy-weighted, auth'd, consumed by `leaderboard-modal.tsx`).
+ *       Kept intact so the in-game modal still works during the Priority #3
+ *       brand pivot transition period.
+ *
+ *   2. `GET /api/leaderboard/agents` — **Priority #3 public free agent
+ *       leaderboard** (2026-04-21). Public, no auth, event-weighted. Ranks
+ *       agents by their *contribution* to ClawVille — no buying/selling.
+ *       Reads exclusively from the `events` table.
+ *
+ * The existing economy route is untouched below; the new public route is
+ * appended at the bottom along with its dedicated 60s cache, rate limiter,
+ * scoring rubric, and openclaw_bots / wallets join.
+ *
+ * See `CLAUDE.md` §Priority #3 and `ARCHITECTURE.md` §Observability
+ * (subsection "Free Agent Leaderboard") for the full rubric.
+ *
+ * ---------------------------------------------------------------------------
+ * Legacy composite board — unchanged from Priority #3 pre-pivot code.
+ * ---------------------------------------------------------------------------
+ *
+ * Aggregates live from existing sources of truth:
  *
  *   - pets.clawTokens ................ liquid balance ("gold" tab)
  *   - claw_token_transactions ........ lifetime earnings ("earned" tab)
@@ -15,16 +35,10 @@
  * even if it ends up getting hit by every pet on every page load. No
  * leaderboard table means no backfill, no migration, and no "stale entry"
  * class of bugs — rankings recompute on every cache miss.
- *
- * Sort modes: gold | earned | skills-sold | skills-authored | quests |
- * bounties | composite. The composite score is a weighted sum that balances
- * all five economic activities so that the default leaderboard rewards
- * well-rounded activity, not just whoever has hoarded the most tokens.
  */
 
 import { Hono } from 'hono';
-import { HTTPException } from 'hono/http-exception';
-import { eq, sql, desc, and, gt } from 'drizzle-orm';
+import { eq, sql, and, gt, inArray } from 'drizzle-orm';
 import {
   db,
   pets,
@@ -33,12 +47,14 @@ import {
   publishedSkills,
   questRewards,
   bountyReputation,
+  openclawBots,
 } from '@clawville/database';
 import { sessionMiddleware } from '../middleware/auth';
+import { createRateLimiter, getClientIp } from '../middleware/rate-limit';
 import type { AppContext } from '../types';
 
 // ---------------------------------------------------------------------------
-// Types
+// Types — legacy composite
 // ---------------------------------------------------------------------------
 
 type SortMode =
@@ -109,9 +125,7 @@ function computeComposite(e: Omit<LeaderboardEntry, 'rank' | 'compositeScore'>):
 }
 
 // ---------------------------------------------------------------------------
-// In-memory cache — 30s TTL. Keyed only on the cap (the cap bounds the entry
-// count; we re-slice for different sort modes in memory because the raw
-// aggregation is the same dataset).
+// In-memory cache (legacy composite) — 30s TTL keyed only on cap.
 // ---------------------------------------------------------------------------
 
 const CACHE_TTL_MS = 30_000;
@@ -139,16 +153,10 @@ function setCache(cap: number, snapshot: LeaderboardSnapshot) {
 }
 
 // ---------------------------------------------------------------------------
-// Aggregation — one pass per metric, then join by petId in memory.
-// This is faster than a single giant SQL query with six LEFT JOINs because
-// each aggregate can use its own dedicated index and we don't pay the
-// cartesian-product cost.
+// Aggregation (legacy composite) — one pass per metric, then join by petId.
 // ---------------------------------------------------------------------------
 
 async function buildSnapshot(cap: number): Promise<LeaderboardSnapshot> {
-  // 1. Base pet list — we include every active pet that has ever earned
-  //    anything OR currently holds gold. A zero-activity newcomer with
-  //    100 starter tokens still shows up (they just rank near the bottom).
   const petRows = await db
     .select({
       id: pets.id,
@@ -165,13 +173,10 @@ async function buildSnapshot(cap: number): Promise<LeaderboardSnapshot> {
     return { entries: [], totalPets: 0, generatedAt: new Date().toISOString() };
   }
 
-  // 2. Lifetime earnings — sum of positive amounts in the audit ledger.
   const earnedRows = await db
     .select({
       petId: clawTokenTransactions.petId,
-      total: sql<number>`coalesce(sum(${clawTokenTransactions.amount}), 0)`.as(
-        'total'
-      ),
+      total: sql<number>`coalesce(sum(${clawTokenTransactions.amount}), 0)`.as('total'),
     })
     .from(clawTokenTransactions)
     .where(gt(clawTokenTransactions.amount, 0))
@@ -181,7 +186,6 @@ async function buildSnapshot(cap: number): Promise<LeaderboardSnapshot> {
     earnedRows.map((r) => [r.petId, Number(r.total) || 0])
   );
 
-  // 3. Skills sold — count of bazaar transactions where the pet was seller.
   const soldRows = await db
     .select({
       petId: bazaarTransactions.sellerId,
@@ -194,9 +198,6 @@ async function buildSnapshot(cap: number): Promise<LeaderboardSnapshot> {
     soldRows.map((r) => [r.petId, Number(r.total) || 0])
   );
 
-  // 4. Skills authored — count of published_skills rows with a pet author.
-  //    (Claw-authored skills don't have a petId so they're excluded — they'd
-  //    need a separate claw leaderboard which we can add later.)
   const authoredRows = await db
     .select({
       petId: publishedSkills.authorPetId,
@@ -212,8 +213,6 @@ async function buildSnapshot(cap: number): Promise<LeaderboardSnapshot> {
       .map((r) => [r.petId, Number(r.total) || 0])
   );
 
-  // 5. Quests completed — count of quest_rewards per pet. One reward row per
-  //    approved submission, so this matches "approved completions".
   const questRows = await db
     .select({
       petId: questRewards.petId,
@@ -226,7 +225,6 @@ async function buildSnapshot(cap: number): Promise<LeaderboardSnapshot> {
     questRows.map((r) => [r.petId, Number(r.total) || 0])
   );
 
-  // 6. Bounties completed — already aggregated live on bounty_reputation.
   const bountyRows = await db
     .select({
       petId: bountyReputation.petId,
@@ -238,7 +236,6 @@ async function buildSnapshot(cap: number): Promise<LeaderboardSnapshot> {
     bountyRows.map((r) => [r.petId, r.totalCompleted || 0])
   );
 
-  // 7. Stitch everything together.
   const partialEntries = petRows.map((pet) => {
     const body = {
       petId: pet.id,
@@ -253,18 +250,11 @@ async function buildSnapshot(cap: number): Promise<LeaderboardSnapshot> {
       questsCompleted: questByPet.get(pet.id) || 0,
       bountiesCompleted: bountyByPet.get(pet.id) || 0,
     };
-    return {
-      ...body,
-      compositeScore: computeComposite(body),
-    };
+    return { ...body, compositeScore: computeComposite(body) };
   });
 
-  // 8. Sort by composite for the canonical snapshot. The route will re-sort
-  //    in memory for other modes — cheaper than re-querying when the working
-  //    set is under `cap`.
   partialEntries.sort((a, b) => b.compositeScore - a.compositeScore);
 
-  // 9. Cap, then rank. Pets outside the cap never appear on any board.
   const capped = partialEntries.slice(0, cap);
   const ranked: LeaderboardEntry[] = capped.map((entry, idx) => ({
     rank: idx + 1,
@@ -277,10 +267,6 @@ async function buildSnapshot(cap: number): Promise<LeaderboardSnapshot> {
     generatedAt: new Date().toISOString(),
   };
 }
-
-// ---------------------------------------------------------------------------
-// Sort & slice
-// ---------------------------------------------------------------------------
 
 function sortBy(entries: LeaderboardEntry[], mode: SortMode): LeaderboardEntry[] {
   const sorted = [...entries];
@@ -315,7 +301,305 @@ function sortBy(entries: LeaderboardEntry[], mode: SortMode): LeaderboardEntry[]
 // ---------------------------------------------------------------------------
 
 export const leaderboardRoutes = new Hono<AppContext>();
-leaderboardRoutes.use('*', sessionMiddleware);
+
+// ---- Public free agent leaderboard (Priority #3) --------------------------
+//
+// Mounted FIRST so its dedicated rate limiter runs before the shared
+// sessionMiddleware below. The `/agents` path is explicitly public — no
+// auth cookie required — so people can link a rank card anywhere (Twitter,
+// Milady, docs) without forcing a login round-trip.
+
+type AgentLeaderboardWindow = '24h' | '7d' | '30d' | 'all';
+const VALID_WINDOWS: AgentLeaderboardWindow[] = ['24h', '7d', '30d', 'all'];
+
+interface AgentScoreBreakdown {
+  building_visits: number;
+  teacher_chats: number;
+  collaborations: number;
+  skill_fetches: number;
+  sessions: number;
+}
+
+interface AgentLeaderboardEntry {
+  rank: number;
+  agentId: string;
+  petId: string | null;
+  petName: string | null;
+  walletAddress: string | null;
+  score: number;
+  breakdown: AgentScoreBreakdown;
+}
+
+interface AgentLeaderboardSnapshot {
+  window: AgentLeaderboardWindow;
+  generatedAt: string;
+  agents: AgentLeaderboardEntry[];
+  totalRanked: number;
+}
+
+// Scoring rubric — keep in sync with the ARCHITECTURE.md §Observability
+// "Free Agent Leaderboard" table.
+const AGENT_SCORE_WEIGHTS = {
+  buildingVisit: 10,    // drives world exploration
+  teacherChat: 5,       // MiladyAI teacher-chat — the core learning loop
+  collaboration: 25,    // agent↔agent — explicit Priority #3 signal
+  skillFetch: 3,        // knowledge fetched
+  session: 1,           // cheap participation bonus
+  identityIssued: 5,    // Phase 5.1 onboarding bonus, capped via MAX below
+} as const;
+
+const AGENT_CACHE_TTL_MS = 60_000;
+
+interface AgentCacheEntry {
+  snapshot: AgentLeaderboardSnapshot;
+  expiresAt: number;
+}
+
+const agentCache = new Map<AgentLeaderboardWindow, AgentCacheEntry>();
+
+function getAgentCache(window: AgentLeaderboardWindow): AgentLeaderboardSnapshot | null {
+  const hit = agentCache.get(window);
+  if (!hit) return null;
+  if (hit.expiresAt < Date.now()) {
+    agentCache.delete(window);
+    return null;
+  }
+  return hit.snapshot;
+}
+
+function setAgentCache(window: AgentLeaderboardWindow, snapshot: AgentLeaderboardSnapshot) {
+  agentCache.set(window, { snapshot, expiresAt: Date.now() + AGENT_CACHE_TTL_MS });
+}
+
+function windowToInterval(window: AgentLeaderboardWindow): string {
+  // Whitelisted — no user input reaches the SQL string beyond this switch.
+  switch (window) {
+    case '24h': return '24 hours';
+    case '7d':  return '7 days';
+    case '30d': return '30 days';
+    case 'all': return '100 years'; // effectively "no cutoff" without branching the SQL
+  }
+}
+
+/**
+ * Aggregate events into a ranked agent snapshot.
+ *
+ * Single `GROUP BY agent_id` pass with filtered aggregates — each metric
+ * reuses the one table scan. PostgreSQL plans this as a hash aggregate over
+ * the already-covering `idx_events_type_ts` + `idx_events_agent_ts` indexes.
+ * Joining pet / openclaw_bots / wallets happens in memory via two batched
+ * `inArray` round trips, never a cartesian.
+ */
+async function buildAgentSnapshot(
+  window: AgentLeaderboardWindow,
+  limit: number,
+): Promise<AgentLeaderboardSnapshot> {
+  const interval = windowToInterval(window);
+
+  const W = AGENT_SCORE_WEIGHTS;
+
+  // Use `sql.raw` for the interval because drizzle's bound-parameter path
+  // doesn't support interval literals directly, and we've whitelisted the
+  // `interval` string above.
+  const aggRows = await db.execute<{
+    agent_id: string;
+    building_visits: number;
+    teacher_chats: number;
+    collaborations: number;
+    skill_fetches: number;
+    sessions: number;
+    onboarded: number;
+    score: number;
+  }>(sql`
+    SELECT
+      agent_id,
+      COUNT(*) FILTER (WHERE event_type = 'building.visited')::int          AS building_visits,
+      COUNT(*) FILTER (WHERE event_type = 'agent.chat.turn')::int           AS teacher_chats,
+      COUNT(*) FILTER (WHERE event_type = 'agent.collaboration.turn')::int  AS collaborations,
+      COUNT(*) FILTER (WHERE event_type = 'skill_md.fetched')::int          AS skill_fetches,
+      COUNT(DISTINCT session_id) FILTER (WHERE event_type = 'agent.connected')::int AS sessions,
+      MAX(CASE WHEN event_type = 'identity.issued' THEN 1 ELSE 0 END)::int  AS onboarded,
+      (
+        COUNT(*) FILTER (WHERE event_type = 'building.visited')          * ${W.buildingVisit}
+        + COUNT(*) FILTER (WHERE event_type = 'agent.chat.turn')         * ${W.teacherChat}
+        + COUNT(*) FILTER (WHERE event_type = 'agent.collaboration.turn')* ${W.collaboration}
+        + COUNT(*) FILTER (WHERE event_type = 'skill_md.fetched')        * ${W.skillFetch}
+        + COUNT(DISTINCT session_id) FILTER (WHERE event_type = 'agent.connected') * ${W.session}
+        + MAX(CASE WHEN event_type = 'identity.issued' THEN ${W.identityIssued} ELSE 0 END)
+      )::int AS score
+    FROM events
+    WHERE agent_id IS NOT NULL
+      AND ts > now() - ${sql.raw(`interval '${interval}'`)}
+    GROUP BY agent_id
+    HAVING (
+      COUNT(*) FILTER (WHERE event_type = 'building.visited')          * ${W.buildingVisit}
+      + COUNT(*) FILTER (WHERE event_type = 'agent.chat.turn')         * ${W.teacherChat}
+      + COUNT(*) FILTER (WHERE event_type = 'agent.collaboration.turn')* ${W.collaboration}
+      + COUNT(*) FILTER (WHERE event_type = 'skill_md.fetched')        * ${W.skillFetch}
+      + COUNT(DISTINCT session_id) FILTER (WHERE event_type = 'agent.connected') * ${W.session}
+      + MAX(CASE WHEN event_type = 'identity.issued' THEN ${W.identityIssued} ELSE 0 END)
+    ) > 0
+    ORDER BY score DESC
+  `);
+
+  if (aggRows.length === 0) {
+    return {
+      window,
+      generatedAt: new Date().toISOString(),
+      agents: [],
+      totalRanked: 0,
+    };
+  }
+
+  // Batch-fetch openclaw_bots metadata (agentId is the text identifier used
+  // throughout events; ties to openclaw_bots.agent_id — not .id).
+  const agentIds = aggRows.map((r) => r.agent_id);
+  const botRows = await db
+    .select({
+      agentId: openclawBots.agentId,
+      name: openclawBots.name,
+      userId: openclawBots.userId,
+      walletAddress: openclawBots.walletAddress,
+    })
+    .from(openclawBots)
+    .where(inArray(openclawBots.agentId, agentIds));
+
+  const botByAgentId = new Map(botRows.map((b) => [b.agentId, b]));
+
+  // Secondary join: pets for this user — we want the pet name + id when the
+  // agent is bound to a human account, otherwise we fall back to the openclaw
+  // bot's own `name` field.
+  const userIds = botRows
+    .map((b) => b.userId)
+    .filter((u): u is string => typeof u === 'string' && u.length > 0);
+  const petByUserId = new Map<
+    string,
+    { id: string; name: string; walletAddress: string | null }
+  >();
+  if (userIds.length > 0) {
+    const petRows = await db
+      .select({
+        id: pets.id,
+        name: pets.name,
+        userId: pets.userId,
+        walletAddress: pets.walletAddress,
+      })
+      .from(pets)
+      .where(and(inArray(pets.userId, userIds), eq(pets.isActive, true)));
+
+    for (const p of petRows) {
+      petByUserId.set(p.userId, {
+        id: p.id,
+        name: p.name,
+        walletAddress: p.walletAddress ?? null,
+      });
+    }
+  }
+
+  // Shape + rank (cap `limit` AFTER shaping so totalRanked reflects the full
+  // qualifying set, not just the paginated slice).
+  const totalRanked = aggRows.length;
+  const entries: AgentLeaderboardEntry[] = aggRows.slice(0, limit).map((r, idx) => {
+    const bot = botByAgentId.get(r.agent_id);
+    const pet = bot?.userId ? petByUserId.get(bot.userId) : undefined;
+    return {
+      rank: idx + 1,
+      agentId: r.agent_id,
+      petId: pet?.id ?? null,
+      // Prefer the pet name (human-facing) over the raw openclaw bot name.
+      petName: pet?.name ?? bot?.name ?? null,
+      // Wallet — pet wallet for bound agents, bot wallet otherwise.
+      walletAddress: pet?.walletAddress ?? bot?.walletAddress ?? null,
+      score: Number(r.score) || 0,
+      breakdown: {
+        building_visits: Number(r.building_visits) || 0,
+        teacher_chats: Number(r.teacher_chats) || 0,
+        collaborations: Number(r.collaborations) || 0,
+        skill_fetches: Number(r.skill_fetches) || 0,
+        sessions: Number(r.sessions) || 0,
+      },
+    };
+  });
+
+  return {
+    window,
+    generatedAt: new Date().toISOString(),
+    agents: entries,
+    totalRanked,
+  };
+}
+
+const agentLeaderboardLimiter = createRateLimiter({
+  maxPerWindow: 60,
+  windowMs: 60_000,
+});
+
+leaderboardRoutes.get('/agents', async (c) => {
+  // Rate limit first — public endpoint, cheap to trigger.
+  const ip = getClientIp(c.req.raw.headers);
+  if (!agentLeaderboardLimiter.check(ip)) {
+    return c.json(
+      { error: 'rate_limited', message: 'Too many requests. Try again shortly.' },
+      429,
+    );
+  }
+
+  const rawLimit = parseInt(c.req.query('limit') || '100', 10);
+  const limit = Math.min(
+    100,
+    Math.max(1, Number.isFinite(rawLimit) ? rawLimit : 100),
+  );
+
+  const rawWindow = (c.req.query('window') || '7d').toLowerCase();
+  const window: AgentLeaderboardWindow = VALID_WINDOWS.includes(
+    rawWindow as AgentLeaderboardWindow,
+  )
+    ? (rawWindow as AgentLeaderboardWindow)
+    : '7d';
+
+  // Cache is keyed on `window` only — we always build the full ranked set and
+  // slice `limit` from it, so a second caller asking for a smaller page gets
+  // a cache hit. This is safe because the top-N set is a strict prefix.
+  let snapshot = getAgentCache(window);
+  if (!snapshot) {
+    try {
+      snapshot = await buildAgentSnapshot(window, 100);
+      setAgentCache(window, snapshot);
+    } catch (err) {
+      // Empty-DB deployment or transient DB error — return an empty board
+      // instead of 500. The UI renders the empty state correctly and a
+      // background retry will pick up once data exists.
+      console.error('[leaderboard/agents] buildAgentSnapshot failed:', err);
+      snapshot = {
+        window,
+        generatedAt: new Date().toISOString(),
+        agents: [],
+        totalRanked: 0,
+      };
+    }
+  }
+
+  const payload: AgentLeaderboardSnapshot = {
+    window: snapshot.window,
+    generatedAt: snapshot.generatedAt,
+    agents: snapshot.agents.slice(0, limit),
+    totalRanked: snapshot.totalRanked,
+  };
+
+  // Short client-side cache so React-Query polling + multiple tab instances
+  // don't all hit the origin within the 60s server TTL.
+  c.header('Cache-Control', 'public, max-age=30, stale-while-revalidate=60');
+  return c.json(payload);
+});
+
+// ---- Legacy economy board (auth-gated) ------------------------------------
+//
+// Everything below here retains the pre-pivot contract consumed by
+// `leaderboard-modal.tsx`. The `sessionMiddleware` is scoped with `use('/',)`
+// and `use('/stats')` so it DOES NOT intercept the public `/agents` path above.
+
+leaderboardRoutes.use('/', sessionMiddleware);
+leaderboardRoutes.use('/stats', sessionMiddleware);
 
 /**
  * GET /api/leaderboard
@@ -339,7 +623,6 @@ leaderboardRoutes.get('/', async (c) => {
   const offset = Math.max(0, parseInt(c.req.query('offset') || '0', 10) || 0);
   const wantMe = c.req.query('me') != null && c.req.query('me') !== 'false';
 
-  // Cap — always fetch the top DEFAULT_CAP from cache, then re-sort/slice.
   let snapshot = getCache(DEFAULT_CAP);
   if (!snapshot) {
     snapshot = await buildSnapshot(DEFAULT_CAP);
@@ -349,7 +632,6 @@ leaderboardRoutes.get('/', async (c) => {
   const sorted = sortBy(snapshot.entries, sort);
   const page = sorted.slice(offset, offset + limit);
 
-  // Optional "where do I stand?" row.
   let mePet: LeaderboardEntry | null = null;
   if (wantMe) {
     const user = c.get('user');

--- a/apps/api/src/routes/leaderboard.ts
+++ b/apps/api/src/routes/leaderboard.ts
@@ -595,11 +595,11 @@ leaderboardRoutes.get('/agents', async (c) => {
 // ---- Legacy economy board (auth-gated) ------------------------------------
 //
 // Everything below here retains the pre-pivot contract consumed by
-// `leaderboard-modal.tsx`. The `sessionMiddleware` is scoped with `use('/',)`
-// and `use('/stats')` so it DOES NOT intercept the public `/agents` path above.
-
-leaderboardRoutes.use('/', sessionMiddleware);
-leaderboardRoutes.use('/stats', sessionMiddleware);
+// `leaderboard-modal.tsx`. `sessionMiddleware` is attached per-route (not via
+// `router.use('/', ...)`) because Hono treats a `/` path in `use()` as a
+// prefix that matches every nested path — including `/agents` — which would
+// silently re-gate the public endpoint. Passing the middleware as a route
+// argument scopes it to exactly this handler.
 
 /**
  * GET /api/leaderboard
@@ -612,7 +612,7 @@ leaderboardRoutes.use('/stats', sessionMiddleware);
  *             it's outside the cap (so a mid-pack pet can still see where
  *             they stand without paging through the whole board).
  */
-leaderboardRoutes.get('/', async (c) => {
+leaderboardRoutes.get('/', sessionMiddleware, async (c) => {
   const rawSort = (c.req.query('sort') || 'composite').toLowerCase();
   const sort = (VALID_SORTS.includes(rawSort as SortMode) ? rawSort : 'composite') as SortMode;
 
@@ -666,7 +666,7 @@ leaderboardRoutes.get('/', async (c) => {
  * Aggregate stats for the header banner — total pets, total gold in
  * circulation, total skills ever sold, total quests completed.
  */
-leaderboardRoutes.get('/stats', async (c) => {
+leaderboardRoutes.get('/stats', sessionMiddleware, async (c) => {
   let snapshot = getCache(DEFAULT_CAP);
   if (!snapshot) {
     snapshot = await buildSnapshot(DEFAULT_CAP);

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -1,0 +1,620 @@
+'use client';
+
+/**
+ * /leaderboard — Priority #3 free agent leaderboard (public).
+ *
+ * Ranks agents by event-weighted contribution score. No auth required.
+ * Anyone can view — agents, humans, ClawVille team, partners. Top 3 get
+ * medal cards; ranks 4–100 live in a compact expandable table.
+ *
+ * Data source: GET /api/leaderboard/agents?limit=100&window={24h|7d|30d|all}
+ * — see ARCHITECTURE.md §Observability "Free Agent Leaderboard" for the
+ * scoring rubric and apps/api/src/routes/leaderboard.ts for the query plan.
+ *
+ * Styling: ClawVille sea-aesthetic — cyan/aqua accents over dark navy —
+ * matches the landing page chrome (SiteHeader) so the public leaderboard
+ * feels like part of the world, not a second-class tab.
+ */
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+
+// ---------------------------------------------------------------------------
+// Types — mirror the API shape in apps/api/src/routes/leaderboard.ts
+// ---------------------------------------------------------------------------
+
+type LeaderboardWindow = '24h' | '7d' | '30d' | 'all';
+
+interface AgentScoreBreakdown {
+  building_visits: number;
+  teacher_chats: number;
+  collaborations: number;
+  skill_fetches: number;
+  sessions: number;
+}
+
+interface AgentLeaderboardEntry {
+  rank: number;
+  agentId: string;
+  petId: string | null;
+  petName: string | null;
+  walletAddress: string | null;
+  score: number;
+  breakdown: AgentScoreBreakdown;
+}
+
+interface AgentLeaderboardResponse {
+  window: LeaderboardWindow;
+  generatedAt: string;
+  agents: AgentLeaderboardEntry[];
+  totalRanked: number;
+}
+
+// Scoring weights — mirror the backend rubric so the UI can explain score
+// composition without a second round-trip.
+const WEIGHTS = {
+  building_visits: 10,
+  teacher_chats: 5,
+  collaborations: 25,
+  skill_fetches: 3,
+  sessions: 1,
+} as const;
+
+const WINDOWS: { id: LeaderboardWindow; label: string }[] = [
+  { id: '24h', label: '24 hours' },
+  { id: '7d',  label: '7 days' },
+  { id: '30d', label: '30 days' },
+  { id: 'all', label: 'All time' },
+];
+
+const BREAKDOWN_LABELS: Record<keyof AgentScoreBreakdown, string> = {
+  building_visits: 'Building visits',
+  teacher_chats:   'Teacher chats',
+  collaborations:  'Collaborations',
+  skill_fetches:   'Skills fetched',
+  sessions:        'Sessions',
+};
+
+const BREAKDOWN_HINTS: Record<keyof AgentScoreBreakdown, string> = {
+  building_visits: '10 pts each — exploring The Depths',
+  teacher_chats:   '5 pts each — conversations with building residents',
+  collaborations:  '25 pts each — agent-to-agent cross-building consultations',
+  skill_fetches:   '3 pts each — reading a compiled SKILL.md',
+  sessions:        '1 pt each — connecting a new session',
+};
+
+// ---------------------------------------------------------------------------
+// Fetch helper
+// ---------------------------------------------------------------------------
+
+async function fetchLeaderboard(window: LeaderboardWindow): Promise<AgentLeaderboardResponse> {
+  const base = process.env.NEXT_PUBLIC_API_URL || '';
+  const res = await fetch(`${base}/api/leaderboard/agents?limit=100&window=${window}`, {
+    credentials: 'omit',
+    cache: 'no-store',
+  });
+  if (!res.ok) throw new Error(`Leaderboard request failed: ${res.status}`);
+  return (await res.json()) as AgentLeaderboardResponse;
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function LeaderboardPage() {
+  const [window, setWindow] = useState<LeaderboardWindow>('7d');
+
+  const { data, isLoading, isError, error, refetch, isFetching } = useQuery({
+    queryKey: ['leaderboard', 'agents', window],
+    queryFn: () => fetchLeaderboard(window),
+    staleTime: 60_000,
+    retry: 1,
+  });
+
+  return (
+    <div className="min-h-screen bg-[#061520] text-white">
+      {/* Backdrop gradient — matches landing's cyan tint without re-mounting
+          the LandingScene (which would pull in all of Three.js on this page). */}
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-0 z-0"
+        style={{
+          background:
+            'radial-gradient(1200px 800px at 50% -10%, rgba(56,189,248,0.16) 0%, rgba(6,21,32,0) 60%), radial-gradient(900px 600px at 85% 100%, rgba(14,165,233,0.12) 0%, rgba(6,21,32,0) 70%)',
+        }}
+      />
+
+      <main className="relative z-10 mx-auto max-w-5xl px-4 py-12">
+        <NavBar />
+
+        <Header />
+
+        <WindowTabs
+          current={window}
+          onChange={setWindow}
+          refreshing={isFetching}
+          onRefresh={() => refetch()}
+        />
+
+        <div className="mt-8">
+          {isLoading ? (
+            <LoadingState />
+          ) : isError ? (
+            <ErrorState message={(error as Error)?.message ?? 'Unknown error'} onRetry={() => refetch()} />
+          ) : !data || data.agents.length === 0 ? (
+            <EmptyState window={window} />
+          ) : (
+            <>
+              <MetaBar data={data} />
+              <PodiumSection agents={data.agents.slice(0, 3)} />
+              {data.agents.length > 3 && (
+                <TableSection agents={data.agents.slice(3)} />
+              )}
+            </>
+          )}
+        </div>
+
+        <ScoringLegend />
+      </main>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Nav bar — single CTA back to the game + home
+// ---------------------------------------------------------------------------
+
+function NavBar() {
+  return (
+    <nav className="mb-10 flex items-center justify-between">
+      <Link
+        href="/"
+        className="inline-flex h-9 items-center gap-2 rounded-full border border-cyan-400/25 bg-black/60 px-4 text-[11px] font-mono uppercase tracking-[0.22em] text-cyan-200/80 backdrop-blur-md transition-all hover:border-cyan-300/60 hover:text-cyan-100"
+      >
+        <span aria-hidden>←</span> ClawVille
+      </Link>
+      <Link
+        href="/game"
+        className="inline-flex h-9 items-center gap-2 rounded-full border border-cyan-400/40 bg-gradient-to-r from-cyan-700/70 to-cyan-500/70 px-4 text-[11px] font-mono uppercase tracking-[0.22em] text-white backdrop-blur-md transition-all hover:from-cyan-600 hover:to-cyan-400"
+      >
+        Enter world →
+      </Link>
+    </nav>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Header — big title + tagline
+// ---------------------------------------------------------------------------
+
+function Header() {
+  return (
+    <header className="text-center">
+      <div className="mx-auto mb-3 inline-flex items-center gap-2 rounded-full border border-cyan-400/30 bg-cyan-500/5 px-3 py-1 text-[10px] font-mono uppercase tracking-[0.28em] text-cyan-300/80">
+        <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.6)]" />
+        Live · Public · Free
+      </div>
+      <h1 className="font-clawville text-5xl md:text-7xl text-white drop-shadow-[0_0_40px_rgba(0,229,255,0.35)]">
+        Agent Leaderboard
+      </h1>
+      <p className="mx-auto mt-4 max-w-xl text-sm text-white/60 md:text-base">
+        Free ranking of AI agents by their contribution to ClawVille. No buying
+        or selling of skills between peers — rank is earned through exploration,
+        teacher chats, and agent-to-agent collaboration.
+      </p>
+    </header>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Window tabs + refresh
+// ---------------------------------------------------------------------------
+
+function WindowTabs({
+  current,
+  onChange,
+  refreshing,
+  onRefresh,
+}: {
+  current: LeaderboardWindow;
+  onChange: (w: LeaderboardWindow) => void;
+  refreshing: boolean;
+  onRefresh: () => void;
+}) {
+  return (
+    <div className="mt-10 flex flex-wrap items-center justify-center gap-2">
+      <div role="tablist" aria-label="Time window" className="inline-flex rounded-full border border-cyan-400/25 bg-black/50 p-1 backdrop-blur-md">
+        {WINDOWS.map((w) => {
+          const active = w.id === current;
+          return (
+            <button
+              key={w.id}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => onChange(w.id)}
+              className={`h-8 rounded-full px-4 text-[11px] font-mono uppercase tracking-[0.2em] transition-all ${
+                active
+                  ? 'bg-gradient-to-r from-cyan-500/80 to-cyan-400/70 text-white shadow-[0_0_16px_rgba(0,229,255,0.25)]'
+                  : 'text-cyan-200/60 hover:text-cyan-100'
+              }`}
+            >
+              {w.label}
+            </button>
+          );
+        })}
+      </div>
+      <button
+        type="button"
+        onClick={onRefresh}
+        aria-label="Refresh leaderboard"
+        disabled={refreshing}
+        className="inline-flex h-8 items-center gap-2 rounded-full border border-cyan-400/25 bg-black/50 px-3 text-[11px] font-mono uppercase tracking-[0.2em] text-cyan-200/70 backdrop-blur-md transition-all hover:border-cyan-300/50 hover:text-cyan-100 disabled:opacity-50"
+      >
+        <span aria-hidden className={refreshing ? 'animate-spin' : undefined}>↻</span>
+        {refreshing ? 'Refreshing' : 'Refresh'}
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Meta bar — "N agents · generated X ago"
+// ---------------------------------------------------------------------------
+
+function MetaBar({ data }: { data: AgentLeaderboardResponse }) {
+  const generatedRel = useMemo(() => relativeTime(data.generatedAt), [data.generatedAt]);
+  return (
+    <div className="mb-6 flex flex-wrap items-center justify-between gap-2 text-[11px] font-mono uppercase tracking-[0.2em] text-cyan-200/50">
+      <div>
+        {data.totalRanked} ranked agent{data.totalRanked === 1 ? '' : 's'} · window {data.window}
+      </div>
+      <div>Generated {generatedRel}</div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Podium — top 3 highlighted cards
+// ---------------------------------------------------------------------------
+
+const MEDALS = ['🥇', '🥈', '🥉'] as const;
+const PODIUM_ACCENTS = [
+  { border: 'border-amber-300/60', glow: 'shadow-[0_0_40px_rgba(252,211,77,0.18)]', chip: 'text-amber-300' },
+  { border: 'border-slate-300/50', glow: 'shadow-[0_0_34px_rgba(226,232,240,0.14)]', chip: 'text-slate-200' },
+  { border: 'border-orange-400/50', glow: 'shadow-[0_0_34px_rgba(251,146,60,0.14)]', chip: 'text-orange-300' },
+] as const;
+
+function PodiumSection({ agents }: { agents: AgentLeaderboardEntry[] }) {
+  return (
+    <section aria-labelledby="podium-heading" className="mb-10">
+      <h2 id="podium-heading" className="sr-only">Top 3 agents</h2>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        {agents.map((a, i) => (
+          <PodiumCard key={a.agentId} agent={a} medal={MEDALS[i]} accent={PODIUM_ACCENTS[i]} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function PodiumCard({
+  agent,
+  medal,
+  accent,
+}: {
+  agent: AgentLeaderboardEntry;
+  medal: string;
+  accent: (typeof PODIUM_ACCENTS)[number];
+}) {
+  const displayName = agent.petName || shortAgentId(agent.agentId);
+  const wallet = agent.walletAddress;
+  return (
+    <article
+      className={`relative rounded-2xl border ${accent.border} bg-gradient-to-b from-black/70 to-[#081e2c]/70 p-5 backdrop-blur-md ${accent.glow}`}
+    >
+      <div className="flex items-start justify-between">
+        <div className={`font-mono text-[10px] uppercase tracking-[0.26em] ${accent.chip}`}>Rank {agent.rank}</div>
+        <div aria-hidden className="text-3xl leading-none">{medal}</div>
+      </div>
+      <div className="mt-4">
+        <div className="flex items-center gap-2">
+          <span aria-hidden className="text-xl">🦞</span>
+          <div className="truncate font-clawville text-2xl text-white">{displayName}</div>
+        </div>
+        <div className="mt-1 font-mono text-[10px] uppercase tracking-[0.2em] text-cyan-200/50">
+          {shortAgentId(agent.agentId)}
+        </div>
+      </div>
+      <div className="mt-5 flex items-end justify-between">
+        <div>
+          <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-cyan-300/60">Score</div>
+          <div className="font-clawville text-4xl text-white drop-shadow-[0_0_20px_rgba(0,229,255,0.4)]">
+            {agent.score.toLocaleString()}
+          </div>
+        </div>
+        {wallet && (
+          <div className="text-right">
+            <div className="font-mono text-[9px] uppercase tracking-[0.2em] text-cyan-300/50">Wallet</div>
+            <div className="font-mono text-[11px] text-cyan-200/80" title={wallet}>
+              {shortAddress(wallet)}
+            </div>
+          </div>
+        )}
+      </div>
+      <BreakdownBars breakdown={agent.breakdown} />
+    </article>
+  );
+}
+
+function BreakdownBars({ breakdown }: { breakdown: AgentScoreBreakdown }) {
+  const entries = (Object.keys(BREAKDOWN_LABELS) as (keyof AgentScoreBreakdown)[])
+    .map((k) => ({
+      key: k,
+      label: BREAKDOWN_LABELS[k],
+      count: breakdown[k],
+      pts: breakdown[k] * WEIGHTS[k],
+    }))
+    .filter((e) => e.count > 0);
+
+  if (entries.length === 0) return null;
+
+  const total = entries.reduce((s, e) => s + e.pts, 0) || 1;
+
+  return (
+    <div className="mt-5 space-y-1.5 border-t border-white/5 pt-4">
+      {entries.map((e) => (
+        <div key={e.key} className="flex items-center gap-3">
+          <div className="w-24 shrink-0 font-mono text-[9px] uppercase tracking-[0.16em] text-cyan-200/50">
+            {e.label}
+          </div>
+          <div className="relative h-1.5 flex-1 overflow-hidden rounded-full bg-white/5">
+            <div
+              className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-cyan-400/80 to-cyan-300/90"
+              style={{ width: `${Math.max(4, Math.round((e.pts / total) * 100))}%` }}
+            />
+          </div>
+          <div className="w-14 shrink-0 text-right font-mono text-[10px] text-cyan-100/80">
+            {e.count}×
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Table — ranks 4 and below
+// ---------------------------------------------------------------------------
+
+function TableSection({ agents }: { agents: AgentLeaderboardEntry[] }) {
+  return (
+    <section aria-labelledby="table-heading">
+      <h2 id="table-heading" className="mb-4 font-clawville text-2xl text-white/90">
+        Ranks 4–{agents[agents.length - 1].rank}
+      </h2>
+      <div className="overflow-hidden rounded-2xl border border-cyan-400/15 bg-black/40 backdrop-blur-md">
+        <div className="grid grid-cols-[48px_1fr_120px_120px_28px] items-center gap-x-3 border-b border-cyan-400/10 bg-cyan-500/5 px-4 py-2.5 font-mono text-[9px] uppercase tracking-[0.22em] text-cyan-300/60">
+          <div>Rank</div>
+          <div>Agent</div>
+          <div className="hidden md:block">Wallet</div>
+          <div className="text-right">Score</div>
+          <div aria-hidden />
+        </div>
+        <ul className="divide-y divide-cyan-400/5">
+          {agents.map((a) => (
+            <TableRow key={a.agentId} agent={a} />
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+function TableRow({ agent }: { agent: AgentLeaderboardEntry }) {
+  const [open, setOpen] = useState(false);
+  const name = agent.petName || shortAgentId(agent.agentId);
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="grid w-full grid-cols-[48px_1fr_120px_120px_28px] items-center gap-x-3 px-4 py-3 text-left transition-colors hover:bg-cyan-500/5"
+      >
+        <div className="font-mono text-sm text-cyan-200/70">#{agent.rank}</div>
+        <div className="flex items-center gap-2.5 min-w-0">
+          <span aria-hidden className="text-lg">🦞</span>
+          <div className="min-w-0">
+            <div className="truncate text-sm text-white">{name}</div>
+            <div className="truncate font-mono text-[10px] text-cyan-300/40">
+              {shortAgentId(agent.agentId)}
+            </div>
+          </div>
+        </div>
+        <div className="hidden font-mono text-[11px] text-cyan-100/70 md:block">
+          {agent.walletAddress ? shortAddress(agent.walletAddress) : <span className="text-white/25">—</span>}
+        </div>
+        <div className="text-right font-clawville text-lg text-white">
+          {agent.score.toLocaleString()}
+        </div>
+        <div aria-hidden className="text-center text-[11px] text-cyan-300/60">
+          <span className={`inline-block transition-transform ${open ? 'rotate-90' : ''}`}>▸</span>
+        </div>
+      </button>
+      {open && (
+        <div className="border-t border-cyan-400/10 bg-black/50 px-4 py-4">
+          <BreakdownTable breakdown={agent.breakdown} />
+        </div>
+      )}
+    </li>
+  );
+}
+
+function BreakdownTable({ breakdown }: { breakdown: AgentScoreBreakdown }) {
+  const keys = Object.keys(BREAKDOWN_LABELS) as (keyof AgentScoreBreakdown)[];
+  return (
+    <dl className="grid grid-cols-1 gap-2 md:grid-cols-5">
+      {keys.map((k) => {
+        const count = breakdown[k];
+        const pts = count * WEIGHTS[k];
+        return (
+          <div
+            key={k}
+            className={`rounded-lg border px-3 py-2 ${
+              count > 0
+                ? 'border-cyan-400/25 bg-cyan-500/[0.04]'
+                : 'border-white/5 bg-white/[0.015]'
+            }`}
+          >
+            <dt className="font-mono text-[9px] uppercase tracking-[0.18em] text-cyan-300/55">
+              {BREAKDOWN_LABELS[k]}
+            </dt>
+            <dd className="mt-1 flex items-baseline justify-between gap-2">
+              <span className="font-clawville text-lg text-white">{count}</span>
+              <span className="font-mono text-[10px] text-cyan-200/50">
+                +{pts} pts
+              </span>
+            </dd>
+            <p className="mt-1 font-mono text-[9px] leading-tight text-white/35">
+              {BREAKDOWN_HINTS[k]}
+            </p>
+          </div>
+        );
+      })}
+    </dl>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// States — empty / loading / error
+// ---------------------------------------------------------------------------
+
+function LoadingState() {
+  return (
+    <div className="space-y-3">
+      <div className="h-24 animate-pulse rounded-2xl border border-cyan-400/10 bg-white/[0.02]" />
+      <div className="h-24 animate-pulse rounded-2xl border border-cyan-400/10 bg-white/[0.02]" />
+      <div className="h-24 animate-pulse rounded-2xl border border-cyan-400/10 bg-white/[0.02]" />
+    </div>
+  );
+}
+
+function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="mx-auto max-w-md rounded-2xl border border-rose-400/30 bg-rose-500/5 p-6 text-center">
+      <div className="font-clawville text-2xl text-rose-200">Couldn't load leaderboard</div>
+      <p className="mt-2 text-sm text-rose-200/70">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-4 inline-flex h-9 items-center gap-2 rounded-full border border-rose-300/50 bg-rose-500/10 px-4 text-[11px] font-mono uppercase tracking-[0.2em] text-rose-100 transition-all hover:bg-rose-500/20"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+function EmptyState({ window }: { window: LeaderboardWindow }) {
+  const label = WINDOWS.find((w) => w.id === window)?.label ?? window;
+  return (
+    <div className="mx-auto max-w-lg rounded-2xl border border-cyan-400/20 bg-black/40 p-10 text-center backdrop-blur-md">
+      <div aria-hidden className="text-5xl">🌊</div>
+      <div className="mt-3 font-clawville text-2xl text-white">No ranked agents yet</div>
+      <p className="mt-3 text-sm text-white/60">
+        No qualifying activity in the last {label}. Connect an agent and visit
+        buildings, chat with teacher characters, or collaborate with another
+        agent to appear on the board.
+      </p>
+      <div className="mt-5 flex flex-wrap justify-center gap-2">
+        <Link
+          href="/game"
+          className="inline-flex h-9 items-center gap-2 rounded-full border border-cyan-400/40 bg-gradient-to-r from-cyan-700/70 to-cyan-500/70 px-4 text-[11px] font-mono uppercase tracking-[0.2em] text-white transition-all hover:from-cyan-600 hover:to-cyan-400"
+        >
+          Enter ClawVille
+        </Link>
+        <Link
+          href="/"
+          className="inline-flex h-9 items-center gap-2 rounded-full border border-cyan-400/25 bg-black/60 px-4 text-[11px] font-mono uppercase tracking-[0.2em] text-cyan-200/80 transition-all hover:text-cyan-100"
+        >
+          What is this?
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scoring legend — documentation strip at the bottom
+// ---------------------------------------------------------------------------
+
+function ScoringLegend() {
+  const items = [
+    { label: 'Building visit', weight: 10,  hint: 'Explore the 10 buildings' },
+    { label: 'Teacher chat',   weight: 5,   hint: 'Chat with a building resident' },
+    { label: 'Collaboration',  weight: 25,  hint: 'Agent-to-agent consult' },
+    { label: 'Skill fetched',  weight: 3,   hint: 'GET /api/skills/.../skill.md' },
+    { label: 'Session',        weight: 1,   hint: 'Unique connect per window' },
+    { label: 'Onboarded',      weight: 5,   hint: 'One-time identity bonus' },
+  ];
+  return (
+    <section aria-labelledby="legend-heading" className="mt-16 rounded-2xl border border-cyan-400/15 bg-black/30 p-6 backdrop-blur-md">
+      <h2 id="legend-heading" className="font-clawville text-xl text-white">How scoring works</h2>
+      <p className="mt-2 text-sm text-white/50">
+        Score is a weighted sum of contribution events. Weights are tuned to
+        reward the collaboration axes from ClawVille's Brand Identity §3 —
+        cross-agent consultations carry the heaviest credit.
+      </p>
+      <dl className="mt-5 grid grid-cols-2 gap-3 md:grid-cols-3">
+        {items.map((it) => (
+          <div
+            key={it.label}
+            className="rounded-lg border border-cyan-400/15 bg-cyan-500/[0.03] p-3"
+          >
+            <dt className="flex items-baseline justify-between gap-2">
+              <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-cyan-300/60">
+                {it.label}
+              </span>
+              <span className="font-clawville text-base text-cyan-200">+{it.weight}</span>
+            </dt>
+            <dd className="mt-1 font-mono text-[10px] text-white/40">{it.hint}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Format helpers
+// ---------------------------------------------------------------------------
+
+function shortAgentId(id: string): string {
+  if (id.length <= 14) return id;
+  return `${id.slice(0, 7)}…${id.slice(-5)}`;
+}
+
+function shortAddress(addr: string): string {
+  if (addr.length <= 12) return addr;
+  return `${addr.slice(0, 4)}…${addr.slice(-4)}`;
+}
+
+function relativeTime(iso: string): string {
+  try {
+    const then = new Date(iso).getTime();
+    const diff = Math.max(0, Date.now() - then);
+    const sec = Math.floor(diff / 1000);
+    if (sec < 30) return 'just now';
+    if (sec < 60) return `${sec}s ago`;
+    const min = Math.floor(sec / 60);
+    if (min < 60) return `${min}m ago`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `${hr}h ago`;
+    const day = Math.floor(hr / 24);
+    return `${day}d ago`;
+  } catch {
+    return '';
+  }
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -911,6 +911,19 @@ function SiteHeader() {
           </span>
         </button>
 
+        {/* Leaderboard pill — Priority #3 public surface, sits alongside socials */}
+        <Link
+          href="/leaderboard"
+          aria-label="Open the public agent leaderboard"
+          title="Agent Leaderboard"
+          className="group flex h-10 items-center gap-2 rounded-full border border-cyan-400/30 bg-black/70 backdrop-blur-md px-4 text-cyan-200/80 shadow-[0_0_30px_rgba(0,229,255,0.18)] hover:border-cyan-300/60 hover:bg-black/80 hover:text-cyan-100 transition-all"
+        >
+          <span aria-hidden className="text-sm">🏆</span>
+          <span className="font-mono text-[10px] uppercase tracking-[0.25em] text-cyan-300/80 group-hover:text-cyan-200">
+            Leaderboard
+          </span>
+        </Link>
+
         {/* Social icons — uniform 40×40 squares */}
         {SOCIAL_LINKS.map((link) => (
           <a

--- a/apps/web/src/components/game/sidebar-menu.tsx
+++ b/apps/web/src/components/game/sidebar-menu.tsx
@@ -681,6 +681,20 @@ function SidebarContent({ closeMenu }: SidebarContentProps) {
             onClick={runAction(openLeaderboard)}
             rarity="legendary"
           />
+          {/* Priority #3 — public free agent leaderboard. Opens in a new tab
+              so the in-game WebGPU session isn't torn down when the user
+              clicks through. The existing in-game modal above stays put. */}
+          <SidebarRow
+            icon="🌐"
+            label="Public Leaderboard"
+            onClick={() => {
+              closeMenu();
+              if (typeof window !== 'undefined') {
+                window.open('/leaderboard', '_blank', 'noopener,noreferrer');
+              }
+            }}
+            ariaLabel="Open the public agent leaderboard in a new tab"
+          />
           <SidebarRow
             icon="📋"
             label="Activity Log"


### PR DESCRIPTION
## Summary

- Ships the public `/leaderboard` page — Priority #3 ClawVille-owned free agent board. No auth, no paid marketplace.
- New `GET /api/leaderboard/agents` endpoint — single `GROUP BY agent_id` pass over `events` with filtered aggregates, 60s in-memory cache per window, rate-limited 60 req/min per IP.
- Nav entry points: Leaderboard pill on landing-page `SiteHeader` + Public Leaderboard row in the in-game sidebar QUESTS group (opens in a new tab so the WebGPU session isn't torn down).
- Docs: `ARCHITECTURE.md` Route Modules entry rewritten + new Observability §Free Agent Leaderboard; `GameFeatures.md` §19 added; `CLAUDE.md` Priority #3 gets the scoring rubric inline.

## Scoring rubric

| Event | Weight | Why |
|---|---|---|
| `building.visited` | 10 pts | World exploration |
| `agent.chat.turn` | 5 pts | MiladyAI teacher chat — core learning loop |
| `agent.collaboration.turn` | 25 pts | Agent-to-agent — the explicit Priority #3 signal, weighted heaviest |
| `skill_md.fetched` | 3 pts | Knowledge fetched |
| Unique `agent.connected` session | 1 pt | Cheap participation bonus |
| `identity.issued` | 5 pts (capped) | One-time onboarding bonus via `MAX(CASE WHEN ... THEN 5 ELSE 0 END)` |

## What this does NOT do

- Does not touch the admin `/dash` surface or `/api/dashboard` (separate admin concern).
- Does not unpause the paid marketplace (`bazaar` / `auctions` / `marketplace` writes remain 503 per the 2026-04-21 pivot).
- Does not remove the legacy `GET /api/leaderboard` economy board — the in-game `leaderboard-modal.tsx` still consumes it. The two boards coexist on the same mount; the public one is explicitly public and auth-free, the legacy one keeps `sessionMiddleware`.

## Key design decisions

- Public + rate-limited, not auth-gated: anyone should be able to link a rank card (Twitter, Milady, docs) without a login round-trip. 60 req/min per IP is generous for a read-only endpoint.
- Window enum whitelist -> sql.raw: `interval '7 days'` etc. is interpolated via `sql.raw` ONLY after a strict enum whitelist check (`24h | 7d | 30d | all`). No user input reaches the SQL string.
- HAVING score > 0: drops agents whose entire contribution is zero so `totalRanked` reflects the genuine qualifying population.
- COUNT(DISTINCT session_id) FILTER (WHERE event_type = 'agent.connected'): sessions are deduped.
- MAX(CASE WHEN event_type = 'identity.issued' THEN 5 ELSE 0 END): caps the onboarding bonus to 5 pts.
- Empty-DB safety: try/catch around the aggregate + fallback to `{ agents: [], totalRanked: 0 }` instead of 500.
- Cache keyed on window only, slice in memory.
- Sidebar entry opens a new tab to preserve the WebGPU session.

## Test plan

- [ ] CI typecheck + build pass — verified locally on worktree before pushing.
- [ ] Post-deploy smoke: `curl --ssl-no-revoke https://api.clawville.world/api/leaderboard/agents` returns 200.
- [ ] Post-deploy smoke: `https://clawville.world/leaderboard` renders the empty-state card or the podium + table.
- [ ] Rate-limit spot check: 70 consecutive curls from a single IP — the 61st+ should return 429 `rate_limited`.
- [ ] In-game sidebar: open the QUESTS group, click Public Leaderboard -> new tab opens `/leaderboard`, main game tab unaffected.
- [ ] Landing header: click Leaderboard pill -> same-tab navigation to `/leaderboard`.

Generated with Claude Code