### PR TITLE
feat(activities): chunk #4 — Bumper Shells 3D scene + client wiring

### DIFF
--- a/apps/web/src/app/activity/[activityId]/[roomId]/page.tsx
+++ b/apps/web/src/app/activity/[activityId]/[roomId]/page.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+/**
+ * Bumper Shells (and future activities) match page.
+ *
+ * Route: `/activity/[activityId]/[roomId]?shortCode=...`
+ *
+ * Why a separate top-level route: the open-world `<World3DCanvas>` lives
+ * at `/game` and holds a long-lived WebGPU context. Mounting Bumper
+ * Shells inside it would force two GPU pipeline sets to share state +
+ * draw budget. Splitting onto its own route lets us instantiate a fresh
+ * WebGPU context (per `Canvas key={roomId}` in `BumperShellsScene`) and
+ * unmount it cleanly when the user leaves the match. Mirrors the
+ * 3d-spec §3.1 invariant.
+ *
+ * Layout: this page rides the root `app/layout.tsx` (no `app/game/layout.tsx`
+ * exists today — the game page sets its own full-bleed root). We do the
+ * same — full-screen black background + scene + HUD overlay.
+ */
+
+import { useEffect, useMemo, useState, use } from 'react';
+import dynamic from 'next/dynamic';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { isActivityLive, getActivityDefinition } from '@clawville/shared';
+import { usePet } from '@/hooks/use-pet';
+import { useActivityStore, selectSelfAlive } from '@/stores/activity';
+import { useActivityWs } from '@/hooks/useActivityWs';
+import { useActivityInput } from '@/hooks/useActivityInput';
+import BumperShellsHud from '@/components/game/bumper-shells-hud';
+
+// 3da-owned scene — dynamic-imported so the WebGPU context only initializes
+// after the page mounts (avoids bundling Three.js WebGPU into the entry chunk
+// of every other route).
+const BumperShellsScene = dynamic(
+  () => import('@/lib/three/activities/bumper-shells/BumperShellsScene'),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#0A1628',
+          color: '#00E5FF',
+          fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+          letterSpacing: '0.2em',
+          fontSize: 12,
+        }}
+      >
+        ENTERING ARENA…
+      </div>
+    ),
+  },
+);
+
+// ─── Page params (Next 15+ requires unwrapping with React.use()) ────────────
+
+interface ActivityRouteParams {
+  activityId: string;
+  roomId: string;
+}
+
+interface ActivityPageProps {
+  params: Promise<ActivityRouteParams>;
+}
+
+export default function ActivityRoomPage({ params }: ActivityPageProps) {
+  // Next.js 15+ async params — use React.use() inside a Client Component.
+  const { activityId, roomId } = use(params);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [shortCode, setShortCode] = useState<string | null>(
+    searchParams?.get('shortCode') ?? null,
+  );
+  const [shortCodeError, setShortCodeError] = useState<string | null>(null);
+
+  const { data: pet, isLoading: petLoading } = usePet();
+  const petId = pet?.id ?? null;
+
+  // Reset store on mount and whenever roomId changes (room teardown safety).
+  useEffect(() => {
+    useActivityStore.getState().reset(roomId);
+    if (petId) useActivityStore.getState().setSelfPetId(petId);
+    return () => {
+      useActivityStore.getState().reset(null);
+    };
+  }, [roomId, petId]);
+
+  // Push selfPetId into the store the moment we know it (might land after
+  // the WS opens; the store re-renders the scene then for self-highlight).
+  useEffect(() => {
+    if (petId) useActivityStore.getState().setSelfPetId(petId);
+  }, [petId]);
+
+  // If the lobby didn't pass shortCode, fetch room state to recover it.
+  // This also acts as the participant gate — `/state` returns 403 if the
+  // pet isn't in `room.participants`.
+  useEffect(() => {
+    if (shortCode || !petId || !activityId || !roomId) return;
+    let aborted = false;
+    (async () => {
+      try {
+        const apiBase = process.env.NEXT_PUBLIC_API_URL || '';
+        const res = await fetch(`${apiBase}/api/activities/${activityId}/rooms/${roomId}/state`, {
+          credentials: 'include',
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          if (!aborted) setShortCodeError(err?.error || `HTTP ${res.status}`);
+          return;
+        }
+        const json = (await res.json()) as { room: { shortCode: string } };
+        if (!aborted) setShortCode(json.room.shortCode);
+      } catch (err) {
+        if (!aborted)
+          setShortCodeError(err instanceof Error ? err.message : 'Failed to fetch room state');
+      }
+    })();
+    return () => {
+      aborted = true;
+    };
+  }, [shortCode, petId, activityId, roomId]);
+
+  // Activity gate — only `bumper-shells` is wired this chunk.
+  const activityIsLive = useMemo(() => isActivityLive(activityId), [activityId]);
+  const activityDef = useMemo(() => getActivityDefinition(activityId), [activityId]);
+
+  // Open WS as soon as we have everything.
+  const wsEnabled = !!petId && !!shortCode && activityIsLive && activityId === 'bumper-shells';
+  const { send, ping, status } = useActivityWs({
+    activityId,
+    roomId,
+    shortCode: shortCode ?? '',
+    enabled: wsEnabled,
+  });
+
+  // Gate input: only when scene is in play AND self is alive AND WS is open.
+  const matchPhase = useActivityStore((s) => s.matchPhase);
+  const selfAlive = useActivityStore(selectSelfAlive);
+  const inputEnabled =
+    wsEnabled && status === 'connected' && matchPhase === 'live' && selfAlive;
+
+  useActivityInput({ send, enabled: inputEnabled });
+
+  // Surface ping into local state already — no extra wiring needed
+  // (BumperShellsHud reads from the store).
+  void ping;
+
+  function handleLeave() {
+    // Best-effort `leave` frame goes out via the WS hook's unmount cleanup.
+    router.push('/game');
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────
+
+  if (petLoading) {
+    return <FullScreenStatus message="LOADING PET…" tone="neutral" />;
+  }
+
+  if (!pet) {
+    return (
+      <FullScreenStatus
+        message="No pet found — return to ClawVille and create one"
+        tone="warning"
+        action={{ label: 'BACK TO LOBBY', onClick: () => router.push('/game') }}
+      />
+    );
+  }
+
+  if (!activityIsLive || !activityDef) {
+    return (
+      <FullScreenStatus
+        message={`Activity "${activityId}" is not live yet`}
+        tone="warning"
+        action={{ label: 'BACK TO LOBBY', onClick: () => router.push('/game') }}
+      />
+    );
+  }
+
+  if (activityId !== 'bumper-shells') {
+    return (
+      <FullScreenStatus
+        message={`${activityDef.title} ships in a later chunk — only Bumper Shells is wired today`}
+        tone="warning"
+        action={{ label: 'BACK TO LOBBY', onClick: () => router.push('/game') }}
+      />
+    );
+  }
+
+  if (shortCodeError) {
+    return (
+      <FullScreenStatus
+        message={`Couldn't load room: ${shortCodeError}`}
+        tone="danger"
+        action={{ label: 'BACK TO LOBBY', onClick: () => router.push('/game') }}
+      />
+    );
+  }
+
+  if (!shortCode) {
+    return <FullScreenStatus message="RESOLVING ROOM…" tone="neutral" />;
+  }
+
+  return (
+    <main
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: '#0A1628',
+        overflow: 'hidden',
+      }}
+    >
+      <div style={{ position: 'absolute', inset: 0 }}>
+        <BumperShellsScene roomId={roomId} selfPetId={petId} />
+      </div>
+      <BumperShellsHud onLeave={handleLeave} />
+    </main>
+  );
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function FullScreenStatus({
+  message,
+  tone = 'neutral',
+  action,
+}: {
+  message: string;
+  tone?: 'neutral' | 'warning' | 'danger';
+  action?: { label: string; onClick: () => void };
+}) {
+  const accent =
+    tone === 'danger' ? '#fca5a5' : tone === 'warning' ? '#fde68a' : '#00E5FF';
+  return (
+    <main
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: '#0A1628',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 16,
+        color: accent,
+        fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+        letterSpacing: '0.16em',
+        fontSize: 14,
+        textShadow: `0 0 12px ${accent}`,
+      }}
+    >
+      <div>{message}</div>
+      {action && (
+        <button
+          type="button"
+          onClick={action.onClick}
+          style={{
+            padding: '10px 24px',
+            background: 'transparent',
+            border: `1px solid ${accent}`,
+            borderRadius: 6,
+            color: accent,
+            fontFamily: 'inherit',
+            fontWeight: 700,
+            letterSpacing: '0.12em',
+            cursor: 'pointer',
+            fontSize: 11,
+          }}
+        >
+          {action.label}
+        </button>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/components/game/activity/EliminatedOverlay.tsx
+++ b/apps/web/src/components/game/activity/EliminatedOverlay.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+/**
+ * EliminatedOverlay — full-viewport dim + "ELIMINATED — spectating" message
+ * shown when self has been knocked off the arena. Spec: frontend-spec.md
+ * §3.4 + §7 (spectator mode).
+ */
+
+export interface EliminatedOverlayProps {
+  /** Wall-clock timestamp the elimination happened (Date.now()). */
+  eliminatedAt: number;
+  /** Final/current placement of self. */
+  placement: number | null;
+  /** Optional name of the player the camera is following (chunk #8). */
+  spectatingPet?: string;
+}
+
+export default function EliminatedOverlay({
+  eliminatedAt,
+  placement,
+  spectatingPet,
+}: EliminatedOverlayProps) {
+  const elapsedSec = Math.max(0, Math.floor((Date.now() - eliminatedAt) / 1000));
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background:
+          'radial-gradient(ellipse at center, rgba(11, 18, 32, 0.55) 0%, rgba(11, 18, 32, 0.85) 100%)',
+        backdropFilter: 'grayscale(60%) brightness(0.7)',
+        WebkitBackdropFilter: 'grayscale(60%) brightness(0.7)',
+        pointerEvents: 'none',
+        zIndex: 25,
+      }}
+      role="status"
+      aria-live="polite"
+    >
+      <div
+        className="claw-panel"
+        style={{
+          padding: '20px 32px',
+          textAlign: 'center',
+          borderColor: 'rgba(255, 82, 82, 0.55)',
+          boxShadow: '0 0 28px rgba(255, 82, 82, 0.32)',
+        }}
+      >
+        <div
+          style={{
+            fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+            fontSize: 36,
+            fontWeight: 900,
+            letterSpacing: '0.12em',
+            color: '#fca5a5',
+            textShadow: '0 0 16px rgba(255, 82, 82, 0.6)',
+            marginBottom: 6,
+          }}
+        >
+          ELIMINATED
+        </div>
+        {placement !== null && (
+          <div
+            style={{
+              fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+              fontSize: 14,
+              color: '#facc15',
+              letterSpacing: '0.16em',
+              marginBottom: 10,
+            }}
+          >
+            FINAL PLACEMENT · #{placement}
+          </div>
+        )}
+        <div
+          style={{
+            fontSize: 12,
+            color: 'rgba(226, 232, 240, 0.85)',
+            marginBottom: 4,
+          }}
+        >
+          {spectatingPet ? `Spectating ${spectatingPet}` : 'Spectating remaining shells…'}
+        </div>
+        <div
+          style={{
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            fontSize: 10,
+            color: 'rgba(148, 163, 184, 0.75)',
+            letterSpacing: '0.1em',
+          }}
+        >
+          {elapsedSec}s ago
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/game/activity/HudMiniLeaderboard.tsx
+++ b/apps/web/src/components/game/activity/HudMiniLeaderboard.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+/**
+ * HudMiniLeaderboard — top-N + self row, top-right stack under
+ * `<HudPlacement>`. Spec: frontend-spec.md §3.4.
+ */
+
+import type { ActivityScoreEntry } from '@/stores/activity';
+
+export interface HudMiniLeaderboardProps {
+  entries: ActivityScoreEntry[];
+  selfId: string | null;
+  max?: number;
+}
+
+export default function HudMiniLeaderboard({ entries, selfId, max = 5 }: HudMiniLeaderboardProps) {
+  if (entries.length === 0) return null;
+
+  const visible = entries.slice(0, max);
+  // Always include self even if rank > max (spec §3.2 "3. You ◀")
+  const selfIncluded = visible.find((e) => e.petId === selfId);
+  const selfEntry =
+    selfId && !selfIncluded ? entries.find((e) => e.petId === selfId) ?? null : null;
+
+  return (
+    <div
+      className="claw-panel"
+      style={{
+        padding: '10px 12px',
+        minWidth: 200,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+        pointerEvents: 'none',
+      }}
+    >
+      <div
+        style={{
+          fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+          fontSize: 9,
+          letterSpacing: '0.22em',
+          textTransform: 'uppercase',
+          color: 'rgba(0, 229, 255, 0.7)',
+          fontWeight: 700,
+          marginBottom: 4,
+          borderBottom: '1px solid rgba(0, 229, 255, 0.15)',
+          paddingBottom: 4,
+        }}
+      >
+        Standings
+      </div>
+      {visible.map((e, i) => (
+        <Row key={e.petId} rank={i + 1} entry={e} isSelf={e.petId === selfId} />
+      ))}
+      {selfEntry && (
+        <>
+          <div
+            style={{
+              borderTop: '1px dashed rgba(0, 229, 255, 0.25)',
+              margin: '4px 0 2px',
+            }}
+          />
+          <Row
+            rank={entries.findIndex((x) => x.petId === selfEntry.petId) + 1}
+            entry={selfEntry}
+            isSelf
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+function Row({
+  rank,
+  entry,
+  isSelf,
+}: {
+  rank: number;
+  entry: ActivityScoreEntry;
+  isSelf: boolean;
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '3px 4px',
+        borderRadius: 4,
+        background: isSelf ? 'rgba(0, 230, 118, 0.12)' : 'transparent',
+        border: isSelf ? '1px solid rgba(0, 230, 118, 0.4)' : '1px solid transparent',
+      }}
+    >
+      <span
+        style={{
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+          fontSize: 11,
+          fontWeight: 700,
+          width: 22,
+          color: isSelf ? '#86efac' : 'rgba(148, 163, 184, 0.8)',
+        }}
+      >
+        #{rank}
+      </span>
+      <span
+        style={{
+          flex: 1,
+          fontSize: 11,
+          fontWeight: 600,
+          color: isSelf ? '#f0fdf4' : '#e2e8f0',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+      >
+        {entry.displayName}
+      </span>
+      <span
+        style={{
+          fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+          fontSize: 11,
+          fontWeight: 700,
+          color: isSelf ? '#86efac' : '#fde68a',
+        }}
+      >
+        {entry.score}
+      </span>
+      {isSelf && (
+        <span aria-hidden style={{ fontSize: 10, color: '#86efac' }}>
+          ◀
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/game/activity/HudPlacement.tsx
+++ b/apps/web/src/components/game/activity/HudPlacement.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+/**
+ * HudPlacement — large rank chip ("PLACEMENT #3") in the top-right corner.
+ * Spec: frontend-spec.md §3.4 + §3.2 wireframe.
+ */
+
+export interface HudPlacementProps {
+  /** 1-indexed rank, or null if not yet known. */
+  rank: number | null;
+  total: number;
+  highlight?: boolean;
+}
+
+function getMedalEmoji(rank: number): string {
+  switch (rank) {
+    case 1:
+      return '🥇';
+    case 2:
+      return '🥈';
+    case 3:
+      return '🥉';
+    default:
+      return '';
+  }
+}
+
+export default function HudPlacement({ rank, total, highlight = false }: HudPlacementProps) {
+  const display = rank ?? '–';
+  const medal = rank ? getMedalEmoji(rank) : '';
+  const isPodium = rank !== null && rank <= 3;
+  const accent = isPodium ? '#facc15' : '#00E5FF';
+  const glow = isPodium ? 'rgba(250, 204, 21, 0.45)' : 'rgba(0, 229, 255, 0.35)';
+
+  return (
+    <div
+      className={`claw-panel ${highlight ? 'animate-pulse' : ''}`}
+      style={{
+        padding: '10px 16px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 2,
+        minWidth: 140,
+        borderColor: accent,
+        boxShadow: `0 0 24px ${glow}, inset 0 1px 0 rgba(255, 255, 255, 0.08)`,
+        pointerEvents: 'none',
+      }}
+    >
+      <span
+        style={{
+          fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+          fontSize: 10,
+          letterSpacing: '0.22em',
+          textTransform: 'uppercase',
+          color: 'rgba(148, 163, 184, 0.85)',
+          fontWeight: 700,
+        }}
+      >
+        Placement
+      </span>
+      <span
+        style={{
+          fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+          fontSize: 32,
+          fontWeight: 900,
+          lineHeight: 1,
+          color: accent,
+          textShadow: `0 0 14px ${glow}`,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+        }}
+      >
+        {medal && <span style={{ fontSize: 24 }}>{medal}</span>}
+        #{display}
+      </span>
+      <span
+        style={{
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+          fontSize: 10,
+          color: 'rgba(148, 163, 184, 0.85)',
+          letterSpacing: '0.08em',
+        }}
+      >
+        of {total}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/components/game/activity/HudTile.tsx
+++ b/apps/web/src/components/game/activity/HudTile.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+/**
+ * HudTile — small top-corner status pill for ping / fps / round timer.
+ * Spec: frontend-spec.md §3.4. RPG style (claw-panel + Orbitron).
+ */
+
+import type { ReactNode } from 'react';
+
+export type HudTileTone = 'neutral' | 'success' | 'warning' | 'danger' | 'gold';
+
+export interface HudTileProps {
+  label: string;
+  value: ReactNode;
+  icon?: ReactNode;
+  tone?: HudTileTone;
+}
+
+const TONE_TO_CSS: Record<HudTileTone, { border: string; glow: string; valueColor: string }> = {
+  neutral: {
+    border: 'rgba(0, 229, 255, 0.4)',
+    glow: 'rgba(0, 229, 255, 0.18)',
+    valueColor: '#e0f2fe',
+  },
+  success: {
+    border: 'rgba(0, 230, 118, 0.45)',
+    glow: 'rgba(0, 230, 118, 0.22)',
+    valueColor: '#86efac',
+  },
+  warning: {
+    border: 'rgba(255, 215, 0, 0.5)',
+    glow: 'rgba(255, 215, 0, 0.22)',
+    valueColor: '#fde68a',
+  },
+  danger: {
+    border: 'rgba(255, 82, 82, 0.5)',
+    glow: 'rgba(255, 82, 82, 0.22)',
+    valueColor: '#fca5a5',
+  },
+  gold: {
+    border: 'rgba(255, 215, 0, 0.6)',
+    glow: 'rgba(255, 215, 0, 0.28)',
+    valueColor: '#facc15',
+  },
+};
+
+export default function HudTile({ label, value, icon, tone = 'neutral' }: HudTileProps) {
+  const t = TONE_TO_CSS[tone];
+  return (
+    <div
+      className="claw-panel"
+      style={{
+        padding: '8px 12px',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 10,
+        borderColor: t.border,
+        boxShadow: `0 0 14px ${t.glow}, inset 0 1px 0 rgba(255, 255, 255, 0.05)`,
+        pointerEvents: 'none',
+      }}
+    >
+      {icon ? (
+        <span aria-hidden style={{ fontSize: 14, lineHeight: 1, color: t.valueColor }}>
+          {icon}
+        </span>
+      ) : null}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 1, lineHeight: 1.05 }}>
+        <span
+          style={{
+            fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+            fontSize: 9,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: 'rgba(148, 163, 184, 0.85)',
+            fontWeight: 700,
+          }}
+        >
+          {label}
+        </span>
+        <span
+          style={{
+            fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+            fontSize: 14,
+            fontWeight: 700,
+            color: t.valueColor,
+            textShadow: `0 0 10px ${t.glow}`,
+          }}
+        >
+          {value}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/game/activity/PingIndicator.tsx
+++ b/apps/web/src/components/game/activity/PingIndicator.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+/**
+ * PingIndicator — colored dot + ms latency. Spec: frontend-spec.md §3.4.
+ * Wraps `<HudTile>` so it inherits the same chrome.
+ */
+
+import HudTile, { type HudTileTone } from './HudTile';
+
+export interface PingIndicatorProps {
+  ms: number;
+}
+
+function toneFor(ms: number): HudTileTone {
+  if (ms <= 0) return 'neutral'; // not yet measured
+  if (ms < 60) return 'success';
+  if (ms < 120) return 'neutral';
+  if (ms < 200) return 'warning';
+  return 'danger';
+}
+
+function dotColor(tone: HudTileTone): string {
+  switch (tone) {
+    case 'success':
+      return '#86efac';
+    case 'warning':
+      return '#fde68a';
+    case 'danger':
+      return '#fca5a5';
+    case 'gold':
+      return '#facc15';
+    default:
+      return '#00E5FF';
+  }
+}
+
+export default function PingIndicator({ ms }: PingIndicatorProps) {
+  const tone = toneFor(ms);
+  const display = ms <= 0 ? '—' : `${Math.round(ms)}ms`;
+  return (
+    <HudTile
+      label="Ping"
+      value={display}
+      tone={tone}
+      icon={
+        <span
+          style={{
+            display: 'inline-block',
+            width: 8,
+            height: 8,
+            borderRadius: '50%',
+            background: dotColor(tone),
+            boxShadow: `0 0 6px ${dotColor(tone)}`,
+          }}
+        />
+      }
+    />
+  );
+}

--- a/apps/web/src/components/game/activity/PowerUpBar.tsx
+++ b/apps/web/src/components/game/activity/PowerUpBar.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+/**
+ * PowerUpBar — bottom-center horizontal slot strip showing the player's
+ * inventory + cooldown rings. Spec: frontend-spec.md §3.4. Bumper Shells
+ * caps at 2 slots (§5.1 "Max 2 items held total"); we render 2 slots so
+ * empty ones still appear as placeholders (clearer mental model than the
+ * bar shrinking).
+ */
+
+import type { PowerUpSlot } from '@/stores/activity';
+import PowerUpIcon, { rarityForPowerUp } from './PowerUpIcon';
+
+export interface PowerUpBarProps {
+  slots: PowerUpSlot[];
+  onUse?: (slotIndex: number) => void;
+  /** Number of placeholder slots to render when inventory is short. */
+  capacity?: number;
+}
+
+export default function PowerUpBar({ slots, onUse, capacity = 2 }: PowerUpBarProps) {
+  const padded: (PowerUpSlot | null)[] = [];
+  for (let i = 0; i < capacity; i++) padded.push(slots[i] ?? null);
+
+  return (
+    <div
+      data-hud-interactive="true"
+      className="claw-panel"
+      style={{
+        padding: '8px 12px',
+        display: 'inline-flex',
+        gap: 10,
+        alignItems: 'center',
+        pointerEvents: 'auto',
+      }}
+    >
+      <span
+        style={{
+          fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+          fontSize: 9,
+          letterSpacing: '0.2em',
+          textTransform: 'uppercase',
+          color: 'rgba(0, 229, 255, 0.7)',
+          fontWeight: 700,
+        }}
+      >
+        Items
+      </span>
+      {padded.map((slot, i) => {
+        const cooldownRatio = slot?.cooldownUntil
+          ? Math.max(0, Math.min(1, (slot.cooldownUntil - Date.now()) / 5000))
+          : 0;
+        return (
+          <button
+            key={i}
+            type="button"
+            disabled={!slot || cooldownRatio > 0}
+            onClick={() => onUse?.(i)}
+            aria-label={
+              slot ? `Use ${slot.kind} (slot ${i + 1})` : `Empty slot ${i + 1}`
+            }
+            style={{
+              all: 'unset',
+              cursor: slot && cooldownRatio === 0 ? 'pointer' : 'default',
+              borderRadius: 8,
+              padding: 1,
+            }}
+          >
+            {slot ? (
+              <PowerUpIcon
+                powerUpId={slot.kind}
+                cooldownRatio={cooldownRatio}
+                rarity={rarityForPowerUp(slot.kind)}
+                charges={slot.charges}
+              />
+            ) : (
+              <EmptySlot />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function EmptySlot() {
+  return (
+    <div
+      style={{
+        width: 38,
+        height: 38,
+        borderRadius: 8,
+        background: 'rgba(15, 31, 58, 0.55)',
+        border: '1.5px dashed rgba(148, 163, 184, 0.3)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: 'rgba(148, 163, 184, 0.4)',
+        fontSize: 18,
+        flexShrink: 0,
+      }}
+      aria-hidden
+    >
+      ·
+    </div>
+  );
+}

--- a/apps/web/src/components/game/activity/PowerUpIcon.tsx
+++ b/apps/web/src/components/game/activity/PowerUpIcon.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+/**
+ * PowerUpIcon — 32×32 icon with rarity tint + cooldown ring overlay.
+ * Spec: frontend-spec.md §3.4. Symbols mapped from §5.1 catalog.
+ */
+
+export type PowerUpRarity = 'common' | 'uncommon' | 'rare' | 'legendary';
+
+export interface PowerUpIconProps {
+  /** Catalog id like `bs-speed-boost` OR a normalized kind. */
+  powerUpId: string;
+  /** 0 = ready, 1 = just used. Renders sweep ring. */
+  cooldownRatio?: number;
+  rarity?: PowerUpRarity;
+  /** Show "× N" badge for stackable items. */
+  charges?: number;
+}
+
+const RARITY_TO_COLOR: Record<PowerUpRarity, { border: string; glow: string }> = {
+  common: { border: 'rgba(148, 163, 184, 0.7)', glow: 'rgba(148, 163, 184, 0.4)' },
+  uncommon: { border: 'rgba(0, 230, 118, 0.7)', glow: 'rgba(0, 230, 118, 0.4)' },
+  rare: { border: 'rgba(66, 165, 245, 0.85)', glow: 'rgba(66, 165, 245, 0.55)' },
+  legendary: { border: 'rgba(255, 215, 0, 0.9)', glow: 'rgba(255, 215, 0, 0.65)' },
+};
+
+function symbolFor(id: string): string {
+  if (id.includes('speed') || id.includes('turbo')) return '⚡';
+  if (id.includes('shield')) return '🛡️';
+  if (id.includes('bomb') || id.includes('mine')) return '💣';
+  if (id.includes('aura') || id.includes('whirlpool')) return '🌀';
+  if (id.includes('ghost') || id.includes('phantom')) return '👻';
+  if (id.includes('tractor') || id.includes('siren')) return '🧲';
+  if (id.includes('ink')) return '🦑';
+  if (id.includes('jelly')) return '🪼';
+  if (id.includes('wave') || id.includes('tide')) return '🌊';
+  return '✨';
+}
+
+export default function PowerUpIcon({
+  powerUpId,
+  cooldownRatio = 0,
+  rarity = 'common',
+  charges,
+}: PowerUpIconProps) {
+  const r = RARITY_TO_COLOR[rarity];
+  const ratio = Math.max(0, Math.min(1, cooldownRatio));
+  // SVG arc — cooldown sweep clockwise. circumference of r=14 stroke=3 → 87.96.
+  const C = 2 * Math.PI * 14;
+  const dashOffset = C * (1 - ratio);
+
+  return (
+    <div
+      role="img"
+      aria-label={powerUpId}
+      style={{
+        position: 'relative',
+        width: 38,
+        height: 38,
+        borderRadius: 8,
+        background: 'linear-gradient(160deg, rgba(15, 31, 58, 0.95) 0%, rgba(6, 13, 23, 0.95) 100%)',
+        border: `1.5px solid ${r.border}`,
+        boxShadow: `0 0 12px ${r.glow}, inset 0 0 6px rgba(0, 229, 255, 0.08)`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+      }}
+    >
+      <span style={{ fontSize: 18, lineHeight: 1, filter: ratio > 0 ? 'grayscale(70%)' : undefined }}>
+        {symbolFor(powerUpId)}
+      </span>
+      {ratio > 0 && (
+        <svg
+          aria-hidden
+          viewBox="0 0 32 32"
+          style={{
+            position: 'absolute',
+            inset: 0,
+            width: '100%',
+            height: '100%',
+            transform: 'rotate(-90deg)',
+            pointerEvents: 'none',
+          }}
+        >
+          <circle
+            cx={16}
+            cy={16}
+            r={14}
+            fill="none"
+            stroke={r.border}
+            strokeWidth={2}
+            strokeDasharray={C}
+            strokeDashoffset={dashOffset}
+            opacity={0.85}
+          />
+        </svg>
+      )}
+      {typeof charges === 'number' && charges > 1 && (
+        <span
+          style={{
+            position: 'absolute',
+            bottom: -4,
+            right: -4,
+            background: '#0A1628',
+            border: `1px solid ${r.border}`,
+            borderRadius: 8,
+            fontSize: 9,
+            fontWeight: 700,
+            padding: '1px 4px',
+            color: '#facc15',
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            lineHeight: 1.1,
+          }}
+        >
+          ×{charges}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** Internal helper — derive rarity from a catalog id via the locked Q2
+ *  rarity table (frontend-spec.md §5.1). Re-exported so PowerUpBar can map
+ *  inventory rows to icons without re-implementing the lookup. */
+export function rarityForPowerUp(id: string): PowerUpRarity {
+  if (id.includes('tractor') || id.includes('tide-wave')) return 'legendary';
+  if (id.includes('aura') || id.includes('ghost') || id.includes('seeker') || id.includes('whirlpool'))
+    return 'rare';
+  if (id.includes('shield') || id.includes('bomb') || id.includes('mine')) return 'uncommon';
+  return 'common';
+}

--- a/apps/web/src/components/game/activity/RoundCountdown.tsx
+++ b/apps/web/src/components/game/activity/RoundCountdown.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+/**
+ * RoundCountdown — full-screen "3 · 2 · 1 · GO!" overlay during the
+ * pregame phase. Spec: frontend-spec.md §3.4. Driven by the store's
+ * `countdownSecondsRemaining` (server-authoritative; we just animate the
+ * value as it changes).
+ */
+
+import { useEffect, useState } from 'react';
+
+export interface RoundCountdownProps {
+  /** Seconds remaining (server-driven). 0 → render "GO!". */
+  secondsRemaining: number;
+  /** Fires once when secondsRemaining transitions through 0. */
+  onComplete?: () => void;
+}
+
+export default function RoundCountdown({ secondsRemaining, onComplete }: RoundCountdownProps) {
+  const [showGo, setShowGo] = useState(false);
+  const [pulseKey, setPulseKey] = useState(0);
+
+  // Bump pulse key when integer seconds change so CSS animation re-fires.
+  useEffect(() => {
+    setPulseKey((k) => k + 1);
+  }, [secondsRemaining]);
+
+  // GO splash on transition to 0.
+  useEffect(() => {
+    if (secondsRemaining === 0) {
+      setShowGo(true);
+      onComplete?.();
+      const t = setTimeout(() => setShowGo(false), 800);
+      return () => clearTimeout(t);
+    }
+  }, [secondsRemaining, onComplete]);
+
+  if (secondsRemaining > 3 && !showGo) return null;
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        pointerEvents: 'none',
+        zIndex: 30,
+      }}
+    >
+      <div
+        key={pulseKey}
+        style={{
+          fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+          fontSize: showGo ? 120 : 96,
+          fontWeight: 900,
+          color: showGo ? '#00E676' : '#00E5FF',
+          textShadow:
+            '0 0 28px currentColor, 0 0 56px currentColor, 0 4px 24px rgba(0, 0, 0, 0.65)',
+          animation: 'rpg-countdown-pop 0.55s ease-out',
+          letterSpacing: '0.05em',
+        }}
+      >
+        {showGo ? 'GO!' : Math.max(1, secondsRemaining)}
+      </div>
+      <style>{`
+        @keyframes rpg-countdown-pop {
+          0%   { transform: scale(0.4); opacity: 0; }
+          40%  { transform: scale(1.15); opacity: 1; }
+          100% { transform: scale(1.0); opacity: 1; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/web/src/components/game/activity/index.ts
+++ b/apps/web/src/components/game/activity/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Q2 Activity Portals — HUD atom barrel.
+ *
+ * Re-exports the reusable status / score / power-up components used by
+ * `<BumperShellsHud>` (chunk #4) and `<ReefRaceHud>` (chunk #6).
+ */
+export { default as HudTile } from './HudTile';
+export type { HudTileProps, HudTileTone } from './HudTile';
+export { default as HudPlacement } from './HudPlacement';
+export type { HudPlacementProps } from './HudPlacement';
+export { default as HudMiniLeaderboard } from './HudMiniLeaderboard';
+export type { HudMiniLeaderboardProps } from './HudMiniLeaderboard';
+export { default as PowerUpBar } from './PowerUpBar';
+export type { PowerUpBarProps } from './PowerUpBar';
+export {
+  default as PowerUpIcon,
+  rarityForPowerUp,
+} from './PowerUpIcon';
+export type { PowerUpIconProps, PowerUpRarity } from './PowerUpIcon';
+export { default as RoundCountdown } from './RoundCountdown';
+export type { RoundCountdownProps } from './RoundCountdown';
+export { default as EliminatedOverlay } from './EliminatedOverlay';
+export type { EliminatedOverlayProps } from './EliminatedOverlay';
+export { default as PingIndicator } from './PingIndicator';
+export type { PingIndicatorProps } from './PingIndicator';

--- a/apps/web/src/components/game/bumper-shells-hud.tsx
+++ b/apps/web/src/components/game/bumper-shells-hud.tsx
@@ -1,0 +1,429 @@
+'use client';
+
+/**
+ * BumperShellsHud — composes the HUD atoms into the in-match overlay
+ * for Bumper Shells. Spec: frontend-spec.md §3.2 (desktop), §3.3 (mobile),
+ * §3.5 ("Game-specific wrappers").
+ *
+ * The overall containers are pointer-events:none so 3D click-through
+ * works; individual interactive bits set `pointer-events: auto` via
+ * `data-hud-interactive="true"` (see PowerUpBar).
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  useActivityStore,
+  selectLeaderboard,
+  selectSelfAlive,
+  type ActivityState,
+} from '@/stores/activity';
+import {
+  HudTile,
+  HudPlacement,
+  HudMiniLeaderboard,
+  PowerUpBar,
+  RoundCountdown,
+  EliminatedOverlay,
+  PingIndicator,
+} from './activity';
+
+function formatTime(secondsRemaining: number): string {
+  const s = Math.max(0, Math.round(secondsRemaining));
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return `${m}:${r.toString().padStart(2, '0')}`;
+}
+
+function useTickClock(intervalMs = 250) {
+  const [, setT] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setT((x) => x + 1), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+}
+
+export interface BumperShellsHudProps {
+  /** Optional callback to leave the match — page wires to navigate back. */
+  onLeave?: () => void;
+}
+
+export default function BumperShellsHud({ onLeave }: BumperShellsHudProps) {
+  // Re-render every 250ms so the round timer counts down smoothly without
+  // requiring server frames.
+  useTickClock(250);
+
+  const ping = useActivityStore((s) => s.ping);
+  const placement = useActivityStore((s) => s.placement);
+  const total = useActivityStore((s) => s.total);
+  const alive = useActivityStore((s) => s.alive);
+  const matchPhase = useActivityStore((s) => s.matchPhase);
+  const countdownSecondsRemaining = useActivityStore((s) => s.countdownSecondsRemaining);
+  const roundEndsAt = useActivityStore((s) => s.roundEndsAt);
+  const room = useActivityStore((s) => s.room);
+  const errorBanner = useActivityStore((s) => s.errorBanner);
+  const connectionStatus = useActivityStore((s) => s.connectionStatus);
+  const winners = useActivityStore((s) => s.winners);
+  const rewardPreview = useActivityStore((s) => s.rewardPreview);
+  const matchEndReason = useActivityStore((s) => s.matchEndReason);
+  const powerUpInventory = useActivityStore((s) => s.powerUpInventory);
+  const eliminations = useActivityStore((s) => s.events.eliminations);
+  const selfPetId = useActivityStore((s) => s.selfPetId);
+
+  const leaderboard = useActivityStore((s: ActivityState) => selectLeaderboard(s, 5));
+  const selfAlive = useActivityStore(selectSelfAlive);
+
+  // Derive round seconds remaining — server emits `endsAt` in `snapshot.init`.
+  // During pregame we show the countdown; during live we show the timer.
+  const liveSecondsRemaining = roundEndsAt ? Math.max(0, (roundEndsAt - Date.now()) / 1000) : null;
+
+  const eliminatedSelfEvent =
+    selfPetId && !selfAlive
+      ? eliminations.find((e) => e.petId === selfPetId) ?? null
+      : null;
+
+  return (
+    <>
+      {/* Top-left — ping + status pills */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 12,
+          left: 12,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+          pointerEvents: 'none',
+          zIndex: 20,
+        }}
+      >
+        <PingIndicator ms={ping} />
+        {connectionStatus === 'reconnecting' && (
+          <HudTile label="Network" value="Reconnecting…" tone="warning" icon="🔄" />
+        )}
+        {connectionStatus === 'closed' && (
+          <HudTile label="Network" value="Disconnected" tone="danger" icon="⚠" />
+        )}
+      </div>
+
+      {/* Top-center — round timer */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 12,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          pointerEvents: 'none',
+          zIndex: 20,
+        }}
+      >
+        {matchPhase === 'live' && liveSecondsRemaining !== null && (
+          <HudTile
+            label="Round"
+            value={formatTime(liveSecondsRemaining)}
+            tone={liveSecondsRemaining < 15 ? 'danger' : liveSecondsRemaining < 30 ? 'warning' : 'neutral'}
+            icon="⏱"
+          />
+        )}
+        {matchPhase === 'pregame-countdown' && (
+          <HudTile label="Match" value="Starting…" tone="gold" icon="✨" />
+        )}
+        {matchPhase === 'ended' && (
+          <HudTile label="Match" value="Complete" tone="success" icon="🏁" />
+        )}
+      </div>
+
+      {/* Top-right — placement + mini-leaderboard + alive counter */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 12,
+          right: 12,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+          alignItems: 'flex-end',
+          pointerEvents: 'none',
+          zIndex: 20,
+          maxWidth: 280,
+        }}
+      >
+        <HudPlacement rank={placement} total={total} highlight={placement === 1 && matchPhase === 'live'} />
+        <HudTile
+          label="Alive"
+          value={`${alive}/${total}`}
+          tone={alive <= 2 ? 'danger' : alive <= 4 ? 'warning' : 'neutral'}
+          icon="🦞"
+        />
+        <HudMiniLeaderboard entries={leaderboard} selfId={selfPetId} max={5} />
+      </div>
+
+      {/* Bottom-center — power-up bar + control hint */}
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 16,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 8,
+          pointerEvents: 'none',
+          zIndex: 20,
+        }}
+      >
+        <PowerUpBar slots={powerUpInventory} />
+        <div
+          className="claw-panel"
+          style={{
+            padding: '4px 10px',
+            fontSize: 10,
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            letterSpacing: '0.1em',
+            color: 'rgba(226, 232, 240, 0.85)',
+            pointerEvents: 'none',
+          }}
+        >
+          WASD · SPACE boost · Q power-up · ESC leave
+        </div>
+      </div>
+
+      {/* Top-left below network — leave button (pointer-events:auto) */}
+      {onLeave && (
+        <button
+          type="button"
+          data-hud-interactive="true"
+          onClick={onLeave}
+          style={{
+            position: 'absolute',
+            bottom: 16,
+            left: 16,
+            zIndex: 21,
+            padding: '8px 14px',
+            background: 'linear-gradient(180deg, rgba(15, 31, 58, 0.95), rgba(6, 13, 23, 0.95))',
+            border: '1px solid rgba(255, 82, 82, 0.5)',
+            borderRadius: 8,
+            color: '#fca5a5',
+            fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.1em',
+            cursor: 'pointer',
+            pointerEvents: 'auto',
+            boxShadow: '0 0 14px rgba(255, 82, 82, 0.18)',
+          }}
+          aria-label="Leave match and return to ClawVille"
+        >
+          ← LEAVE MATCH
+        </button>
+      )}
+
+      {/* Pregame countdown overlay */}
+      {matchPhase === 'pregame-countdown' && countdownSecondsRemaining > 0 && (
+        <RoundCountdown secondsRemaining={countdownSecondsRemaining} />
+      )}
+
+      {/* Eliminated overlay */}
+      {matchPhase === 'live' && eliminatedSelfEvent && (
+        <EliminatedOverlay
+          eliminatedAt={eliminatedSelfEvent.at}
+          placement={placement}
+        />
+      )}
+
+      {/* Match-ended summary card (chunk #8 will swap for the full RPG modal) */}
+      {matchPhase === 'ended' && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'rgba(0, 0, 0, 0.55)',
+            pointerEvents: 'auto',
+            zIndex: 28,
+          }}
+          data-hud-interactive="true"
+        >
+          <div
+            className="claw-panel"
+            style={{
+              padding: 28,
+              minWidth: 340,
+              maxWidth: 460,
+              textAlign: 'center',
+              borderColor: 'rgba(255, 215, 0, 0.7)',
+              boxShadow: '0 0 36px rgba(255, 215, 0, 0.32)',
+            }}
+          >
+            <div
+              style={{
+                fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+                fontSize: 22,
+                fontWeight: 900,
+                color: '#facc15',
+                letterSpacing: '0.12em',
+                marginBottom: 6,
+              }}
+            >
+              MATCH COMPLETE
+            </div>
+            <div
+              style={{
+                fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                fontSize: 11,
+                color: 'rgba(148, 163, 184, 0.85)',
+                marginBottom: 16,
+                letterSpacing: '0.08em',
+              }}
+            >
+              {matchEndReason === 'forfeit'
+                ? 'By forfeit'
+                : matchEndReason === 'aborted'
+                  ? 'Round aborted'
+                  : 'Last shell standing'}
+            </div>
+
+            {winners.length > 0 && (
+              <div style={{ marginBottom: 16 }}>
+                {winners.slice(0, 3).map((w) => (
+                  <div
+                    key={w.petId}
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      padding: '4px 12px',
+                      fontSize: 13,
+                      fontWeight: w.petId === selfPetId ? 700 : 500,
+                      color: w.petId === selfPetId ? '#86efac' : '#e2e8f0',
+                    }}
+                  >
+                    <span>
+                      {w.placement === 1 ? '🥇' : w.placement === 2 ? '🥈' : '🥉'} #{w.placement}
+                    </span>
+                    <span
+                      style={{
+                        fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                        fontSize: 11,
+                      }}
+                    >
+                      {w.petId.length > 16 ? `…${w.petId.slice(-12)}` : w.petId}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {rewardPreview && (
+              <div
+                style={{
+                  display: 'inline-flex',
+                  flexDirection: 'column',
+                  gap: 4,
+                  alignItems: 'center',
+                  padding: '10px 16px',
+                  background: 'rgba(0, 230, 118, 0.1)',
+                  border: '1px solid rgba(0, 230, 118, 0.4)',
+                  borderRadius: 6,
+                  marginBottom: 16,
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+                    fontSize: 18,
+                    fontWeight: 800,
+                    color: '#facc15',
+                  }}
+                >
+                  +{rewardPreview.tokens} 🪙 ClawTokens
+                </span>
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: 'rgba(226, 232, 240, 0.85)',
+                  }}
+                >
+                  +{rewardPreview.leaderboardPoints} leaderboard pts · placement #{rewardPreview.placement}
+                </span>
+                {rewardPreview.firstPlayOfDayBonus && (
+                  <span style={{ fontSize: 10, color: '#86efac' }}>
+                    +15 first-play-of-day bonus
+                  </span>
+                )}
+                {rewardPreview.focusBonus && (
+                  <span style={{ fontSize: 10, color: '#86efac' }}>+25% focus bonus</span>
+                )}
+              </div>
+            )}
+
+            {onLeave && (
+              <button
+                type="button"
+                onClick={onLeave}
+                style={{
+                  padding: '10px 24px',
+                  background: 'linear-gradient(180deg, #00E5FF 0%, #0288D1 100%)',
+                  border: 'none',
+                  borderRadius: 8,
+                  color: '#0A1628',
+                  fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+                  fontWeight: 800,
+                  letterSpacing: '0.08em',
+                  cursor: 'pointer',
+                  fontSize: 12,
+                  boxShadow: '0 4px 14px rgba(0, 229, 255, 0.4)',
+                }}
+              >
+                BACK TO LOBBY
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Inline error banner */}
+      {errorBanner && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 60,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            background: 'rgba(255, 82, 82, 0.92)',
+            color: '#fff',
+            padding: '8px 16px',
+            borderRadius: 6,
+            fontSize: 12,
+            fontWeight: 700,
+            zIndex: 25,
+            pointerEvents: 'none',
+            boxShadow: '0 4px 16px rgba(255, 82, 82, 0.4)',
+          }}
+        >
+          {errorBanner.message}
+        </div>
+      )}
+
+      {/* Room shortcode (debugging — small bottom-right) */}
+      {room && (
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 16,
+            right: 16,
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            fontSize: 10,
+            color: 'rgba(148, 163, 184, 0.6)',
+            letterSpacing: '0.12em',
+            pointerEvents: 'none',
+            zIndex: 20,
+          }}
+        >
+          ROOM {room.shortCode}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/game/sidebar-menu.tsx
+++ b/apps/web/src/components/game/sidebar-menu.tsx
@@ -527,6 +527,7 @@ function SidebarContent({ closeMenu }: SidebarContentProps) {
   const [helpOpen, setHelpOpen] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
   const [crossingToScape, setCrossingToScape] = useState(false);
+  const [queueingBumper, setQueueingBumper] = useState(false);
 
   const runAction = (fn: () => void) => () => {
     closeMenu();
@@ -536,6 +537,78 @@ function SidebarContent({ closeMenu }: SidebarContentProps) {
   const handleCreateAgent = () => {
     closeMenu();
     router.push('/create-agent');
+  };
+
+  /**
+   * Q2 Activity Portals — chunk #4 dev affordance.
+   *
+   * Quick Queue: Bumper Shells. Hits `/api/activities/bumper-shells/queue`,
+   * polls `/queue-status` every 2s for `matchedRoomId + matchedRoomShortCode`,
+   * navigates to the activity room page on match found. Replaced by the
+   * full portal+lobby UX in chunk #8.
+   */
+  const handleQuickQueueBumperShells = async () => {
+    if (queueingBumper) return;
+    setQueueingBumper(true);
+    closeMenu();
+    let pollTimer: ReturnType<typeof setInterval> | null = null;
+    let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+    const cleanup = () => {
+      if (pollTimer) clearInterval(pollTimer);
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      setQueueingBumper(false);
+    };
+    try {
+      const apiBase = process.env.NEXT_PUBLIC_API_URL || '';
+      const enqueueRes = await fetch(`${apiBase}/api/activities/bumper-shells/queue`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      if (!enqueueRes.ok) {
+        const err = await enqueueRes.json().catch(() => ({}));
+        addToast('⚠️', err?.error ?? `Queue failed (${enqueueRes.status})`, 4500);
+        cleanup();
+        return;
+      }
+      addToast('🎮', 'Queued for Bumper Shells — finding match…', 3000);
+
+      // Poll every 2s up to 90s for a match assignment.
+      const startedAt = Date.now();
+      pollTimer = setInterval(async () => {
+        try {
+          const statusRes = await fetch(
+            `${apiBase}/api/activities/bumper-shells/queue-status`,
+            { credentials: 'include' },
+          );
+          if (!statusRes.ok) return;
+          const data = (await statusRes.json()) as {
+            matchedRoomId?: string | null;
+            matchedRoomShortCode?: string | null;
+          };
+          if (data.matchedRoomId && data.matchedRoomShortCode) {
+            cleanup();
+            addToast('✨', 'Match found — entering arena!', 2500);
+            const url = `/activity/bumper-shells/${data.matchedRoomId}?shortCode=${encodeURIComponent(data.matchedRoomShortCode)}`;
+            router.push(url);
+          } else if (Date.now() - startedAt > 90_000) {
+            cleanup();
+            addToast('⏳', 'No match found — try again later', 4000);
+          }
+        } catch {
+          /* ignore transient poll errors */
+        }
+      }, 2000);
+
+      // Hard timeout safeguard.
+      timeoutTimer = setTimeout(() => {
+        cleanup();
+      }, 100_000);
+    } catch (err) {
+      addToast('⚠️', err instanceof Error ? err.message : 'Queue request failed', 4500);
+      cleanup();
+    }
   };
 
   const handleCrossToScape = async () => {
@@ -621,6 +694,24 @@ function SidebarContent({ closeMenu }: SidebarContentProps) {
               ) : null
             }
           />
+          {/*
+           * Q2 Activity Portals — chunk #4 dev affordance. Replaced by the
+           * full portal+lobby UX in chunk #8. Always visible so QA can
+           * smoke-test prod end-to-end without a feature flag toggle.
+           */}
+          {hasPet && (
+            <SidebarRow
+              icon={queueingBumper ? <SidebarSpinner /> : '🎮'}
+              label={queueingBumper ? 'Finding match…' : 'Quick Queue: Bumper Shells'}
+              onClick={handleQuickQueueBumperShells}
+              disabled={queueingBumper}
+              ariaLabel="Quick Queue: Bumper Shells (dev affordance — chunk #8 ships full portal/lobby UX)"
+              accentOverride={{
+                accent: '#facc15',
+                glow: 'rgba(250, 204, 21, 0.45)',
+              }}
+            />
+          )}
         </div>
 
         {/* AGENT — Priority 1: Milady launch surface */}

--- a/apps/web/src/hooks/useActivityInput.ts
+++ b/apps/web/src/hooks/useActivityInput.ts
@@ -1,0 +1,284 @@
+'use client';
+
+/**
+ * useActivityInput — captures keyboard + mobile-joystick input for the
+ * active Bumper Shells room and sends `{type:'input'}` frames at ~30 Hz.
+ *
+ * Why 30 Hz, not 60: backend §3.4 caps inbound at 60 Hz and the protocol
+ * note says ">60 Hz inputs are dropped with `error: input_rate`". 30 Hz
+ * gives us ~33ms input granularity which is well below the 60 Hz sim tick
+ * — server interpolates between received inputs for the missed ticks.
+ * Starting conservative respects bandwidth budget (8 players × 30 Hz × ~40
+ * bytes = 9.6 KB/s in vs §3.4's 19.2 KB/s ceiling at 60 Hz).
+ *
+ * Wiring:
+ *   - Mounted by `app/activity/[activityId]/[roomId]/page.tsx` after the
+ *     WS connects.
+ *   - `enabled` should be false during pregame countdown, after self
+ *     elimination, after match-end, or while disconnected.
+ *
+ * Action bits (16-bit packed):
+ *   bit 0 — boost (Space)
+ *   bit 1 — power-up use (Q OR click-on-viewport)
+ *   bit 2 — drift (Shift)  // captured for forward-compat; sim chunk #5 may ignore
+ */
+
+import { useEffect, useRef } from 'react';
+import type { ClientFrame } from '@clawville/shared';
+import { useGameStore } from '@/stores/game';
+
+export const ACTION_BIT_BOOST = 1 << 0;
+export const ACTION_BIT_USE_POWERUP = 1 << 1;
+export const ACTION_BIT_DRIFT = 1 << 2;
+
+const SEND_INTERVAL_MS = 1000 / 30;
+
+export interface UseActivityInputOptions {
+  /** WS send fn returned by `useActivityWs`. */
+  send: (frame: ClientFrame) => boolean;
+  /** Master gate — false suppresses ALL input (HUD overlays etc.). */
+  enabled: boolean;
+}
+
+export function useActivityInput({ send, enabled }: UseActivityInputOptions): void {
+  // Per-input mutable state. Stored in refs to avoid React re-renders
+  // and keep the keyboard handlers stable across the session.
+  const dirRef = useRef({ x: 0, y: 0 });
+  const keysRef = useRef<{ w: boolean; a: boolean; s: boolean; d: boolean }>({
+    w: false,
+    a: false,
+    s: false,
+    d: false,
+  });
+  const actionBitsRef = useRef(0);
+  /** Latched bits — fired ONCE on next send tick then cleared. */
+  const oneShotBitsRef = useRef(0);
+  const seqRef = useRef(0);
+  const lastSendAtRef = useRef(0);
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+
+  // Subscribe to mobile joystick velocity from the game store. The mobile
+  // controls layer (`mobile-controls.tsx`) writes nipplejs output to
+  // `joystickVelocity` which we mirror into `dirRef` so a single send loop
+  // can ship desktop OR mobile input without branching.
+  // We use a manual subscribe instead of useGameStore() to avoid a re-render
+  // every time the joystick moves (could be 60 Hz on mobile).
+  useEffect(() => {
+    const unsub = useGameStore.subscribe((s, prev) => {
+      if (
+        s.joystickVelocity.x !== prev.joystickVelocity.x ||
+        s.joystickVelocity.y !== prev.joystickVelocity.y
+      ) {
+        // joystickVelocity uses world-down as +y. We feed the input frame
+        // an unaltered vector — server-side sim normalizes its own axes.
+        dirRef.current = { x: s.joystickVelocity.x, y: s.joystickVelocity.y };
+      }
+    });
+    return unsub;
+  }, []);
+
+  // ── Keyboard handlers ───────────────────────────────────────────────────
+  useEffect(() => {
+    function recomputeDirFromKeys() {
+      const k = keysRef.current;
+      let x = 0;
+      let y = 0;
+      if (k.a) x -= 1;
+      if (k.d) x += 1;
+      if (k.w) y -= 1; // server convention: -y = forward / north
+      if (k.s) y += 1;
+      // Normalize so diagonals aren't √2 faster.
+      const mag = Math.hypot(x, y);
+      if (mag > 0) {
+        x /= mag;
+        y /= mag;
+      }
+      // Only OVERRIDE the joystick when keyboard is actively pressed —
+      // a mobile user using both shouldn't have keys clobber thumb input.
+      if (k.w || k.a || k.s || k.d) {
+        dirRef.current = { x, y };
+      } else if (
+        useGameStore.getState().joystickVelocity.x === 0 &&
+        useGameStore.getState().joystickVelocity.y === 0
+      ) {
+        dirRef.current = { x: 0, y: 0 };
+      }
+    }
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (!enabledRef.current) return;
+      // Don't grab input while the user is typing into a chat box etc.
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+
+      const code = e.code;
+      switch (code) {
+        case 'KeyW':
+        case 'ArrowUp':
+          keysRef.current.w = true;
+          recomputeDirFromKeys();
+          e.preventDefault();
+          break;
+        case 'KeyA':
+        case 'ArrowLeft':
+          keysRef.current.a = true;
+          recomputeDirFromKeys();
+          e.preventDefault();
+          break;
+        case 'KeyS':
+        case 'ArrowDown':
+          keysRef.current.s = true;
+          recomputeDirFromKeys();
+          e.preventDefault();
+          break;
+        case 'KeyD':
+        case 'ArrowRight':
+          keysRef.current.d = true;
+          recomputeDirFromKeys();
+          e.preventDefault();
+          break;
+        case 'Space':
+          actionBitsRef.current |= ACTION_BIT_BOOST;
+          // Capture immediately so even short taps register on the next send.
+          oneShotBitsRef.current |= ACTION_BIT_BOOST;
+          e.preventDefault();
+          break;
+        case 'KeyQ':
+          oneShotBitsRef.current |= ACTION_BIT_USE_POWERUP;
+          e.preventDefault();
+          break;
+        case 'ShiftLeft':
+        case 'ShiftRight':
+          actionBitsRef.current |= ACTION_BIT_DRIFT;
+          break;
+        default:
+          break;
+      }
+    }
+
+    function onKeyUp(e: KeyboardEvent) {
+      // We unset key state regardless of `enabled` — otherwise toggling the
+      // gate mid-keypress can leave a phantom direction.
+      switch (e.code) {
+        case 'KeyW':
+        case 'ArrowUp':
+          keysRef.current.w = false;
+          recomputeDirFromKeys();
+          break;
+        case 'KeyA':
+        case 'ArrowLeft':
+          keysRef.current.a = false;
+          recomputeDirFromKeys();
+          break;
+        case 'KeyS':
+        case 'ArrowDown':
+          keysRef.current.s = false;
+          recomputeDirFromKeys();
+          break;
+        case 'KeyD':
+        case 'ArrowRight':
+          keysRef.current.d = false;
+          recomputeDirFromKeys();
+          break;
+        case 'Space':
+          actionBitsRef.current &= ~ACTION_BIT_BOOST;
+          break;
+        case 'ShiftLeft':
+        case 'ShiftRight':
+          actionBitsRef.current &= ~ACTION_BIT_DRIFT;
+          break;
+        default:
+          break;
+      }
+    }
+
+    /** Power-up alt: left-click anywhere on the viewport → use. */
+    function onPointerDown(e: MouseEvent) {
+      if (!enabledRef.current) return;
+      // Only main button, no modifiers — Shift+click could be a future
+      // re-bind for "aim".
+      if (e.button !== 0) return;
+      // Don't fire when clicking the HUD chrome — those elements set
+      // pointer-events:auto and stop propagation, but a defensive check
+      // keeps unrelated click targets safe.
+      const target = e.target as HTMLElement | null;
+      if (target?.closest('[data-hud-interactive="true"]')) return;
+      oneShotBitsRef.current |= ACTION_BIT_USE_POWERUP;
+    }
+
+    /** Mobile B-button → power-up. Provided as a window event so the
+     *  mobile controls overlay can dispatch it via
+     *  `window.dispatchEvent(new CustomEvent('clawville:activity-action', { detail: { bit: ACTION_BIT_USE_POWERUP } }))`. */
+    function onCustomAction(e: Event) {
+      if (!enabledRef.current) return;
+      const detail = (e as CustomEvent<{ bit?: number }>).detail;
+      if (typeof detail?.bit === 'number') {
+        oneShotBitsRef.current |= detail.bit;
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    window.addEventListener('pointerdown', onPointerDown);
+    window.addEventListener('clawville:activity-action', onCustomAction as EventListener);
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+      window.removeEventListener('pointerdown', onPointerDown);
+      window.removeEventListener(
+        'clawville:activity-action',
+        onCustomAction as EventListener,
+      );
+      // Reset key state on teardown to prevent leak across remounts.
+      keysRef.current = { w: false, a: false, s: false, d: false };
+      actionBitsRef.current = 0;
+      oneShotBitsRef.current = 0;
+      dirRef.current = { x: 0, y: 0 };
+    };
+  }, []);
+
+  // ── 30 Hz send loop ─────────────────────────────────────────────────────
+  useEffect(() => {
+    let timer: ReturnType<typeof setInterval> | null = null;
+    timer = setInterval(() => {
+      if (!enabledRef.current) return;
+      const now = Date.now();
+      const dt = lastSendAtRef.current ? (now - lastSendAtRef.current) / 1000 : 0;
+      lastSendAtRef.current = now;
+
+      // Combine sticky bits (boost held) with one-shot bits (Q/click).
+      const bits = actionBitsRef.current | oneShotBitsRef.current;
+      oneShotBitsRef.current = 0;
+
+      const dir = dirRef.current;
+      const moving = dir.x !== 0 || dir.y !== 0;
+
+      seqRef.current = (seqRef.current + 1) >>> 0;
+
+      const frame: ClientFrame = {
+        type: 'input',
+        seq: seqRef.current,
+        dt,
+        ...(moving ? { dir: { x: dir.x, y: dir.y } } : {}),
+        ...(bits & ACTION_BIT_BOOST ? { thrust: 1 } : {}),
+        ...(bits ? { actionBits: bits } : {}),
+      };
+
+      send(frame);
+    }, SEND_INTERVAL_MS);
+
+    return () => {
+      if (timer) clearInterval(timer);
+      lastSendAtRef.current = 0;
+    };
+  }, [send]);
+}

--- a/apps/web/src/hooks/useActivityWs.ts
+++ b/apps/web/src/hooks/useActivityWs.ts
@@ -1,0 +1,292 @@
+'use client';
+
+/**
+ * useActivityWs — single WebSocket lifecycle hook for the Q2 activity room.
+ *
+ * Owns:
+ *  - Connecting to `wss://api.clawville.world/api/activities/:id/rooms/:roomId/ws`
+ *    (derives base from `NEXT_PUBLIC_API_URL`; protocol swapped http(s) → ws(s)).
+ *  - Sending the auth frame on `open` (Lucia cookie attaches automatically;
+ *    we still pass `sessionToken` per protocol — empty string when relying
+ *    on the cookie, agent sessionId when running headless).
+ *  - Routing inbound frames into `useActivityStore.applyServerFrame()`.
+ *  - Ping/pong roundtrip → `setPing(ms)`.
+ *  - Reconnect with backoff on unexpected close (10s grace per backend §3.6).
+ *
+ * Wire format: plain JSON (text frames). The hub on the API side
+ * (`apps/api/src/services/activity/activity-ws-hub.ts`) calls JSON.parse
+ * on inbound frames and JSON.stringify on outbound — confirmed against
+ * source. MessagePack-binary is reserved for a later optimization pass and
+ * is gated by `@msgpack/msgpack` dep landing (not in web's package.json
+ * today; not adding to keep chunk #4 free of new runtime deps per plan
+ * §"Out of scope … new runtime deps that aren't already in dependencies").
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { ClientFrame, ServerFrame } from '@clawville/shared';
+import { useActivityStore, type ConnectionStatus } from '@/stores/activity';
+
+// ─── Tuning constants ───────────────────────────────────────────────────────
+
+/** Heartbeat cadence per backend §3.4 — 1 Hz. */
+const PING_INTERVAL_MS = 1000;
+
+/**
+ * Backend §3.6: "10s reconnect grace with existing sessionId". We retry
+ * every 1.5s up to 10s total before the user sees `closed`.
+ */
+const RECONNECT_GRACE_MS = 10_000;
+const RECONNECT_DELAY_MS = 1500;
+
+// ─── Hook signature ─────────────────────────────────────────────────────────
+
+export interface UseActivityWsOptions {
+  /** Activity definition id (e.g. 'bumper-shells'). */
+  activityId: string;
+  /** Room UUID assigned by matchmaker. */
+  roomId: string;
+  /** Public room short code (`Q7X3RT`); required for the auth frame. */
+  shortCode: string;
+  /**
+   * Lucia session token mirror — pass empty string when the browser cookie
+   * is sufficient (server resolves Lucia OR `X-Clawville-Agent-Session`).
+   * Agents pass their `agentSessionId`. The auth frame requires a non-empty
+   * string, so we send `'cookie'` placeholder when the caller passes ''
+   * (server's `requireAuthOrAgentSession` middleware re-resolves via cookie).
+   */
+  sessionToken?: string;
+  /** Set to false to skip opening (e.g. waiting on petId / shortCode). */
+  enabled?: boolean;
+}
+
+export interface UseActivityWsResult {
+  send: (frame: ClientFrame) => boolean;
+  ping: number;
+  status: ConnectionStatus;
+}
+
+// ─── Implementation ─────────────────────────────────────────────────────────
+
+export function useActivityWs(opts: UseActivityWsOptions): UseActivityWsResult {
+  const {
+    activityId,
+    roomId,
+    shortCode,
+    sessionToken = '',
+    enabled = true,
+  } = opts;
+
+  // Per-tick ping state surfaced to consumers.
+  const [ping, setPingLocal] = useState(0);
+  const [status, setStatus] = useState<ConnectionStatus>('idle');
+
+  // Long-lived refs so React closures don't capture stale wsRef.
+  const wsRef = useRef<WebSocket | null>(null);
+  const pingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Wall-clock when the last close fired — gates reconnect grace window. */
+  const lastCloseAtRef = useRef<number>(0);
+  /** True after the consumer-initiated unmount/close so we don't reconnect. */
+  const intentionallyClosedRef = useRef(false);
+  /** Track sentAt of the most-recent ping so pong can compute RTT. */
+  const lastPingSentAtRef = useRef(0);
+
+  // Derive WS URL from NEXT_PUBLIC_API_URL — same env var the rest of the
+  // client uses (api.ts: HONO_API_URL fallback to localhost:4000 for dev).
+  const wsUrl = useMemo(() => {
+    if (!enabled || !roomId || !activityId) return null;
+    const base = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+    const wsBase = base
+      .replace(/^http:\/\//i, 'ws://')
+      .replace(/^https:\/\//i, 'wss://');
+    return `${wsBase}/api/activities/${encodeURIComponent(activityId)}/rooms/${encodeURIComponent(roomId)}/ws`;
+  }, [activityId, roomId, enabled]);
+
+  // ── send wrapper (stable identity via useRef) ────────────────────────────
+  const sendRef = useRef<(frame: ClientFrame) => boolean>(() => false);
+  sendRef.current = (frame: ClientFrame): boolean => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+    try {
+      ws.send(JSON.stringify(frame));
+      return true;
+    } catch (err) {
+      // Buffer full / connection died mid-send — surface as a soft failure.
+      console.warn('[useActivityWs] send failed:', err);
+      return false;
+    }
+  };
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!wsUrl) return;
+
+    intentionallyClosedRef.current = false;
+    const setStoreStatus = useActivityStore.getState().setConnectionStatus;
+    const setStorePing = useActivityStore.getState().setPing;
+    const applyFrame = useActivityStore.getState().applyServerFrame;
+
+    function clearTimers() {
+      if (pingIntervalRef.current) {
+        clearInterval(pingIntervalRef.current);
+        pingIntervalRef.current = null;
+      }
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+    }
+
+    function open() {
+      if (!wsUrl) return;
+      setStatus('connecting');
+      setStoreStatus('connecting');
+
+      let ws: WebSocket;
+      try {
+        ws = new WebSocket(wsUrl);
+      } catch (err) {
+        console.error('[useActivityWs] construction threw', err);
+        scheduleReconnect();
+        return;
+      }
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        setStatus('connected');
+        setStoreStatus('connected');
+
+        // First frame MUST be auth per backend §3.2.
+        // The Lucia cookie is sent automatically with the WS upgrade because
+        // the API hostname matches the cookie domain. We still ship a
+        // sessionToken string because the protocol's Zod schema requires
+        // `sessionToken: z.string().min(1)` — when the server resolves the
+        // identity via cookie this value is ignored. For agent sessions,
+        // pass the agent's sessionId via `sessionToken` prop.
+        const authToken = sessionToken && sessionToken.length > 0 ? sessionToken : 'cookie';
+        sendRef.current({ type: 'auth', sessionToken: authToken, shortCode });
+
+        // Start 1 Hz ping loop.
+        pingIntervalRef.current = setInterval(() => {
+          const sentAt = Date.now();
+          lastPingSentAtRef.current = sentAt;
+          sendRef.current({ type: 'ping', sentAt });
+        }, PING_INTERVAL_MS);
+      };
+
+      ws.onmessage = (evt) => {
+        let frame: ServerFrame;
+        try {
+          // Server emits JSON text frames (confirmed against
+          // `apps/api/src/services/activity/activity-ws-hub.ts:507` —
+          // `ws.send(JSON.stringify(frame))`).
+          frame = JSON.parse(evt.data as string) as ServerFrame;
+        } catch (err) {
+          console.warn('[useActivityWs] non-JSON frame received', err);
+          return;
+        }
+
+        // Compute ping RTT for pong frames before delegating to the store.
+        if (frame.type === 'pong') {
+          const sentAt = frame.sentAt ?? lastPingSentAtRef.current;
+          if (sentAt) {
+            const rtt = Math.max(0, Date.now() - sentAt);
+            setPingLocal(rtt);
+            setStorePing(rtt);
+          }
+        }
+
+        try {
+          applyFrame(frame);
+        } catch (err) {
+          // Defensive — store mutations should never throw, but if they do
+          // we don't want one bad frame to kill the socket.
+          console.error('[useActivityWs] applyServerFrame threw', err);
+        }
+      };
+
+      ws.onerror = (evt) => {
+        console.warn('[useActivityWs] socket error', evt);
+        // onclose will fire after; no state mutation here.
+      };
+
+      ws.onclose = (evt) => {
+        if (pingIntervalRef.current) {
+          clearInterval(pingIntervalRef.current);
+          pingIntervalRef.current = null;
+        }
+        wsRef.current = null;
+        lastCloseAtRef.current = Date.now();
+
+        if (intentionallyClosedRef.current) {
+          setStatus('closed');
+          setStoreStatus('closed');
+          return;
+        }
+
+        // 4xxx fatal codes — don't retry blindly. UNAUTHORIZED is the most
+        // common (cookie expired); INTEGRITY/CONCURRENCY_CAP are server
+        // policies the user can't recover from. Surface as `closed`.
+        // 4001=UNAUTHORIZED, 4002=SLOW_READ (transient OK), 4003=INTEGRITY,
+        // 4004=CONCURRENCY_CAP.
+        if (evt.code === 4001 || evt.code === 4003 || evt.code === 4004) {
+          console.warn(`[useActivityWs] fatal close code ${evt.code} — not reconnecting`);
+          setStatus('closed');
+          setStoreStatus('closed');
+          return;
+        }
+
+        scheduleReconnect();
+      };
+    }
+
+    function scheduleReconnect() {
+      if (intentionallyClosedRef.current) return;
+      const elapsed = lastCloseAtRef.current ? Date.now() - lastCloseAtRef.current : 0;
+      if (elapsed > RECONNECT_GRACE_MS) {
+        // Grace exhausted — give up.
+        setStatus('closed');
+        setStoreStatus('closed');
+        return;
+      }
+      setStatus('reconnecting');
+      setStoreStatus('reconnecting');
+      reconnectTimerRef.current = setTimeout(() => {
+        if (intentionallyClosedRef.current) return;
+        open();
+      }, RECONNECT_DELAY_MS);
+    }
+
+    open();
+
+    return () => {
+      intentionallyClosedRef.current = true;
+      clearTimers();
+      const ws = wsRef.current;
+      if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+        try {
+          // Best-effort graceful leave per protocol §"Client → Server: leave".
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ type: 'leave' }));
+          }
+        } catch {
+          /* ignore */
+        }
+        try {
+          ws.close(1000, 'unmount');
+        } catch {
+          /* ignore */
+        }
+      }
+      wsRef.current = null;
+      // Don't push `closed` into the store on unmount — the next page mount
+      // resets it via `useActivityStore.getState().reset(roomId)`.
+    };
+  }, [wsUrl, shortCode, sessionToken]);
+
+  return {
+    send: sendRef.current,
+    ping,
+    status,
+  };
+}

--- a/apps/web/src/lib/three/activities/bumper-shells/BumperShellsArena.tsx
+++ b/apps/web/src/lib/three/activities/bumper-shells/BumperShellsArena.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+/**
+ * BumperShellsArena.tsx
+ *
+ * Static arena geometry: platform disc, rim glow torus, danger ring, void backdrop.
+ * All meshes are static — matrixAutoUpdate=false after mount.
+ *
+ * Draw calls: 4 (platform, rim, danger ring, void backdrop).
+ * Iris Xe invariants:
+ *   - MeshBasicNodeMaterial for the rim glow (no lighting = no ShaderMaterial needed).
+ *   - MeshStandardMaterial for platform and danger ring (no ShaderMaterial).
+ *   - Void backdrop at y=-2000 — MeshBasicNodeMaterial ignores fog, so we place it
+ *     far enough that the edge is never visible (fog kills everything past 900wu).
+ *   - matrixAutoUpdate=false on every mesh — these never move.
+ */
+
+import { useRef, useEffect, useMemo } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three/webgpu';
+import {
+  ARENA_RADIUS,
+  ARENA_HEIGHT,
+  ARENA_RADIAL_SEGMENTS,
+  RIM_TUBE_RADIUS,
+  RIM_RADIAL_SEGMENTS,
+  RIM_TUBULAR_SEGMENTS,
+  DANGER_RING_INNER,
+  VOID_BACKDROP_Y,
+  VOID_BACKDROP_SIZE,
+} from './bumper-shells-config';
+
+// ─── Module-scope scratch ────────────────────────────────────────────────────
+// No allocations inside useFrame.
+let _elapsedTime = 0;
+
+// ─── Geometry / material singletons ─────────────────────────────────────────
+// Created once at module load, shared across HMR cycles, disposed on unmount.
+const platformGeo = new THREE.CylinderGeometry(
+  ARENA_RADIUS,
+  ARENA_RADIUS,
+  ARENA_HEIGHT,
+  ARENA_RADIAL_SEGMENTS,
+  1,
+);
+
+const rimGeo = new THREE.TorusGeometry(
+  ARENA_RADIUS,
+  RIM_TUBE_RADIUS,
+  RIM_RADIAL_SEGMENTS,
+  RIM_TUBULAR_SEGMENTS,
+);
+
+// Danger ring: outer radius = ARENA_RADIUS, inner = DANGER_RING_INNER.
+// Built as a thin CylinderGeometry ring (open at top/bottom).
+const dangerGeo = new THREE.CylinderGeometry(
+  ARENA_RADIUS,
+  ARENA_RADIUS,
+  4, // thin disc
+  ARENA_RADIAL_SEGMENTS,
+  1,
+  false, // openEnded=false so it renders as a ring cap
+);
+
+const voidGeo = new THREE.PlaneGeometry(VOID_BACKDROP_SIZE, VOID_BACKDROP_SIZE);
+
+const platformMat = new THREE.MeshStandardMaterial({
+  color: new THREE.Color('#1a2a3a'),
+  roughness: 0.85,
+  metalness: 0.0,
+});
+
+const dangerMat = new THREE.MeshStandardMaterial({
+  color: new THREE.Color('#cc2200'),
+  roughness: 0.7,
+  metalness: 0.0,
+  transparent: true,
+  opacity: 0.75,
+});
+
+// MeshBasicNodeMaterial for the rim glow — safe on WebGPU, no fog dependency.
+// Pulse via JS opacity mutation each frame (simpler than TSL opacityNode for now).
+const rimMat = new THREE.MeshBasicNodeMaterial
+  ? new (THREE as any).MeshBasicNodeMaterial({
+      color: new THREE.Color(0x00ccff),
+      transparent: true,
+      depthWrite: false,
+    })
+  : new THREE.MeshBasicMaterial({
+      color: new THREE.Color(0x00ccff),
+      transparent: true,
+      depthWrite: false,
+    });
+
+const voidMat = new THREE.MeshBasicMaterial
+  ? (THREE as any).MeshBasicNodeMaterial
+    ? new (THREE as any).MeshBasicNodeMaterial({
+        color: new THREE.Color('#020810'),
+        transparent: true,
+        opacity: 1,
+        depthWrite: false,
+      })
+    : new THREE.MeshBasicMaterial({
+        color: new THREE.Color('#020810'),
+        side: THREE.DoubleSide,
+      })
+  : new THREE.MeshBasicMaterial({
+      color: new THREE.Color('#020810'),
+      side: THREE.DoubleSide,
+    });
+
+export default function BumperShellsArena() {
+  const platformRef = useRef<THREE.Mesh>(null);
+  const rimRef = useRef<THREE.Mesh>(null);
+  const dangerRef = useRef<THREE.Mesh>(null);
+  const voidRef = useRef<THREE.Mesh>(null);
+
+  // Freeze matrices after mount — these never move.
+  useEffect(() => {
+    for (const ref of [platformRef, rimRef, dangerRef, voidRef]) {
+      const m = ref.current;
+      if (!m) continue;
+      m.matrixAutoUpdate = false;
+      m.updateMatrix();
+    }
+  }, []);
+
+  // Rim glow pulse — GPU-driven: sin(t*2)*0.3+0.7.
+  // No new allocations — just write opacity.
+  useFrame((_, delta) => {
+    _elapsedTime += delta;
+    const rim = rimRef.current;
+    if (rim) {
+      (rim.material as THREE.Material & { opacity: number }).opacity =
+        Math.sin(_elapsedTime * 2) * 0.3 + 0.7;
+    }
+  });
+
+  return (
+    <group>
+      {/* Platform disc — flat at y=0 */}
+      <mesh
+        ref={platformRef}
+        geometry={platformGeo}
+        material={platformMat}
+        position={[0, 0, 0]}
+        receiveShadow
+        castShadow={false}
+        frustumCulled={false}
+      />
+
+      {/* Rim glow torus — top surface of disc */}
+      <mesh
+        ref={rimRef}
+        geometry={rimGeo}
+        material={rimMat}
+        position={[0, ARENA_HEIGHT / 2, 0]}
+        rotation={[Math.PI / 2, 0, 0]}
+        frustumCulled={false}
+      />
+
+      {/* Danger zone ring — outer 15% of disc, slightly above platform */}
+      <mesh
+        ref={dangerRef}
+        geometry={dangerGeo}
+        material={dangerMat}
+        position={[0, ARENA_HEIGHT / 2 + 1, 0]}
+        frustumCulled={false}
+      />
+
+      {/* Void backdrop — deep below arena, fills the view past the edge */}
+      <mesh
+        ref={voidRef}
+        geometry={voidGeo}
+        material={voidMat}
+        position={[0, VOID_BACKDROP_Y, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        frustumCulled={false}
+      />
+    </group>
+  );
+}

--- a/apps/web/src/lib/three/activities/bumper-shells/BumperShellsHazard.tsx
+++ b/apps/web/src/lib/three/activities/bumper-shells/BumperShellsHazard.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+/**
+ * BumperShellsHazard.tsx
+ *
+ * Central spinning spiked-ball hazard: sphere body + 8 instanced cone spikes.
+ *
+ * Draw calls: 2 (sphere + InstancedMesh of 8 cones).
+ * Iris Xe invariants:
+ *   - InstancedMesh + MeshStandardMaterial — SAFE (only ShaderMaterial crashes WebGPU).
+ *   - matrixAutoUpdate=false on sphere (InstancedMesh doesn't support it per-instance —
+ *     matrices are managed via setMatrixAt).
+ *   - Spikes positioned once in useEffect, never re-computed per frame.
+ *   - Spin via group.rotation.y mutation in useFrame — 1 write per frame, no allocations.
+ */
+
+import { useRef, useEffect, useMemo } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three/webgpu';
+import {
+  HAZARD_SPHERE_RADIUS,
+  HAZARD_SPIKE_COUNT,
+  HAZARD_SPIN_SPEED,
+} from './bumper-shells-config';
+
+// ─── Module-scope scratch ─────────────────────────────────────────────────────
+const _spikeMatrix = new THREE.Matrix4();
+const _spikeQuat   = new THREE.Quaternion();
+const _spikePos    = new THREE.Vector3();
+const _spikeScale  = new THREE.Vector3(1, 1, 1);
+const _up          = new THREE.Vector3(0, 1, 0);
+
+// ─── Geometry / material singletons ──────────────────────────────────────────
+const sphereGeo = new THREE.SphereGeometry(HAZARD_SPHERE_RADIUS, 16, 16);
+
+// Cone spikes: length = 0.6 * sphere radius, radius = 0.15 * sphere radius.
+const spikeLength = HAZARD_SPHERE_RADIUS * 0.6;
+const spikeRadius = HAZARD_SPHERE_RADIUS * 0.15;
+const spikeGeo = new THREE.ConeGeometry(spikeRadius, spikeLength, 6, 1);
+
+const hazardMat = new THREE.MeshStandardMaterial({
+  color: new THREE.Color('#2a2a3a'),
+  roughness: 0.4,
+  metalness: 0.7,
+});
+
+const spikeMat = new THREE.MeshStandardMaterial({
+  color: new THREE.Color('#cc3300'),
+  roughness: 0.3,
+  metalness: 0.8,
+});
+
+interface BumperShellsHazardProps {
+  enabled?: boolean;
+}
+
+export default function BumperShellsHazard({ enabled = true }: BumperShellsHazardProps) {
+  const groupRef  = useRef<THREE.Group>(null);
+  const sphereRef = useRef<THREE.Mesh>(null);
+  const spikesRef = useRef<THREE.InstancedMesh>(null);
+
+  // Place spikes around the sphere in a ring on the equatorial plane (8 spikes, evenly spaced).
+  useEffect(() => {
+    const im = spikesRef.current;
+    if (!im) return;
+
+    for (let i = 0; i < HAZARD_SPIKE_COUNT; i++) {
+      const angle = (i / HAZARD_SPIKE_COUNT) * Math.PI * 2;
+
+      // Position on sphere surface — spikes point outward from equator.
+      const px = Math.cos(angle) * HAZARD_SPHERE_RADIUS;
+      const pz = Math.sin(angle) * HAZARD_SPHERE_RADIUS;
+      _spikePos.set(px, 0, pz);
+
+      // Cone default up-axis is Y. Rotate it to point along the radial direction.
+      const radialDir = new THREE.Vector3(Math.cos(angle), 0, Math.sin(angle));
+      _spikeQuat.setFromUnitVectors(_up, radialDir);
+
+      // Offset position so spike base sits at the sphere surface.
+      const spikeOffset = _spikePos.clone().normalize().multiplyScalar(spikeLength / 2);
+      _spikePos.add(spikeOffset);
+
+      _spikeMatrix.compose(_spikePos, _spikeQuat, _spikeScale);
+      im.setMatrixAt(i, _spikeMatrix);
+    }
+    im.instanceMatrix.needsUpdate = true;
+
+    // Freeze sphere matrix — it never translates (only the group rotates).
+    const sphere = sphereRef.current;
+    if (sphere) {
+      sphere.matrixAutoUpdate = false;
+      sphere.updateMatrix();
+    }
+  }, []);
+
+  useFrame((_, delta) => {
+    const g = groupRef.current;
+    if (!g || !enabled) return;
+    g.rotation.y += HAZARD_SPIN_SPEED * delta;
+  });
+
+  if (!enabled) return null;
+
+  return (
+    <group ref={groupRef} position={[0, HAZARD_SPHERE_RADIUS, 0]}>
+      {/* Sphere body */}
+      <mesh
+        ref={sphereRef}
+        geometry={sphereGeo}
+        material={hazardMat}
+        castShadow
+        frustumCulled={false}
+      />
+
+      {/* 8 spike cones — InstancedMesh + MeshStandardMaterial = safe on WebGPU */}
+      <instancedMesh
+        ref={spikesRef}
+        args={[spikeGeo, spikeMat, HAZARD_SPIKE_COUNT]}
+        castShadow
+        frustumCulled={false}
+      />
+    </group>
+  );
+}

--- a/apps/web/src/lib/three/activities/bumper-shells/BumperShellsParticles.tsx
+++ b/apps/web/src/lib/three/activities/bumper-shells/BumperShellsParticles.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+/**
+ * BumperShellsParticles.tsx
+ *
+ * Module-scope burst particle pool for knockback hit VFX.
+ * Pool: BURST_POOL_SIZE (4) simultaneous bursts × BURST_POINT_COUNT (16) points each.
+ *
+ * Iris Xe invariants:
+ *   - PointsNodeMaterial (TSL) — safe on WebGPU. Falls back gracefully.
+ *   - 16 points per burst max — Iris Xe fragment throughput constraint.
+ *   - Float32BufferAttribute mutated in-place — no new attribute per frame.
+ *   - Pool slots are mounted at scene init as visible=false — no dynamic mesh creation.
+ *   - No new THREE.Vector3() inside useFrame — module-scope scratch only.
+ *
+ * Public API:
+ *   - `triggerBurst(x, y, z, color)` — imperative, called from BumperShellsScene.
+ *   - `<BumperShellsParticles />` — JSX component, mount once at scene root.
+ */
+
+import { useRef, useEffect } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three/webgpu';
+import {
+  BURST_POOL_SIZE,
+  BURST_POINT_COUNT,
+  BURST_RADIUS,
+  BURST_LIFETIME_MS,
+  BURST_POINT_SIZE,
+} from './bumper-shells-config';
+
+// ─── Module-scope pool state ──────────────────────────────────────────────────
+// These live at module scope so `triggerBurst` can be called from outside React.
+
+interface BurstSlot {
+  active: boolean;
+  startedAt: number;
+  colorHex: string;
+}
+
+const _pool: BurstSlot[] = Array.from({ length: BURST_POOL_SIZE }, () => ({
+  active: false,
+  startedAt: 0,
+  colorHex: '#ffffff',
+}));
+
+// Pre-computed random XZ directions for each slot×point.
+// Computed once at module load — no per-frame random calls.
+const _directions: Float32Array[] = Array.from({ length: BURST_POOL_SIZE }, () => {
+  const d = new Float32Array(BURST_POINT_COUNT * 3);
+  for (let i = 0; i < BURST_POINT_COUNT; i++) {
+    const angle = (i / BURST_POINT_COUNT) * Math.PI * 2 + Math.random() * 0.5;
+    d[i * 3 + 0] = Math.cos(angle);
+    d[i * 3 + 1] = (Math.random() - 0.5) * 0.6; // slight Y scatter
+    d[i * 3 + 2] = Math.sin(angle);
+  }
+  return d;
+});
+
+// Origin positions per slot — set on triggerBurst, read in useFrame.
+const _origins: Array<[number, number, number]> = Array.from(
+  { length: BURST_POOL_SIZE },
+  () => [0, 0, 0],
+);
+
+// ─── Public imperative API ────────────────────────────────────────────────────
+
+/**
+ * Trigger a radial particle burst at the given Three.js world-space position.
+ * Safe to call from outside React (e.g. from BumperShellsScene's useFrame hit handler).
+ *
+ * @param x Three.js world X
+ * @param y Three.js world Y (usually disc top = 6)
+ * @param z Three.js world Z
+ * @param color CSS hex color string, e.g. '#ff6600'
+ */
+export function triggerBurst(x: number, y: number, z: number, color = '#ffffff'): void {
+  // Find an inactive slot. If all active, steal the oldest.
+  let slot = _pool.findIndex((s) => !s.active);
+  if (slot === -1) {
+    // Steal oldest active.
+    let oldest = 0;
+    let oldestTime = Infinity;
+    for (let i = 0; i < BURST_POOL_SIZE; i++) {
+      if (_pool[i].startedAt < oldestTime) {
+        oldest = i;
+        oldestTime = _pool[i].startedAt;
+      }
+    }
+    slot = oldest;
+  }
+
+  _pool[slot].active = true;
+  _pool[slot].startedAt = performance.now();
+  _pool[slot].colorHex = color;
+  _origins[slot][0] = x;
+  _origins[slot][1] = y;
+  _origins[slot][2] = z;
+}
+
+// ─── Internal per-slot component ─────────────────────────────────────────────
+
+// Geometry and positions are shared — each slot has its own BufferGeometry
+// with its own Float32BufferAttribute so updates don't interfere.
+
+function BurstPoints({ slotIndex }: { slotIndex: number }) {
+  const pointsRef = useRef<THREE.Points>(null);
+
+  // Pre-allocate the positions buffer for this slot (BURST_POINT_COUNT * 3 floats).
+  const posBuffer = useRef(new Float32Array(BURST_POINT_COUNT * 3));
+
+  const geometry = useRef<THREE.BufferGeometry>(null!);
+  const material = useRef<THREE.PointsMaterial>(null!);
+
+  useEffect(() => {
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute(
+      'position',
+      new THREE.BufferAttribute(posBuffer.current, 3),
+    );
+    geometry.current = geo;
+
+    // PointsMaterial as fallback — PointsNodeMaterial would need TSL setup.
+    // Using standard PointsMaterial: transparent + additive = acceptable on Iris Xe.
+    const mat = new THREE.PointsMaterial({
+      size: BURST_POINT_SIZE,
+      sizeAttenuation: true,
+      transparent: true,
+      opacity: 0,
+      color: new THREE.Color('#ffffff'),
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    });
+    material.current = mat;
+
+    const pts = pointsRef.current;
+    if (pts) {
+      pts.geometry = geo;
+      pts.material = mat;
+    }
+
+    return () => {
+      geo.dispose();
+      mat.dispose();
+    };
+  }, []);
+
+  useFrame(() => {
+    const slot = _pool[slotIndex];
+    const pts  = pointsRef.current;
+    if (!pts) return;
+
+    if (!slot.active) {
+      if (pts.visible) pts.visible = false;
+      return;
+    }
+
+    const now     = performance.now();
+    const elapsed = now - slot.startedAt;
+    const t       = Math.min(elapsed / BURST_LIFETIME_MS, 1);
+
+    if (t >= 1) {
+      slot.active  = false;
+      pts.visible  = false;
+      (material.current as THREE.PointsMaterial).opacity = 0;
+      return;
+    }
+
+    pts.visible = true;
+
+    // Update opacity on material.
+    (material.current as THREE.PointsMaterial).opacity = 1 - t;
+    (material.current as THREE.PointsMaterial).color.set(_pool[slotIndex].colorHex);
+    (material.current as THREE.PointsMaterial).needsUpdate = true;
+
+    // Update point positions in-place.
+    const dirs   = _directions[slotIndex];
+    const origin = _origins[slotIndex];
+    const pos    = posBuffer.current;
+    const spread = BURST_RADIUS * t; // expand outward over lifetime
+
+    for (let i = 0; i < BURST_POINT_COUNT; i++) {
+      pos[i * 3 + 0] = origin[0] + dirs[i * 3 + 0] * spread;
+      pos[i * 3 + 1] = origin[1] + dirs[i * 3 + 1] * spread * 0.5;
+      pos[i * 3 + 2] = origin[2] + dirs[i * 3 + 2] * spread;
+    }
+
+    if (geometry.current) {
+      (geometry.current.attributes.position as THREE.BufferAttribute).needsUpdate = true;
+    }
+  });
+
+  return <points ref={pointsRef} frustumCulled={false} />;
+}
+
+// ─── Main exported component ──────────────────────────────────────────────────
+
+/**
+ * Mount once inside BumperShellsScene. Contains all BURST_POOL_SIZE burst slots.
+ */
+export default function BumperShellsParticles() {
+  return (
+    <group>
+      {Array.from({ length: BURST_POOL_SIZE }, (_, i) => (
+        <BurstPoints key={i} slotIndex={i} />
+      ))}
+    </group>
+  );
+}

--- a/apps/web/src/lib/three/activities/bumper-shells/BumperShellsPickups.tsx
+++ b/apps/web/src/lib/three/activities/bumper-shells/BumperShellsPickups.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+/**
+ * BumperShellsPickups.tsx
+ *
+ * 6 pre-allocated pickup slots: TorusKnotGeometry prop + drei <Html> emoji label.
+ *
+ * All 6 meshes are mounted at scene init, toggled via visible=true/false on spawn/despawn.
+ * No mesh creation during gameplay — avoids GC pressure and pipeline recompilation on Iris Xe.
+ *
+ * Iris Xe invariants:
+ *   - NO drei <Text> — hard GPU crash. Emoji labels use drei <Html> (DOM overlay).
+ *   - NO distanceFactor on <Html> — per-frame camera-distance recompute (perf-sweep 2026-04-21).
+ *   - Label visibility toggled via labelRef.current.style.display imperatively in useFrame,
+ *     NOT via React state or group.visible (drei <Html> ignores parent visible).
+ *   - matrixAutoUpdate=false on all 6 pickup meshes after initial position set.
+ *   - Per-frame position.y mutation via ref (no new Vector3 allocations).
+ *
+ * Draw calls: up to 6 (one TorusKnotGeometry per active pickup).
+ */
+
+import { useRef, useEffect, useMemo, Suspense } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
+import * as THREE from 'three/webgpu';
+import type { BumperPickup } from './bumper-shells-types';
+import {
+  MAX_PICKUPS,
+  PICKUP_TORUS_RADIUS,
+  PICKUP_TUBE_RADIUS,
+  PICKUP_TUBULAR_SEGMENTS,
+  PICKUP_RADIAL_SEGMENTS,
+  PICKUP_BOB_AMP,
+  PICKUP_BOB_FREQ,
+  PICKUP_SPIN_SPEED,
+  PICKUP_BASE_Y,
+  PICKUP_EMISSIVE,
+  PICKUP_EMOJI,
+} from './bumper-shells-config';
+
+// ─── Module-scope scratch + time accumulator ─────────────────────────────────
+// One shared time counter for all pickups — no per-pickup time state.
+let _pickupTime = 0;
+
+// ─── Geometry singleton — shared across all pickup slots ──────────────────────
+const pickupGeo = new THREE.TorusKnotGeometry(
+  PICKUP_TORUS_RADIUS,
+  PICKUP_TUBE_RADIUS,
+  PICKUP_TUBULAR_SEGMENTS,
+  PICKUP_RADIAL_SEGMENTS,
+);
+
+// ─── Pickup material pool ─────────────────────────────────────────────────────
+// One material per pickup kind, created lazily. Never ShaderMaterial.
+const materialCache: Record<string, THREE.MeshStandardMaterial> = {};
+
+function getPickupMat(kind: string): THREE.MeshStandardMaterial {
+  if (materialCache[kind]) return materialCache[kind];
+  const emissiveHex = PICKUP_EMISSIVE[kind] ?? '#ffffff';
+  const mat = new THREE.MeshStandardMaterial({
+    color: new THREE.Color('#1a1a2e'),
+    emissive: new THREE.Color(emissiveHex),
+    emissiveIntensity: 0.9,
+    roughness: 0.3,
+    metalness: 0.6,
+  });
+  materialCache[kind] = mat;
+  return mat;
+}
+
+// ─── Single pickup slot ───────────────────────────────────────────────────────
+
+interface PickupSlotProps {
+  slotIndex: number;
+  pickup: BumperPickup | null;
+}
+
+function PickupSlot({ slotIndex, pickup }: PickupSlotProps) {
+  const meshRef  = useRef<THREE.Mesh>(null);
+  const labelRef = useRef<HTMLDivElement>(null);
+
+  // Pre-resolve material — changes when kind changes (rare).
+  const mat = useMemo(
+    () => getPickupMat(pickup?.kind ?? 'speed'),
+    [pickup?.kind],
+  );
+
+  // Update mesh matrix when pickup position changes.
+  useEffect(() => {
+    const m = meshRef.current;
+    if (!m) return;
+    if (!pickup) {
+      m.visible = false;
+      // Hide label imperatively — drei <Html> ignores parent visible.
+      if (labelRef.current) labelRef.current.style.display = 'none';
+      return;
+    }
+    m.position.set(pickup.x, PICKUP_BASE_Y, pickup.y);
+    m.visible = true;
+    m.matrixAutoUpdate = false;
+    m.updateMatrix();
+    if (labelRef.current) labelRef.current.style.display = 'flex';
+  }, [pickup]);
+
+  // Bob and spin — mutate position.y and rotation.y, no allocations.
+  useFrame(() => {
+    if (!pickup) return;
+    const m = meshRef.current;
+    if (!m || !m.visible) return;
+
+    m.position.y = PICKUP_BASE_Y + Math.sin(_pickupTime * PICKUP_BOB_FREQ + slotIndex * 0.8) * PICKUP_BOB_AMP;
+    m.rotation.y += PICKUP_SPIN_SPEED * 0.016; // ~60fps delta approximation (cheap)
+    // matrixAutoUpdate is false — must update manually.
+    m.updateMatrix();
+
+    // Sync label visibility with mesh visibility.
+    if (labelRef.current) {
+      const display = m.visible ? 'flex' : 'none';
+      if (labelRef.current.style.display !== display) {
+        labelRef.current.style.display = display;
+      }
+    }
+  });
+
+  return (
+    <group>
+      <mesh
+        ref={meshRef}
+        geometry={pickupGeo}
+        material={mat}
+        visible={false}
+        castShadow
+        frustumCulled={false}
+      />
+      {/* Html label — DOM overlay, safe on Iris Xe. NO distanceFactor. */}
+      {pickup && (
+        <Html
+          position={[
+            pickup.x,
+            PICKUP_BASE_Y + PICKUP_TORUS_RADIUS + 16,
+            pickup.y,
+          ]}
+          center
+          occlude={false}
+          zIndexRange={[10, 100]}
+        >
+          <div
+            ref={labelRef}
+            style={{
+              display: 'none',
+              fontSize: '22px',
+              userSelect: 'none',
+              pointerEvents: 'none',
+            }}
+          >
+            {PICKUP_EMOJI[pickup.kind] ?? '?'}
+          </div>
+        </Html>
+      )}
+    </group>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+interface BumperShellsPickupsProps {
+  /** Live pickups from the activity store. Map<spawnId, BumperPickup>. */
+  pickups: Map<string, BumperPickup>;
+}
+
+export default function BumperShellsPickups({ pickups }: BumperShellsPickupsProps) {
+  // Advance the shared time accumulator once per frame.
+  // Using a static ref to avoid module-level mutation from multiple instances.
+  useFrame((state) => {
+    _pickupTime = state.clock.elapsedTime;
+  });
+
+  // Stable slot array — always render MAX_PICKUPS slots.
+  // Map pickup data into indexed slots so slot identity stays stable.
+  const slots = useMemo(() => {
+    const arr: Array<BumperPickup | null> = Array(MAX_PICKUPS).fill(null);
+    let i = 0;
+    for (const p of pickups.values()) {
+      if (i >= MAX_PICKUPS) break;
+      arr[i++] = p;
+    }
+    return arr;
+  }, [pickups]);
+
+  return (
+    <group>
+      {slots.map((pickup, idx) => (
+        <PickupSlot key={idx} slotIndex={idx} pickup={pickup} />
+      ))}
+    </group>
+  );
+}

--- a/apps/web/src/lib/three/activities/bumper-shells/BumperShellsPlayer.tsx
+++ b/apps/web/src/lib/three/activities/bumper-shells/BumperShellsPlayer.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+/**
+ * BumperShellsPlayer.tsx
+ *
+ * Single player shell component. Clones lobster.glb or crayfish.glb, applies
+ * squash/stretch on hit, fades out on elimination.
+ *
+ * One instance per player, up to MAX_PLAYERS=8 simultaneously.
+ *
+ * Iris Xe invariants:
+ *   - SkeletonUtils.clone() + frustumCulled=false traverse immediately after clone.
+ *   - Squash/stretch applied to ROOT GROUP not SkinnedMesh bones.
+ *   - No per-frame allocations — module-scope scratch vectors.
+ *   - applyColorTint skipped for GLB shells (matches VRM-tinting convention from player-pet.tsx).
+ *
+ * Draw calls: 1 per player (lobster.glb is 1 SkinnedMesh draw call).
+ */
+
+import { useRef, useEffect, useMemo } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { useGLTF } from '@react-three/drei';
+import * as THREE from 'three/webgpu';
+import { clone as skeletonClone } from 'three/examples/jsm/utils/SkeletonUtils.js';
+import { LobsterAnimator } from '@/lib/three/lobster-animations';
+import { discoverLobsterParts } from '@/lib/three/lobster-parts';
+import type { BumperShellEntity, ShellHitAnimState } from './bumper-shells-types';
+import { SHELL_SCALE, HIT_ANIM_FRAMES } from './bumper-shells-config';
+
+// ─── Preloads — fire at module scope so GLBs are warm before a round starts ──
+useGLTF.preload('/models/lobster.glb');
+useGLTF.preload('/models/crayfish.glb');
+
+// ─── Module-scope scratch ─────────────────────────────────────────────────────
+const _scale = new THREE.Vector3();
+
+// ─── Lobster facing constant ──────────────────────────────────────────────────
+// lobster.glb faces +Z at rotation.y=0. Facing formula: atan2(vx, vy) in sim-space,
+// which maps to atan2(vx, vz) in 3D.
+// idle default = 0 (faces +Z toward default camera).
+
+interface BumperShellsPlayerProps {
+  entity: BumperShellEntity;
+  /** True if this is the local player (used for highlight, not yet used in 3D). */
+  isSelf?: boolean;
+}
+
+function BumperShellsPlayerInner({ entity, isSelf = false }: BumperShellsPlayerProps) {
+  const species = entity.species ?? 'lobster';
+  const glbPath = species === 'crayfish' ? '/models/crayfish.glb' : '/models/lobster.glb';
+
+  const { scene: srcScene } = useGLTF(glbPath);
+
+  const groupRef    = useRef<THREE.Group>(null);
+  const meshRootRef = useRef<THREE.Group>(null);
+
+  // Hit animation state — managed via ref (no React re-render needed).
+  const hitAnim = useRef<ShellHitAnimState>({ active: false, elapsed: 0 });
+
+  // Fade state for elimination.
+  const fadeRef = useRef({ active: false, opacity: 1 });
+
+  // Clone the GLB once per entity/species change.
+  const clonedScene = useMemo(() => {
+    const c = skeletonClone(srcScene);
+    // CRITICAL: frustumCulled=false traverse immediately after SkeletonUtils.clone.
+    // SkinnedMesh bind-pose bounding spheres don't encompass animated poses.
+    c.traverse((o) => {
+      o.frustumCulled = false;
+    });
+    return c;
+  }, [srcScene]);
+
+  // Attach and detach the cloned scene.
+  useEffect(() => {
+    const root = meshRootRef.current;
+    if (!root || !clonedScene) return;
+    root.add(clonedScene);
+    return () => {
+      root.remove(clonedScene);
+    };
+  }, [clonedScene]);
+
+  // Track previous alive state to trigger fade on elimination.
+  const wasAlive = useRef(true);
+
+  useFrame((_, delta) => {
+    const group    = groupRef.current;
+    const meshRoot = meshRootRef.current;
+    if (!group || !meshRoot) return;
+
+    // ─── Position + rotation from entity ──────────────────────────────────
+    // Sim-space: x → Three.js X, y → Three.js Z (top-down arena).
+    group.position.x = entity.x;
+    group.position.y = 6; // top of disc
+    group.position.z = entity.y;
+
+    // Facing: lobster faces +Z at rot=0 → atan2(vx, vz).
+    if (entity.vx !== 0 || entity.vy !== 0) {
+      group.rotation.y = Math.atan2(entity.vx, entity.vy);
+    }
+
+    // ─── Squash/stretch animation (applied to meshRoot group) ─────────────
+    const h = hitAnim.current;
+    if (h.active) {
+      h.elapsed += delta;
+      const lastFrame = HIT_ANIM_FRAMES[HIT_ANIM_FRAMES.length - 1];
+      if (h.elapsed >= lastFrame.t) {
+        h.active = false;
+        meshRoot.scale.set(1, 1, 1);
+      } else {
+        // Linear interpolation between keyframes.
+        for (let i = 1; i < HIT_ANIM_FRAMES.length; i++) {
+          const prev = HIT_ANIM_FRAMES[i - 1];
+          const next = HIT_ANIM_FRAMES[i];
+          if (h.elapsed >= prev.t && h.elapsed <= next.t) {
+            const t = (h.elapsed - prev.t) / (next.t - prev.t);
+            meshRoot.scale.set(
+              prev.scale[0] + (next.scale[0] - prev.scale[0]) * t,
+              prev.scale[1] + (next.scale[1] - prev.scale[1]) * t,
+              prev.scale[2] + (next.scale[2] - prev.scale[2]) * t,
+            );
+            break;
+          }
+        }
+      }
+    }
+
+    // ─── Elimination fade ─────────────────────────────────────────────────
+    if (wasAlive.current && !entity.alive) {
+      // Just eliminated — start fade.
+      wasAlive.current = false;
+      fadeRef.current.active = true;
+      fadeRef.current.opacity = 1;
+    }
+
+    if (fadeRef.current.active) {
+      fadeRef.current.opacity = Math.max(0, fadeRef.current.opacity - delta * 1.0);
+      clonedScene.traverse((o) => {
+        if ((o as THREE.Mesh).isMesh) {
+          const mat = (o as THREE.Mesh).material as THREE.MeshStandardMaterial;
+          if (mat) {
+            mat.transparent = true;
+            mat.opacity = fadeRef.current.opacity;
+          }
+        }
+      });
+      if (fadeRef.current.opacity <= 0) {
+        fadeRef.current.active = false;
+        group.visible = false;
+      }
+    }
+
+    // Show/hide based on alive state (after any fade completes).
+    if (entity.alive && !wasAlive.current) {
+      // Re-spawned (future: respawn support).
+      wasAlive.current = true;
+      group.visible = true;
+      fadeRef.current.opacity = 1;
+    }
+  });
+
+  /**
+   * Called externally (by BumperShellsScene) when a hit event matches this petId.
+   * Triggers the squash/stretch animation.
+   */
+  // We expose this via an imperative handle pattern using a ref on the outer group.
+  // BumperShellsScene calls: playerRefs[petId].current?.triggerHit?.()
+  useEffect(() => {
+    const group = groupRef.current;
+    if (!group) return;
+    (group as THREE.Group & { triggerHit?: () => void }).triggerHit = () => {
+      hitAnim.current = { active: true, elapsed: 0 };
+    };
+  });
+
+  return (
+    <group ref={groupRef} scale={[SHELL_SCALE, SHELL_SCALE, SHELL_SCALE]}>
+      {/* meshRoot receives squash/stretch scale — separate from the position group */}
+      <group ref={meshRootRef} />
+    </group>
+  );
+}
+
+export default function BumperShellsPlayer(props: BumperShellsPlayerProps) {
+  return (
+    <BumperShellsPlayerInner {...props} />
+  );
+}

--- a/apps/web/src/lib/three/activities/bumper-shells/BumperShellsScene.tsx
+++ b/apps/web/src/lib/three/activities/bumper-shells/BumperShellsScene.tsx
@@ -1,0 +1,285 @@
+'use client';
+
+/**
+ * BumperShellsScene.tsx
+ *
+ * Root R3F Canvas for the Bumper Shells minigame.
+ *
+ * Route: /activity/bumper-shells/[roomId] (page.tsx — owned by general-purpose agent)
+ *
+ * Architecture:
+ *   - Isolated from the open world — mounts on its own Next.js route.
+ *   - `key={roomId}` on Canvas forces full WebGPU context recreation between rooms.
+ *   - Static OrthographicCamera (top-down with slight isometric tilt).
+ *     Camera never moves after mount — matrixAutoUpdate=false equivalent.
+ *   - <PreCompilePipelines> fires compileAsync after first R3F commit.
+ *   - Reads `useActivityStore` for entity/pickup/event state (written by general-purpose WS hook).
+ *
+ * Iris Xe invariants enforced here:
+ *   - No drei Text/Billboard anywhere.
+ *   - No InstancedMesh + ShaderMaterial.
+ *   - No per-frame allocations in useFrame (module-scope scratch vectors only).
+ *   - 1 shadow map at 512×512.
+ *   - 0 post-processing passes.
+ *   - Fog far (900) < camera.far (1500).
+ *
+ * Performance budget: ≤60 draw calls / ≤180k tris.
+ *
+ * Props accepted by parent route:
+ *   <BumperShellsScene roomId={roomId} selfPetId={selfPetId} />
+ */
+
+import { Suspense, useEffect, useRef, useMemo, useCallback } from 'react';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import * as THREE from 'three/webgpu';
+import { extend } from '@react-three/fiber';
+import type { ThreeToJSXElements } from '@react-three/fiber';
+
+// Register Three.js WebGPU elements with R3F.
+declare module '@react-three/fiber' {
+  interface ThreeElements extends ThreeToJSXElements<typeof THREE> {}
+}
+extend(THREE as any);
+
+import BumperShellsArena    from './BumperShellsArena';
+import BumperShellsHazard   from './BumperShellsHazard';
+import BumperShellsPlayer   from './BumperShellsPlayer';
+import BumperShellsPickups  from './BumperShellsPickups';
+import BumperShellsParticles, { triggerBurst } from './BumperShellsParticles';
+import {
+  FOG_COLOR,
+  FOG_NEAR,
+  FOG_FAR,
+  CAMERA_ORTHO_SIZE,
+  CAMERA_NEAR,
+  CAMERA_FAR,
+  CAMERA_POSITION,
+  HEMI_SKY_COLOR,
+  HEMI_GROUND_COLOR,
+  HEMI_INTENSITY,
+  DIR_COLOR,
+  DIR_INTENSITY,
+  DIR_POSITION,
+  DIR_SHADOW_MAP_SIZE,
+  DIR_SHADOW_NEAR,
+  DIR_SHADOW_FAR,
+  DIR_SHADOW_CAM_BOUNDS,
+  HAZARD_ENABLED,
+  MAX_PLAYERS,
+} from './bumper-shells-config';
+import type { BumperShellEntity, BumperPickup, BumperHitEvent } from './bumper-shells-types';
+
+// ─── Activity store import ────────────────────────────────────────────────────
+// NOTE: This file does not exist yet — general-purpose will land it.
+// The import is stubbed so the module compiles (the store returns empty defaults).
+// Expected type: see ActivityStateForScene in bumper-shells-types.ts.
+import { useActivityStore } from '@/stores/activity';
+
+// ─── Module-scope scratch ─────────────────────────────────────────────────────
+const _hitCheckScratch = { lastHitCount: 0 };
+
+// ─── PreCompilePipelines ──────────────────────────────────────────────────────
+// Must be rendered INSIDE SceneContents, AFTER all other children.
+// Same pattern as World3DCanvas.tsx.
+function PreCompilePipelines() {
+  const { gl, scene, camera } = useThree();
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => {
+      if (typeof (gl as any).compileAsync === 'function') {
+        (gl as any).compileAsync(scene, camera).catch((err: unknown) => {
+          console.warn('[BumperShells] compileAsync failed:', err);
+        });
+      }
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [gl, scene, camera]);
+  return null;
+}
+
+// ─── Static Camera ────────────────────────────────────────────────────────────
+// Orthographic with slight isometric tilt per 3d-spec §1.5.
+// Camera never moves after mount.
+function BumperCamera() {
+  const { camera, size } = useThree();
+
+  useEffect(() => {
+    const ortho = camera as THREE.OrthographicCamera;
+    // Set frustum based on config.
+    ortho.left   = -CAMERA_ORTHO_SIZE;
+    ortho.right  =  CAMERA_ORTHO_SIZE;
+    ortho.top    =  CAMERA_ORTHO_SIZE;
+    ortho.bottom = -CAMERA_ORTHO_SIZE;
+    ortho.near   = CAMERA_NEAR;
+    ortho.far    = CAMERA_FAR;
+    ortho.position.set(CAMERA_POSITION[0], CAMERA_POSITION[1], CAMERA_POSITION[2]);
+    ortho.lookAt(0, 0, 0);
+    ortho.updateProjectionMatrix();
+    // Camera is static — disable per-frame matrix updates.
+    ortho.matrixAutoUpdate = false;
+    ortho.updateMatrix();
+  }, [camera, size]);
+
+  return null;
+}
+
+// ─── Directional light + shadow setup ────────────────────────────────────────
+function BumperLight() {
+  const dirRef = useRef<THREE.DirectionalLight>(null);
+
+  useEffect(() => {
+    const d = dirRef.current;
+    if (!d) return;
+    d.shadow.mapSize.set(DIR_SHADOW_MAP_SIZE, DIR_SHADOW_MAP_SIZE);
+    d.shadow.camera.near   = DIR_SHADOW_NEAR;
+    d.shadow.camera.far    = DIR_SHADOW_FAR;
+    (d.shadow.camera as THREE.OrthographicCamera).left   = -DIR_SHADOW_CAM_BOUNDS;
+    (d.shadow.camera as THREE.OrthographicCamera).right  =  DIR_SHADOW_CAM_BOUNDS;
+    (d.shadow.camera as THREE.OrthographicCamera).top    =  DIR_SHADOW_CAM_BOUNDS;
+    (d.shadow.camera as THREE.OrthographicCamera).bottom = -DIR_SHADOW_CAM_BOUNDS;
+    d.shadow.camera.updateProjectionMatrix();
+    // Static light — freeze matrix.
+    d.matrixAutoUpdate = false;
+    d.updateMatrix();
+  }, []);
+
+  return (
+    <>
+      <hemisphereLight
+        args={[HEMI_SKY_COLOR, HEMI_GROUND_COLOR, HEMI_INTENSITY]}
+      />
+      <directionalLight
+        ref={dirRef}
+        color={DIR_COLOR}
+        intensity={DIR_INTENSITY}
+        position={DIR_POSITION}
+        castShadow
+      />
+      {/* Neon accent point lights — no shadows, static position. */}
+      <pointLight color="#00ccff" intensity={0.6} distance={400} decay={2} position={[400,  80,  0]}  castShadow={false} />
+      <pointLight color="#ff66aa" intensity={0.6} distance={400} decay={2} position={[-300, 80, 350]} castShadow={false} />
+      <pointLight color="#aa44ff" intensity={0.5} distance={350} decay={2} position={[0,    80, -400]} castShadow={false} />
+    </>
+  );
+}
+
+// ─── Hit event processor ──────────────────────────────────────────────────────
+// Processes hit events from the store and calls triggerBurst imperatively.
+// Runs in useFrame to avoid re-renders.
+function HitEventProcessor() {
+  const hitsRef = useRef<BumperHitEvent[]>([]);
+
+  useFrame(() => {
+    const hits = useActivityStore.getState().events?.hits;
+    if (!hits) return;
+
+    // Only process new hits (appended to the array by the store).
+    const len = hits.length;
+    if (len <= _hitCheckScratch.lastHitCount) return;
+
+    for (let i = _hitCheckScratch.lastHitCount; i < len; i++) {
+      const h = hits[i];
+      triggerBurst(h.x, 6, h.y, '#ff6600');
+    }
+    _hitCheckScratch.lastHitCount = len;
+  });
+
+  return null;
+}
+
+// ─── Scene contents ───────────────────────────────────────────────────────────
+// Separated so Canvas props (camera, gl) are accessible via useThree.
+
+interface SceneContentsProps {
+  entities: Map<string, BumperShellEntity>;
+  pickups: Map<string, BumperPickup>;
+  selfPetId: string | null;
+}
+
+function SceneContents({ entities, pickups, selfPetId }: SceneContentsProps) {
+  return (
+    <>
+      {/* Camera */}
+      <BumperCamera />
+
+      {/* Atmosphere */}
+      <fog args={[FOG_COLOR, FOG_NEAR, FOG_FAR]} />
+      <color attach="background" args={[FOG_COLOR]} />
+
+      {/* Lighting — 1 shadow map at 512×512, 3 point lights (no shadows) */}
+      <BumperLight />
+
+      {/* Arena geometry — 4 draw calls */}
+      <BumperShellsArena />
+
+      {/* Central hazard — 2 draw calls */}
+      <BumperShellsHazard enabled={HAZARD_ENABLED} />
+
+      {/* Player shells — up to 8 draw calls */}
+      <Suspense fallback={null}>
+        {Array.from(entities.values()).map((entity) => (
+          <BumperShellsPlayer
+            key={entity.petId}
+            entity={entity}
+            isSelf={entity.petId === selfPetId}
+          />
+        ))}
+      </Suspense>
+
+      {/* Power-up pickups — up to 6 draw calls */}
+      <BumperShellsPickups pickups={pickups} />
+
+      {/* Particle burst pool — 4 Points objects, max 16 pts each */}
+      <BumperShellsParticles />
+
+      {/* Hit event → burst trigger (no React re-renders) */}
+      <HitEventProcessor />
+
+      {/* Pipeline pre-compilation — must be LAST inside SceneContents */}
+      <PreCompilePipelines />
+    </>
+  );
+}
+
+// ─── Public component ─────────────────────────────────────────────────────────
+
+export interface BumperShellsSceneProps {
+  /** Room ID — used as Canvas key to force context recreation between rooms. */
+  roomId: string;
+  /** The current user's pet ID, used for self-highlighting. */
+  selfPetId?: string | null;
+}
+
+export default function BumperShellsScene({
+  roomId,
+  selfPetId = null,
+}: BumperShellsSceneProps) {
+  // Subscribe to activity store — high-frequency path, keep subscriptions narrow.
+  const entities = useActivityStore((s) => s.entities as Map<string, BumperShellEntity>);
+  const pickups  = useActivityStore((s) => s.pickups  as Map<string, BumperPickup>);
+
+  return (
+    <Canvas
+      key={roomId}
+      camera={
+        {
+          // R3F will create an OrthographicCamera when these are passed:
+          // (orthographic=true is not a valid R3F prop — we configure it in BumperCamera)
+          // Use PerspectiveCamera as default; BumperCamera overrides projection.
+          near: CAMERA_NEAR,
+          far: CAMERA_FAR,
+        } as any
+      }
+      orthographic
+      shadows
+      gl={{ antialias: false }} // Disable MSAA for Iris Xe perf budget
+      style={{ width: '100%', height: '100%' }}
+      dpr={[1, 1.5]} // Clamp pixel ratio for Iris Xe
+    >
+      <SceneContents
+        entities={entities ?? new Map()}
+        pickups={pickups ?? new Map()}
+        selfPetId={selfPetId}
+      />
+    </Canvas>
+  );
+}

--- a/apps/web/src/lib/three/activities/bumper-shells/bumper-shells-config.ts
+++ b/apps/web/src/lib/three/activities/bumper-shells/bumper-shells-config.ts
@@ -1,0 +1,192 @@
+/**
+ * bumper-shells-config.ts
+ *
+ * All constants for the Bumper Shells activity scene.
+ * Centralised here so BumperShellsArena, BumperShellsHazard, BumperShellsPlayer,
+ * BumperShellsPickups, and BumperShellsParticles all read from one source.
+ *
+ * Performance budget: ≤60 draw calls / ≤180k tris / 1×512² shadow map / 0 post-processing.
+ * Target GPU: Intel Iris Xe (integrated).
+ */
+
+// ─── Arena geometry ──────────────────────────────────────────────────────────
+
+/** Flat disc radius in world-units (wu). */
+export const ARENA_RADIUS = 500;
+
+/** Platform cylinder height. */
+export const ARENA_HEIGHT = 12;
+
+/** Radial segments for the platform disc — 48 keeps the rim smooth at 500wu. */
+export const ARENA_RADIAL_SEGMENTS = 48;
+
+// ─── Boundary / rim ──────────────────────────────────────────────────────────
+
+/** Rim glow torus outer-tube radius. */
+export const RIM_TUBE_RADIUS = 8;
+
+/** Rim glow torus radial segments (lower = fewer draw-call verts). */
+export const RIM_RADIAL_SEGMENTS = 16;
+
+/** Rim glow torus tubular segments. */
+export const RIM_TUBULAR_SEGMENTS = 64;
+
+/** Outer fraction of arena radius considered a "danger zone" (0–1). */
+export const DANGER_ZONE_FRACTION = 0.15;
+
+/** Inner edge of the danger ring in wu. */
+export const DANGER_RING_INNER = ARENA_RADIUS * (1 - DANGER_ZONE_FRACTION); // ≈ 425
+
+// ─── Hazard ──────────────────────────────────────────────────────────────────
+
+/** Central spiked ball enabled by default — toggleable via prop. */
+export const HAZARD_ENABLED = true;
+
+/** Radius of the central spiked sphere. */
+export const HAZARD_SPHERE_RADIUS = 60;
+
+/** Number of cone spikes on the hazard (InstancedMesh count). */
+export const HAZARD_SPIKE_COUNT = 8;
+
+/** Hazard rotation speed in radians per second. */
+export const HAZARD_SPIN_SPEED = 0.5;
+
+// ─── Camera ──────────────────────────────────────────────────────────────────
+
+/** Orthographic camera frustum half-width/height in wu. */
+export const CAMERA_ORTHO_SIZE = 700;
+
+/** Camera near clip plane. */
+export const CAMERA_NEAR = 1;
+
+/** Camera far clip plane. Must be > FOG_FAR. */
+export const CAMERA_FAR = 1500;
+
+/** Camera position — slight isometric tilt (not pure top-down). */
+export const CAMERA_POSITION = [0, 1100, 300] as const;
+
+/** Camera look-at target. */
+export const CAMERA_LOOK_AT = [0, 0, 0] as const;
+
+// ─── Fog ─────────────────────────────────────────────────────────────────────
+
+/** Fog color hex — deep ocean dark blue. */
+export const FOG_COLOR = '#050a14';
+
+/** Fog near distance. Keep ≤ ARENA_RADIUS so center is always fog-free. */
+export const FOG_NEAR = 200;
+
+/**
+ * Fog far distance. MUST be ≤ CAMERA_FAR.
+ * Iris Xe rule: fog.far > camera.far → 90→50 FPS drop.
+ * 900 < 1500 ✓
+ */
+export const FOG_FAR = 900;
+
+// ─── Lighting ────────────────────────────────────────────────────────────────
+
+export const HEMI_SKY_COLOR = '#1a3a5c';
+export const HEMI_GROUND_COLOR = '#050a14';
+export const HEMI_INTENSITY = 0.4;
+
+export const DIR_COLOR = '#80d4ff';
+export const DIR_INTENSITY = 1.1;
+export const DIR_POSITION = [200, 600, 150] as const;
+export const DIR_SHADOW_MAP_SIZE = 512;
+export const DIR_SHADOW_NEAR = 1;
+export const DIR_SHADOW_FAR = 1200;
+export const DIR_SHADOW_CAM_BOUNDS = 600;
+
+// ─── Player shells ───────────────────────────────────────────────────────────
+
+/**
+ * Scale applied to lobster.glb / crayfish.glb clones.
+ * Matches PET_SCALE=40 from player-pet.tsx (lobster.glb bbox.max.y ≈ 1.12 native → 44.8 wu).
+ */
+export const SHELL_SCALE = 40;
+
+/** Maximum simultaneously-rendered player shells. */
+export const MAX_PLAYERS = 8;
+
+// ─── Squash/stretch animation ────────────────────────────────────────────────
+
+/** Frame schedule for squash/stretch on hit (scale applied to root group, NOT SkinnedMesh). */
+export const HIT_ANIM_FRAMES = [
+  { t: 0,    scale: [1.0,  0.6,  1.0]  },
+  { t: 0.07, scale: [0.85, 1.3,  0.85] },
+  { t: 0.2,  scale: [1.0,  1.0,  1.0]  },
+] as const;
+
+// ─── Power-up pickups ────────────────────────────────────────────────────────
+
+/** Maximum simultaneous pickup slots — pre-allocated at scene init. */
+export const MAX_PICKUPS = 6;
+
+/** TorusKnot geometry params for pickup props. */
+export const PICKUP_TORUS_RADIUS = 20;
+export const PICKUP_TUBE_RADIUS = 6;
+export const PICKUP_TUBULAR_SEGMENTS = 32;
+export const PICKUP_RADIAL_SEGMENTS = 6;
+
+/** Pickup float bob amplitude in wu. */
+export const PICKUP_BOB_AMP = 8;
+
+/** Pickup float bob frequency in Hz. */
+export const PICKUP_BOB_FREQ = 2;
+
+/** Pickup rotation speed in radians per second. */
+export const PICKUP_SPIN_SPEED = 1.2;
+
+/** Y position of pickups above arena surface. */
+export const PICKUP_BASE_Y = 40;
+
+/**
+ * Emissive colour per power-up kind.
+ * Used on MeshStandardMaterial — never ShaderMaterial.
+ */
+export const PICKUP_EMISSIVE: Record<string, string> = {
+  speed:       '#00e5ff',
+  shield:      '#69f0ae',
+  'sticky-bomb': '#ff6d00',
+  whirlpool:   '#9c27b0',
+  ghost:       '#e0e0e0',
+  tractor:     '#f9a825',
+};
+
+/**
+ * Emoji label per power-up kind, rendered via drei <Html>.
+ * NO drei <Text> — Iris Xe crash.
+ */
+export const PICKUP_EMOJI: Record<string, string> = {
+  speed:       '⚡',
+  shield:      '🛡',
+  'sticky-bomb': '💣',
+  whirlpool:   '🌊',
+  ghost:       '👻',
+  tractor:     '🧜',
+};
+
+// ─── Particle bursts ─────────────────────────────────────────────────────────
+
+/** Number of burst pool slots — max simultaneous bursts visible. */
+export const BURST_POOL_SIZE = 4;
+
+/** Points per burst instance. Keep ≤ 16 for Iris Xe fragment budget. */
+export const BURST_POINT_COUNT = 16;
+
+/** Burst radius in wu — how far points scatter from impact point. */
+export const BURST_RADIUS = 80;
+
+/** Burst lifetime in milliseconds. */
+export const BURST_LIFETIME_MS = 400;
+
+/** Burst point size in pixels. */
+export const BURST_POINT_SIZE = 6;
+
+// ─── Void backdrop ───────────────────────────────────────────────────────────
+
+/** Y position of the infinite void plane below the arena. */
+export const VOID_BACKDROP_Y = -2000;
+
+/** Void backdrop quad size in wu — large enough to fill the view at CAMERA_FAR. */
+export const VOID_BACKDROP_SIZE = 8000;

--- a/apps/web/src/lib/three/activities/bumper-shells/bumper-shells-types.ts
+++ b/apps/web/src/lib/three/activities/bumper-shells/bumper-shells-types.ts
@@ -1,0 +1,134 @@
+/**
+ * bumper-shells-types.ts
+ *
+ * Local TypeScript interfaces for the Bumper Shells scene.
+ *
+ * ─── Coordination contract with general-purpose agent ────────────────────────
+ *
+ * The scene reads from `@/stores/activity` (ActivityStateForScene below).
+ * General-purpose owns the WRITER side — the store + WS client that hydrates it
+ * from incoming `ServerFrame` messages. The 3D scene is the READER only.
+ *
+ * Store import path (general-purpose will create this file):
+ *   import { useActivityStore } from '@/stores/activity';
+ *
+ * Store shape the scene needs:
+ *
+ *   interface ActivityStateForScene {
+ *     selfPetId: string | null;
+ *     entities: Map<string, {
+ *       petId: string;
+ *       x: number;       // wu (world units, sim-space)
+ *       y: number;       // wu (z in 3D)
+ *       rot: number;     // radians
+ *       vx: number;
+ *       vy: number;
+ *       alive: boolean;
+ *       color?: string;  // hex tint for shell
+ *       species?: string;
+ *     }>;
+ *     pickups: Map<string, {
+ *       spawnId: string;
+ *       kind: 'speed' | 'shield' | 'sticky-bomb' | 'whirlpool' | 'ghost' | 'tractor';
+ *       x: number;
+ *       y: number;
+ *     }>;
+ *     events: {
+ *       hits: Array<{ at: number; x: number; y: number; power: number }>;
+ *       eliminations: Array<{ at: number; petId: string }>;
+ *     };
+ *     matchPhase: 'pregame-countdown' | 'live' | 'ended';
+ *     countdownSecondsRemaining: number;
+ *     roundEndsAt: number | null;
+ *   }
+ *
+ * The scene subscribes with `useActivityStore(state => state.entities)` etc.
+ * High-frequency fields (entities) must be held in a Map for O(1) lookup in useFrame.
+ *
+ * ─── WS protocol source of truth ─────────────────────────────────────────────
+ * See `packages/shared/src/activities/protocol.ts` — EntityDelta, PowerUpDelta,
+ * ServerFrame. The store writer translates those deltas into this flat shape.
+ */
+
+// ─── Entity state the scene reads per player ─────────────────────────────────
+
+export interface BumperShellEntity {
+  petId: string;
+  /** Sim-space X → Three.js X */
+  x: number;
+  /** Sim-space Y → Three.js Z */
+  y: number;
+  rot: number;
+  vx: number;
+  vy: number;
+  alive: boolean;
+  /** Optional hex string tint applied to the shell material. */
+  color?: string;
+  /** 'lobster' | 'crayfish' — determines which GLB clone is used. */
+  species?: string;
+}
+
+// ─── Pickup state ─────────────────────────────────────────────────────────────
+
+export type BumperPickupKind =
+  | 'speed'
+  | 'shield'
+  | 'sticky-bomb'
+  | 'whirlpool'
+  | 'ghost'
+  | 'tractor';
+
+export interface BumperPickup {
+  spawnId: string;
+  kind: BumperPickupKind;
+  /** Sim-space X → Three.js X */
+  x: number;
+  /** Sim-space Y → Three.js Z */
+  y: number;
+}
+
+// ─── Hit event ────────────────────────────────────────────────────────────────
+
+export interface BumperHitEvent {
+  /** Server timestamp in ms (Date.now() from backend). */
+  at: number;
+  /** Impact position in Three.js world-space X. */
+  x: number;
+  /** Impact position in Three.js world-space Z. */
+  y: number;
+  /** Knockback power (0–1 normalised, used for burst radius scaling). */
+  power: number;
+}
+
+// ─── Elimination event ────────────────────────────────────────────────────────
+
+export interface BumperEliminationEvent {
+  at: number;
+  petId: string;
+}
+
+// ─── Match phase ─────────────────────────────────────────────────────────────
+
+export type BumperMatchPhase = 'pregame-countdown' | 'live' | 'ended';
+
+// ─── Squash/stretch animation state (per player, managed by BumperShellsPlayer) ──
+
+export interface ShellHitAnimState {
+  active: boolean;
+  /** Elapsed time in seconds since hit (0 = just hit). */
+  elapsed: number;
+}
+
+// ─── Burst pool slot (managed by BumperShellsParticles) ──────────────────────
+
+export interface BurstSlot {
+  active: boolean;
+  startedAt: number;
+  color: string;
+  /** Three.js world-space position of the burst origin. */
+  x: number;
+  y: number; // Three.js Y (ground level = 6 for top of disc)
+  z: number; // Three.js Z
+  /** Directional spread vectors (pre-computed at activation, not per-frame). */
+  directions: Float32Array; // 16 * 3 floats
+}

--- a/apps/web/src/lib/three/activities/shared/activity-particles.tsx
+++ b/apps/web/src/lib/three/activities/shared/activity-particles.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+/**
+ * activity-particles.tsx
+ *
+ * Shared reusable burst particle pool for both Bumper Shells and Reef Race.
+ * 8 pool slots × 16 Points each = 128 max simultaneous particles.
+ *
+ * Iris Xe invariants:
+ *   - PointsMaterial with AdditiveBlending — safe on both WebGL and WebGPU.
+ *   - Float32BufferAttribute mutated in-place — no per-frame allocations.
+ *   - All 8 Points objects mounted at scene init as visible=false.
+ *   - Pre-computed random directions per slot at module load — no per-burst RNG.
+ *   - Module-scope pool state — triggerBurst() is imperative, zero React re-renders.
+ *
+ * API:
+ *   - `triggerBurst(position, color, radius)` — imperative, call from useFrame or event handler.
+ *   - `<ActivityBursts />` — JSX component, mount once at scene root.
+ *
+ * Per 3d-spec §3.3:
+ *   Pool size = 8 (both games combined), each burst = 16 Points.
+ *   Trail emitter (Reef Race boost) is NOT shared — lives in ReefRaceBoostFX.tsx.
+ */
+
+import { useRef, useEffect } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+const SHARED_BURST_POOL_SIZE  = 8;
+const SHARED_BURST_POINT_COUNT = 16;
+const DEFAULT_BURST_LIFETIME_MS = 400;
+
+// ─── Module-scope pool state ──────────────────────────────────────────────────
+
+interface SharedBurstSlot {
+  active: boolean;
+  startedAt: number;
+  colorHex: string;
+  radius: number;
+}
+
+const _sharedPool: SharedBurstSlot[] = Array.from(
+  { length: SHARED_BURST_POOL_SIZE },
+  () => ({ active: false, startedAt: 0, colorHex: '#ffffff', radius: 80 }),
+);
+
+// Pre-computed random spread directions for each slot (never changes).
+const _sharedDirections: Float32Array[] = Array.from(
+  { length: SHARED_BURST_POOL_SIZE },
+  (_, slotIdx) => {
+    const d = new Float32Array(SHARED_BURST_POINT_COUNT * 3);
+    for (let i = 0; i < SHARED_BURST_POINT_COUNT; i++) {
+      const angle = (i / SHARED_BURST_POINT_COUNT) * Math.PI * 2 + (slotIdx * 0.3);
+      d[i * 3 + 0] = Math.cos(angle);
+      d[i * 3 + 1] = (Math.random() * 0.6) - 0.3; // slight Y scatter
+      d[i * 3 + 2] = Math.sin(angle);
+    }
+    return d;
+  },
+);
+
+// Origin positions per slot.
+const _sharedOrigins: Array<THREE.Vector3> = Array.from(
+  { length: SHARED_BURST_POOL_SIZE },
+  () => new THREE.Vector3(),
+);
+
+// ─── Public imperative API ────────────────────────────────────────────────────
+
+/**
+ * Trigger a shared burst at a Three.js world-space position.
+ * Safe to call outside React — no state mutation, no re-renders.
+ *
+ * @param position  THREE.Vector3 world position of the burst origin.
+ * @param color     CSS color string, e.g. '#ff6600'.
+ * @param radius    Spread radius in world-units. Default: 80.
+ */
+export function triggerBurst(
+  position: THREE.Vector3,
+  color = '#ffffff',
+  radius = 80,
+): void {
+  // Find inactive slot; steal oldest if all active.
+  let slot = _sharedPool.findIndex((s) => !s.active);
+  if (slot === -1) {
+    let oldest = 0;
+    let oldestTime = Infinity;
+    for (let i = 0; i < SHARED_BURST_POOL_SIZE; i++) {
+      if (_sharedPool[i].startedAt < oldestTime) {
+        oldest = i;
+        oldestTime = _sharedPool[i].startedAt;
+      }
+    }
+    slot = oldest;
+  }
+
+  _sharedPool[slot].active    = true;
+  _sharedPool[slot].startedAt = performance.now();
+  _sharedPool[slot].colorHex  = color;
+  _sharedPool[slot].radius    = radius;
+  _sharedOrigins[slot].copy(position);
+}
+
+// ─── Internal per-slot component ─────────────────────────────────────────────
+
+function SharedBurstPoints({ slotIndex }: { slotIndex: number }) {
+  const pointsRef = useRef<THREE.Points>(null);
+  const posBuffer = useRef(new Float32Array(SHARED_BURST_POINT_COUNT * 3));
+
+  useEffect(() => {
+    const pts = pointsRef.current;
+    if (!pts) return;
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute(
+      'position',
+      new THREE.BufferAttribute(posBuffer.current, 3),
+    );
+
+    const mat = new THREE.PointsMaterial({
+      size: 6,
+      sizeAttenuation: true,
+      transparent: true,
+      opacity: 0,
+      color: new THREE.Color('#ffffff'),
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    });
+
+    pts.geometry = geo;
+    pts.material = mat;
+
+    return () => {
+      geo.dispose();
+      mat.dispose();
+    };
+  }, []);
+
+  useFrame(() => {
+    const slot = _sharedPool[slotIndex];
+    const pts  = pointsRef.current;
+    if (!pts) return;
+
+    if (!slot.active) {
+      if (pts.visible) pts.visible = false;
+      return;
+    }
+
+    const elapsed = performance.now() - slot.startedAt;
+    const t = Math.min(elapsed / DEFAULT_BURST_LIFETIME_MS, 1);
+
+    if (t >= 1) {
+      slot.active = false;
+      pts.visible = false;
+      return;
+    }
+
+    pts.visible = true;
+
+    const mat = pts.material as THREE.PointsMaterial;
+    mat.opacity = 1 - t;
+    mat.color.set(_sharedPool[slotIndex].colorHex);
+    mat.needsUpdate = true;
+
+    const dirs   = _sharedDirections[slotIndex];
+    const origin = _sharedOrigins[slotIndex];
+    const pos    = posBuffer.current;
+    const spread = _sharedPool[slotIndex].radius * t;
+
+    for (let i = 0; i < SHARED_BURST_POINT_COUNT; i++) {
+      pos[i * 3 + 0] = origin.x + dirs[i * 3 + 0] * spread;
+      pos[i * 3 + 1] = origin.y + dirs[i * 3 + 1] * spread * 0.5;
+      pos[i * 3 + 2] = origin.z + dirs[i * 3 + 2] * spread;
+    }
+
+    if (pts.geometry) {
+      (pts.geometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
+    }
+  });
+
+  return <points ref={pointsRef} frustumCulled={false} />;
+}
+
+// ─── Main exported component ──────────────────────────────────────────────────
+
+/**
+ * Mount once inside the activity scene root.
+ * Contains all SHARED_BURST_POOL_SIZE (8) burst Point objects.
+ * Both Bumper Shells and Reef Race can share this component.
+ */
+export function ActivityBursts() {
+  return (
+    <group>
+      {Array.from({ length: SHARED_BURST_POOL_SIZE }, (_, i) => (
+        <SharedBurstPoints key={i} slotIndex={i} />
+      ))}
+    </group>
+  );
+}

--- a/apps/web/src/lib/three/activities/shared/world-to-screen.ts
+++ b/apps/web/src/lib/three/activities/shared/world-to-screen.ts
@@ -1,0 +1,66 @@
+/**
+ * world-to-screen.ts
+ *
+ * Pure projection utility — no React, no Three.js instance state.
+ * Converts a Three.js world-space Vector3 to CSS pixel coordinates for HUD anchoring.
+ *
+ * Called by the frontend agent's HUD overlay to position floating labels
+ * (player names, health bars, ghost indicator) over 3D objects.
+ *
+ * Per 3d-spec §3.2:
+ *   - No 3D geometry involved — pure math.
+ *   - Caller owns the camera and renderer references.
+ *   - `visible` is false when the point is behind the camera (z > 1 in NDC).
+ *
+ * Example (in a HUD component):
+ *   const { gl, camera } = useThree();
+ *   const { x, y, visible } = worldToScreen(playerWorldPos, camera, gl);
+ *   if (visible) labelRef.current.style.transform = `translate(${x}px, ${y}px)`;
+ */
+
+import * as THREE from 'three';
+
+// ─── Module-scope scratch — no per-call allocation ────────────────────────────
+const _ndc = new THREE.Vector3();
+
+export interface ScreenPosition {
+  /** CSS pixel X from left edge of the canvas. */
+  x: number;
+  /** CSS pixel Y from top edge of the canvas. */
+  y: number;
+  /** False when the point is behind the camera (clipped). */
+  visible: boolean;
+}
+
+/**
+ * Project a world-space position to CSS canvas-relative pixel coordinates.
+ *
+ * @param worldPos   Three.js world-space position of the 3D object.
+ * @param camera     The active camera (PerspectiveCamera or OrthographicCamera).
+ * @param gl         The Three.js renderer — used for canvas pixel dimensions.
+ * @returns          {x, y} in CSS pixels + `visible` flag.
+ */
+export function worldToScreen(
+  worldPos: THREE.Vector3,
+  camera: THREE.Camera,
+  gl: { domElement: HTMLCanvasElement },
+): ScreenPosition {
+  // Copy world position into NDC scratch — no allocation.
+  _ndc.copy(worldPos);
+  _ndc.project(camera);
+
+  // NDC z > 1 or < -1 means behind camera.
+  const visible = _ndc.z <= 1;
+
+  const canvas = gl.domElement;
+  const halfW  = canvas.clientWidth  / 2;
+  const halfH  = canvas.clientHeight / 2;
+
+  // NDC → CSS pixels.
+  // NDC: (-1,-1) = bottom-left, (+1,+1) = top-right.
+  // CSS: (0,0) = top-left.
+  const x = (_ndc.x  + 1) * halfW;
+  const y = (-_ndc.y + 1) * halfH;
+
+  return { x, y, visible };
+}

--- a/apps/web/src/stores/activity.ts
+++ b/apps/web/src/stores/activity.ts
@@ -1,0 +1,632 @@
+/**
+ * Activity store — Q2 Activity Portals (chunk #4 wiring).
+ *
+ * Single zustand store that mirrors the server-authoritative match state
+ * for the active activity room. Written by `useActivityWs` (translates
+ * `ServerFrame` deltas), read by:
+ *
+ *   - `apps/web/src/lib/three/activities/bumper-shells/BumperShellsScene.tsx`
+ *     (3da-owned, imports `useActivityStore`)
+ *   - `apps/web/src/components/game/bumper-shells-hud.tsx` (HUD composition)
+ *
+ * ─── Coordination contract with 3da's scene ──────────────────────────────────
+ *
+ * 3da's `bumper-shells-types.ts` declares the EXACT store shape the scene
+ * subscribes to. The contract (copied verbatim from that file's comment) is:
+ *
+ *   interface ActivityStateForScene {
+ *     selfPetId: string | null;
+ *     entities: Map<string, {
+ *       petId: string;
+ *       x: number;       // wu (world units, sim-space)
+ *       y: number;       // wu (z in 3D)
+ *       rot: number;     // radians
+ *       vx: number;
+ *       vy: number;
+ *       alive: boolean;
+ *       color?: string;  // hex tint for shell
+ *       species?: string;
+ *     }>;
+ *     pickups: Map<string, {
+ *       spawnId: string;
+ *       kind: 'speed' | 'shield' | 'sticky-bomb' | 'whirlpool' | 'ghost' | 'tractor';
+ *       x: number;
+ *       y: number;
+ *     }>;
+ *     events: {
+ *       hits: Array<{ at: number; x: number; y: number; power: number }>;
+ *       eliminations: Array<{ at: number; petId: string }>;
+ *     };
+ *     matchPhase: 'pregame-countdown' | 'live' | 'ended';
+ *     countdownSecondsRemaining: number;
+ *     roundEndsAt: number | null;
+ *   }
+ *
+ * High-frequency fields (entities, pickups) are held in a `Map` so the
+ * scene's `useFrame` loop can do O(1) lookups by petId without rebuilding
+ * an index every tick. We allocate a NEW Map on each mutation so zustand's
+ * shallow equality fires re-renders correctly (immer is not in repo deps).
+ *
+ * ─── Extra client-only fields (HUD-only, scene ignores) ──────────────────────
+ *
+ *   ping, connectionStatus, placement, alive, total, scores, powerUpInventory,
+ *   matchEndReason, winners, rewardPreview, room, errorBanner
+ *
+ * These are written by the WS hook from `event.*` / `pong` / `snapshot.delta`
+ * frames and consumed only by the HUD components — keeping the scene's
+ * subscription surface narrow.
+ */
+
+import { create } from 'zustand';
+import { subscribeWithSelector } from 'zustand/middleware';
+import type {
+  ServerFrame,
+  EntityDelta,
+  PowerUpDelta,
+  RewardPreview,
+  RoomMeta,
+  WorldState,
+} from '@clawville/shared';
+import type {
+  BumperShellEntity,
+  BumperPickup,
+  BumperPickupKind,
+  BumperHitEvent,
+  BumperEliminationEvent,
+  BumperMatchPhase,
+} from '@/lib/three/activities/bumper-shells/bumper-shells-types';
+
+// ─── Connection status ──────────────────────────────────────────────────────
+
+export type ConnectionStatus =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'closed';
+
+// ─── Score row (HUD-side mirror of ScoreDelta) ──────────────────────────────
+
+export interface ActivityScoreEntry {
+  petId: string;
+  /** Display name resolved from `event.player_joined` when available, else petId tail */
+  displayName: string;
+  score: number;
+  placement?: number;
+}
+
+// ─── Power-up inventory slot (mirrors PowerUpDelta.inventory[]) ─────────────
+
+export interface PowerUpSlot {
+  kind: string;
+  charges: number;
+  cooldownUntil?: number;
+}
+
+// ─── Match-end winners (mirrors event.match_ended.winners) ──────────────────
+
+export interface MatchWinner {
+  petId: string;
+  placement: number;
+}
+
+// ─── Store interface ────────────────────────────────────────────────────────
+
+export interface ActivityState {
+  // ── Scene contract (READ by 3da's BumperShellsScene) ────────────────────
+  selfPetId: string | null;
+  entities: Map<string, BumperShellEntity>;
+  pickups: Map<string, BumperPickup>;
+  events: {
+    hits: BumperHitEvent[];
+    eliminations: BumperEliminationEvent[];
+  };
+  matchPhase: BumperMatchPhase;
+  countdownSecondsRemaining: number;
+  roundEndsAt: number | null;
+
+  // ── HUD-only mirror state ───────────────────────────────────────────────
+  /** Active room id this store snapshot belongs to (used by `reset` guard). */
+  roomId: string | null;
+  /** Room meta from `snapshot.init`. */
+  room: RoomMeta | null;
+  /** Last RTT ping in ms, computed from pong roundtrip. */
+  ping: number;
+  connectionStatus: ConnectionStatus;
+  /** Self pet's current placement (1-indexed). null until score deltas arrive. */
+  placement: number | null;
+  /** Live count of `entity.alive === true`. */
+  alive: number;
+  /** Total participants (room.participantCount snapshot). */
+  total: number;
+  /** Live score table, sorted by score descending in selectors. */
+  scores: Map<string, ActivityScoreEntry>;
+  /** Self pet's power-up slots from latest PowerUpDelta.inventory. */
+  powerUpInventory: PowerUpSlot[];
+  /** Set when `event.match_ended` arrives. */
+  matchEndReason: 'complete' | 'forfeit' | 'aborted' | null;
+  winners: MatchWinner[];
+  rewardPreview: RewardPreview | null;
+  /** Last server `error` frame (HUD displays inline if set). */
+  errorBanner: { code: string; message: string } | null;
+
+  // ── Writer API ──────────────────────────────────────────────────────────
+
+  /** Single switchboard for `useActivityWs` to apply incoming server frames. */
+  applyServerFrame: (frame: ServerFrame) => void;
+
+  /** Imperative actions (used by hooks + page lifecycle). */
+  reset: (roomId: string | null) => void;
+  setSelfPetId: (petId: string | null) => void;
+  setConnectionStatus: (status: ConnectionStatus) => void;
+  setPing: (ms: number) => void;
+  pushHit: (hit: BumperHitEvent) => void;
+  pushElimination: (ev: BumperEliminationEvent) => void;
+  clearError: () => void;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Trim the events.* arrays so they don't grow unbounded across a long match. */
+const HIT_RING_BUFFER = 64;
+const ELIM_RING_BUFFER = 32;
+
+/** Map server `kind` strings (free-form for forward-compat) onto our enum. */
+function normalizePickupKind(raw: string): BumperPickupKind {
+  // Keep the strict union for the scene's discriminated rendering; unknown
+  // kinds fall back to 'speed' so an out-of-band server change doesn't crash
+  // the scene — it just renders the wrong icon, easy to spot.
+  switch (raw) {
+    case 'bs-speed-boost':
+    case 'speed':
+      return 'speed';
+    case 'bs-shell-shield':
+    case 'shield':
+      return 'shield';
+    case 'bs-sticky-bomb':
+    case 'sticky-bomb':
+      return 'sticky-bomb';
+    case 'bs-knockback-aura':
+    case 'whirlpool':
+      return 'whirlpool';
+    case 'bs-ghost':
+    case 'ghost':
+      return 'ghost';
+    case 'bs-tractor-beam':
+    case 'tractor':
+      return 'tractor';
+    default:
+      return 'speed';
+  }
+}
+
+/** Display name fallback when we don't have a `player_joined` event yet. */
+function shortPetId(petId: string): string {
+  return petId.length > 8 ? `…${petId.slice(-6)}` : petId;
+}
+
+/** Apply a single EntityDelta to a (mutable) entity map clone. */
+function applyEntityDelta(map: Map<string, BumperShellEntity>, delta: EntityDelta): void {
+  const existing = map.get(delta.petId);
+  const c = delta.changed;
+  if (!existing) {
+    // First sighting — only insert if we have at least one positional field.
+    map.set(delta.petId, {
+      petId: delta.petId,
+      x: typeof c.x === 'number' ? c.x : 0,
+      y: typeof c.y === 'number' ? c.y : 0,
+      rot: typeof c.rot === 'number' ? c.rot : 0,
+      vx: typeof c.vx === 'number' ? c.vx : 0,
+      vy: typeof c.vy === 'number' ? c.vy : 0,
+      alive: c.state !== 'dead' && c.state !== 'eliminated',
+    });
+    return;
+  }
+  map.set(delta.petId, {
+    ...existing,
+    ...(typeof c.x === 'number' ? { x: c.x } : {}),
+    ...(typeof c.y === 'number' ? { y: c.y } : {}),
+    ...(typeof c.rot === 'number' ? { rot: c.rot } : {}),
+    ...(typeof c.vx === 'number' ? { vx: c.vx } : {}),
+    ...(typeof c.vy === 'number' ? { vy: c.vy } : {}),
+    ...(typeof c.state === 'string'
+      ? { alive: c.state !== 'dead' && c.state !== 'eliminated' }
+      : {}),
+  });
+}
+
+/** Hydrate from a full WorldState (snapshot.init / snapshot.keyframe). */
+function hydrateFromWorld(world: WorldState): {
+  entities: Map<string, BumperShellEntity>;
+  pickups: Map<string, BumperPickup>;
+  scores: Map<string, ActivityScoreEntry>;
+  alive: number;
+} {
+  const entities = new Map<string, BumperShellEntity>();
+  for (const e of world.entities) {
+    entities.set(e.petId, {
+      petId: e.petId,
+      x: e.position.x,
+      y: e.position.y,
+      rot: e.rotation,
+      vx: e.velocity.x,
+      vy: e.velocity.y,
+      alive: e.state !== 'dead' && e.state !== 'eliminated',
+    });
+  }
+  const pickups = new Map<string, BumperPickup>();
+  for (const p of world.powerUps) {
+    pickups.set(p.spawnId, {
+      spawnId: p.spawnId,
+      kind: normalizePickupKind(p.kind),
+      x: p.position.x,
+      y: p.position.y,
+    });
+  }
+  const scores = new Map<string, ActivityScoreEntry>();
+  for (const s of world.scores) {
+    scores.set(s.petId, {
+      petId: s.petId,
+      displayName: shortPetId(s.petId),
+      score: s.score,
+    });
+  }
+  let alive = 0;
+  entities.forEach((e) => {
+    if (e.alive) alive++;
+  });
+  return { entities, pickups, scores, alive };
+}
+
+// ─── Empty-state factory (shared by initial state + reset) ──────────────────
+
+function emptyState(): Pick<
+  ActivityState,
+  | 'entities'
+  | 'pickups'
+  | 'events'
+  | 'matchPhase'
+  | 'countdownSecondsRemaining'
+  | 'roundEndsAt'
+  | 'placement'
+  | 'alive'
+  | 'total'
+  | 'scores'
+  | 'powerUpInventory'
+  | 'matchEndReason'
+  | 'winners'
+  | 'rewardPreview'
+  | 'errorBanner'
+  | 'room'
+  | 'ping'
+> {
+  return {
+    entities: new Map(),
+    pickups: new Map(),
+    events: { hits: [], eliminations: [] },
+    matchPhase: 'pregame-countdown',
+    countdownSecondsRemaining: 0,
+    roundEndsAt: null,
+    placement: null,
+    alive: 0,
+    total: 0,
+    scores: new Map(),
+    powerUpInventory: [],
+    matchEndReason: null,
+    winners: [],
+    rewardPreview: null,
+    errorBanner: null,
+    room: null,
+    ping: 0,
+  };
+}
+
+// ─── Store ──────────────────────────────────────────────────────────────────
+
+export const useActivityStore = create<ActivityState>()(
+  subscribeWithSelector((set, get) => ({
+    selfPetId: null,
+    roomId: null,
+    connectionStatus: 'idle',
+    ...emptyState(),
+
+    setSelfPetId: (petId) => set({ selfPetId: petId }),
+    setConnectionStatus: (status) => set({ connectionStatus: status }),
+    setPing: (ms) => set({ ping: ms }),
+    clearError: () => set({ errorBanner: null }),
+
+    pushHit: (hit) => {
+      const next = get().events.hits.slice(-HIT_RING_BUFFER + 1);
+      next.push(hit);
+      set({ events: { ...get().events, hits: next } });
+    },
+
+    pushElimination: (ev) => {
+      const next = get().events.eliminations.slice(-ELIM_RING_BUFFER + 1);
+      next.push(ev);
+      set({ events: { ...get().events, eliminations: next } });
+    },
+
+    reset: (roomId) => {
+      set({
+        roomId,
+        // Preserve selfPetId across resets — it's known before the WS opens.
+        ...emptyState(),
+      });
+    },
+
+    applyServerFrame: (frame) => {
+      const state = get();
+
+      switch (frame.type) {
+        // ── Snapshot init ───────────────────────────────────────────────
+        case 'snapshot.init': {
+          const hydrated = hydrateFromWorld(frame.world);
+          set({
+            room: frame.room,
+            entities: hydrated.entities,
+            pickups: hydrated.pickups,
+            scores: hydrated.scores,
+            alive: hydrated.alive,
+            total: hydrated.entities.size,
+            matchPhase:
+              frame.room.status === 'live'
+                ? 'live'
+                : frame.room.status === 'results'
+                  ? 'ended'
+                  : 'pregame-countdown',
+            roundEndsAt: frame.room.endsAt ?? null,
+            connectionStatus: 'connected',
+            errorBanner: null,
+          });
+          break;
+        }
+
+        // ── Snapshot delta (15 Hz hot path) ─────────────────────────────
+        case 'snapshot.delta': {
+          const entities = new Map(state.entities);
+          for (const d of frame.entities) applyEntityDelta(entities, d);
+
+          const pickups = new Map(state.pickups);
+          for (const p of frame.powerUps) {
+            if (p.collectorPetId) {
+              // Collected — drop from world map.
+              pickups.delete(p.spawnId);
+            } else if (p.position) {
+              pickups.set(p.spawnId, {
+                spawnId: p.spawnId,
+                kind: normalizePickupKind(p.kind),
+                x: p.position.x,
+                y: p.position.y,
+              });
+            }
+            // PowerUpDelta.inventory targets the SELF — server only sends
+            // the local pet's inventory (or omits when unchanged).
+            if (p.inventory && state.selfPetId) {
+              set({
+                powerUpInventory: p.inventory.map((slot) => ({
+                  kind: slot.kind,
+                  charges: slot.charges,
+                  cooldownUntil: slot.cooldownUntil,
+                })),
+              });
+            }
+          }
+
+          // Score deltas — recompute placements + self placement.
+          let scores = state.scores;
+          let placement = state.placement;
+          if (frame.scores && frame.scores.length > 0) {
+            scores = new Map(state.scores);
+            for (const s of frame.scores) {
+              const existing = scores.get(s.petId);
+              scores.set(s.petId, {
+                petId: s.petId,
+                displayName: existing?.displayName ?? shortPetId(s.petId),
+                score: s.score,
+                placement: s.placement ?? existing?.placement,
+              });
+            }
+            if (state.selfPetId) {
+              const self = scores.get(state.selfPetId);
+              placement = self?.placement ?? placement;
+            }
+          }
+
+          let alive = 0;
+          entities.forEach((e) => {
+            if (e.alive) alive++;
+          });
+
+          set({ entities, pickups, scores, alive, placement });
+          break;
+        }
+
+        // ── Periodic full state refresh ─────────────────────────────────
+        case 'snapshot.keyframe': {
+          const hydrated = hydrateFromWorld(frame.world);
+          // Preserve scores from prior deltas — keyframes don't always include
+          // displayName context the WS hook may have built up via player_joined.
+          const merged = new Map(state.scores);
+          hydrated.scores.forEach((s, id) => {
+            const existing = merged.get(id);
+            merged.set(id, {
+              petId: id,
+              displayName: existing?.displayName ?? s.displayName,
+              score: s.score,
+              placement: existing?.placement,
+            });
+          });
+          set({
+            entities: hydrated.entities,
+            pickups: hydrated.pickups,
+            scores: merged,
+            alive: hydrated.alive,
+            total: Math.max(state.total, hydrated.entities.size),
+          });
+          break;
+        }
+
+        // ── Lifecycle events ────────────────────────────────────────────
+        case 'event.countdown':
+          set({
+            matchPhase: 'pregame-countdown',
+            countdownSecondsRemaining: Math.max(0, frame.secondsRemaining),
+          });
+          break;
+
+        case 'event.match_started':
+          set({
+            matchPhase: 'live',
+            countdownSecondsRemaining: 0,
+            roundEndsAt: null, // server provides via snapshot.init endsAt
+          });
+          break;
+
+        case 'event.match_ended':
+          set({
+            matchPhase: 'ended',
+            matchEndReason: frame.reason,
+            winners: frame.winners,
+            rewardPreview: frame.rewardPreview,
+          });
+          break;
+
+        case 'event.player_joined': {
+          // Stamp the displayName into the score row so the mini-leaderboard
+          // shows real names instead of petId tails.
+          const scores = new Map(state.scores);
+          const existing = scores.get(frame.petId);
+          scores.set(frame.petId, {
+            petId: frame.petId,
+            displayName: frame.displayName || shortPetId(frame.petId),
+            score: existing?.score ?? 0,
+            placement: existing?.placement,
+          });
+          set({ scores, total: Math.max(state.total, state.entities.size + 1) });
+          break;
+        }
+
+        case 'event.player_left': {
+          // Don't drop from `entities` — the body may still be on the field
+          // as a static/idle target per backend §3.6. The server's next delta
+          // will mark `state: 'dead'` if appropriate.
+          break;
+        }
+
+        case 'event.eliminated': {
+          // Mark entity dead AND push an elimination event for the scene.
+          const entities = new Map(state.entities);
+          const e = entities.get(frame.petId);
+          if (e && e.alive) {
+            entities.set(frame.petId, { ...e, alive: false });
+          }
+          let alive = 0;
+          entities.forEach((x) => {
+            if (x.alive) alive++;
+          });
+          const elims = state.events.eliminations.slice(-ELIM_RING_BUFFER + 1);
+          elims.push({ at: Date.now(), petId: frame.petId });
+          set({
+            entities,
+            alive,
+            events: { ...state.events, eliminations: elims },
+          });
+          break;
+        }
+
+        case 'event.hit': {
+          // VFX-only event — append to the ring buffer; the scene's
+          // HitEventProcessor reads via useFrame and triggers bursts.
+          const hits = state.events.hits.slice(-HIT_RING_BUFFER + 1);
+          hits.push({
+            at: Date.now(),
+            x: frame.position.x,
+            y: frame.position.y,
+            power: typeof frame.power === 'number' ? frame.power : 0.5,
+          });
+          set({ events: { ...state.events, hits } });
+          break;
+        }
+
+        case 'event.power_up_spawned': {
+          const pickups = new Map(state.pickups);
+          pickups.set(frame.spawnId, {
+            spawnId: frame.spawnId,
+            kind: normalizePickupKind(frame.kind),
+            x: frame.position.x,
+            y: frame.position.y,
+          });
+          set({ pickups });
+          break;
+        }
+
+        case 'event.power_up_collected': {
+          const pickups = new Map(state.pickups);
+          pickups.delete(frame.spawnId);
+          set({ pickups });
+          break;
+        }
+
+        // Reef Race-only event — Bumper Shells doesn't use it but the
+        // discriminated union needs a branch so future code-shifts compile.
+        case 'event.lap_completed':
+          // No-op for Bumper Shells; chunk #6 (Reef Race route) will route
+          // this into a separate `reefRaceLaps` slice on the same store.
+          break;
+
+        // ── Chat / pong / error ─────────────────────────────────────────
+        case 'chat':
+          // Chat surface ships in chunk #8 polish — capture for future wiring.
+          break;
+
+        case 'pong':
+          // Ping computation lives in `useActivityWs` because it tracks the
+          // outgoing `sentAt` per-message. Frame is a no-op here.
+          break;
+
+        case 'error':
+          set({ errorBanner: { code: frame.code, message: frame.message } });
+          break;
+
+        default: {
+          // Exhaustiveness sentinel — pull a `never` so a new ServerFrame
+          // type without a branch fails typecheck.
+          const _exhaustive: never = frame;
+          void _exhaustive;
+        }
+      }
+    },
+  })),
+);
+
+// ─── HUD-side selectors ─────────────────────────────────────────────────────
+
+/**
+ * Build a sorted leaderboard array — top N + ALWAYS the self row. Used by
+ * `<HudMiniLeaderboard>`. Returns a stable identity per (scores, selfId)
+ * change so it can be used directly in a render path.
+ */
+export function selectLeaderboard(state: ActivityState, max = 5) {
+  const arr: ActivityScoreEntry[] = [];
+  state.scores.forEach((s) => arr.push(s));
+  arr.sort((a, b) => b.score - a.score);
+  const top = arr.slice(0, max);
+  if (state.selfPetId && !top.find((r) => r.petId === state.selfPetId)) {
+    const self = state.scores.get(state.selfPetId);
+    if (self) top.push(self);
+  }
+  return top;
+}
+
+/**
+ * Convenience selector — derived "is self alive" used to gate input + HUD
+ * overlays. Returns true if we don't yet know (scene not initialized) so the
+ * HUD doesn't flash an "eliminated" overlay before snapshot.init lands.
+ */
+export function selectSelfAlive(state: ActivityState): boolean {
+  if (!state.selfPetId) return true;
+  const e = state.entities.get(state.selfPetId);
+  if (!e) return true;
+  return e.alive;
+}


### PR DESCRIPTION
## Summary

Chunk #4 of the Q2 Activity Portals phase — first end-to-end visible activity. Pairs the 3D scene (3da) with the route page, store, WS hook, input capture, HUD, and a dev-mode queue button so we can play Bumper Shells on prod immediately after merge.

Plan: `.claude/plans/phase-quest-gamification-q2-activity-portals.md`

## What's in this PR (2 commits)

### `6eeeea2` — feat(3d): Bumper Shells scene + shared activity infra (3da)

- `BumperShellsScene` + `Arena` + `Hazard` + `Player` + `Pickups` + `Particles`
- Shared `activity-particles` burst pool + `world-to-screen` projection utility
- Static `OrthographicCamera` with slight tilt (sidesteps Iris Xe multi-frusta shadow ceiling for 8 simultaneous players)
- `TorusKnotGeometry` pickups + drei `<Html>` labels (no `<Text>` — Iris Xe crash gotcha)
- 16-point pooled particle bursts on knockback
- Squash/stretch knockback viz on shell root group (avoids bone interference)
- Reuses `lobster.glb` / `crayfish.glb` — no new GLBs
- Performance budget: ≤60 draw calls / ≤180k tris / 1 shadow map at 512² / ZERO post-processing

### `391dfa9` — feat(web): route + store + WS + HUD + dev queue

- `/activity/[activityId]/[roomId]` Next.js route (separate from `/game` layout — fresh WebGPU context per 3d-spec §3.1)
- `useActivityStore` (zustand) matching 3da's `ActivityStateForScene` contract
- `useActivityWs` hook (auth handshake, snapshot delta/keyframe handling, ping/pong, 10s reconnect grace)
- `useActivityInput` hook (WASD + Space + Q + mobile event channel, 30Hz send rate — conservative; backend caps at 60)
- HUD atoms: `HudTile`, `HudPlacement`, `HudMiniLeaderboard`, `PowerUpBar`, `PowerUpIcon`, `RoundCountdown`, `EliminatedOverlay`, `PingIndicator`
- `BumperShellsHud` composition
- Dev-mode "🎮 Quick Queue: Bumper Shells" sidebar button — temporary, replaced by full portal+lobby UX in chunk #8

## Notable design calls

- **JSON over WS, not MessagePack.** Backend's WS hub uses `JSON.parse`/`JSON.stringify` (apps/api/src/services/activity/activity-ws-hub.ts). MessagePack is a cross-stack swap for later — not blocking.
- **`ActivityStateForScene` is the load-bearing contract** between 3da's scene and the zustand store. The TS interface in `bumper-shells-types.ts` is the source of truth — any drift silently empties the scene.
- **Route page outside `/game` layout** — separate Next.js route ensures the open world's WebGPU context is fully torn down before the activity scene mounts. `key={roomId}` on `<Canvas>` forces re-mount per room.

## Test plan post-merge

- [ ] Auto-deploy fires via `.github/workflows/deploy.yml` (this is the FIRST real test of the new workflow + VPS deploy script)
- [ ] `clawville.world` HTTP 200 with new build
- [ ] `api.clawville.world/api/activities` still returns 10 activities
- [ ] Click sidebar "🎮 Quick Queue: Bumper Shells" → POSTs to `/api/activities/bumper-shells/queue`
- [ ] Queue eventually navigates to `/activity/bumper-shells/:roomId` (need 4 players or wait for queue timeout to bot-backfill — bot backfill is chunk #10, so testing solo will time out at 60s; for now just verify the route page renders empty arena via direct URL: `clawville.world/activity/bumper-shells/<any-uuid>`)
- [ ] 3D scene renders without Iris Xe crash (arena disc, rim glow, hazard, no players)
- [ ] HUD overlay renders (placement chip, ping indicator, control hints)
- [ ] No console errors

## TODO for chunk #8 (frontend polish)

- Replace dev-mode quick-queue button with full `<BuildingPortalModal>` + `<ActivityLobbyModal>`
- Diablo-style match-end results modal (current minimal card is scaffolding)
- Spectator camera modes
- Mobile B-button overlay wiring
- In-match chat/emote rendering (protocol + store paths exist, no UI yet)
- Replay-share flow
- HUD polish (high-contrast toggle, ARIA-live, full atom set per frontend-spec §3.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)