### PR TITLE
[DRAFT - awaiting merge approval] feat(activities): chunk #11 — spectator mode

### DIFF
--- a/apps/web/src/app/activity/[activityId]/[roomId]/page.tsx
+++ b/apps/web/src/app/activity/[activityId]/[roomId]/page.tsx
@@ -18,7 +18,7 @@
  * same — full-screen black background + scene + HUD overlay.
  */
 
-import { useEffect, useMemo, useState, use } from 'react';
+import { useCallback, useEffect, useMemo, useState, use } from 'react';
 import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { isActivityLive, getActivityDefinition } from '@clawville/shared';
@@ -150,6 +150,22 @@ export default function ActivityRoomPage({ params }: ActivityPageProps) {
   // (BumperShellsHud reads from the store).
   void ping;
 
+  // Chunk #11 — wire spectator chat + emote sends to the WS hook. The HUD
+  // owns the rate-limit + local-echo; we just bridge the frame to the wire.
+  const handleSendChat = useCallback(
+    (text: string, opts: { spectator: boolean }): boolean => {
+      return send({ type: 'chat', text, spectator: opts.spectator });
+    },
+    [send],
+  );
+
+  const handleSendEmote = useCallback(
+    (emoteId: string, opts: { spectator: boolean }): boolean => {
+      return send({ type: 'emote', emoteId, spectator: opts.spectator });
+    },
+    [send],
+  );
+
   function handleLeave() {
     // Best-effort `leave` frame goes out via the WS hook's unmount cleanup.
     router.push('/game');
@@ -232,6 +248,8 @@ export default function ActivityRoomPage({ params }: ActivityPageProps) {
         onPlayAgain={handlePlayAgain}
         activityId={activityId}
         roomId={roomId}
+        sendChat={handleSendChat}
+        sendEmote={handleSendEmote}
       />
     </main>
   );

--- a/apps/web/src/components/game/activity/EliminatedOverlay.tsx
+++ b/apps/web/src/components/game/activity/EliminatedOverlay.tsx
@@ -1,100 +1,441 @@
 'use client';
 
 /**
- * EliminatedOverlay — full-viewport dim + "ELIMINATED — spectating" message
- * shown when self has been knocked off the arena. Spec: frontend-spec.md
- * §3.4 + §7 (spectator mode).
+ * EliminatedOverlay — full spectator UX shown after a player is KO'd
+ * mid-match. Spec: frontend-spec.md §7.
+ *
+ * Chunk #11 upgrades the chunk #4 stub from a static "ELIMINATED"
+ * placard into a working spectator surface:
+ *   - Dimmed overlay (does NOT block 3D viewport pointer events outside
+ *     the side panel, so the user can still see the action)
+ *   - Top header: "ELIMINATED — {remainingSec}s remaining"
+ *   - Right-side spectator panel:
+ *      - Spectating row with prev/next + free-cam selector
+ *      - Mini-leaderboard (live)
+ *      - Spectator chat channel (separate from active-player chat)
+ *      - Cheer / Taunt emote buttons (15s rate-limit per emote)
+ *
+ * Camera caveat (see SpectatorCamSelector.tsx) — the cam mode is captured
+ * locally + emitted via `onCamModeChange`, but the underlying scene keeps
+ * its static OrthographicCamera at this chunk to preserve the Iris Xe
+ * perf invariant. Camera motion ships in a 3da-paired follow-up.
+ *
+ * State management: the overlay holds NO match state — all reads come
+ * from props provided by `bumper-shells-hud.tsx`. This keeps it testable
+ * in isolation and prevents a second store subscription path.
  */
 
+import { useMemo } from 'react';
+import HudMiniLeaderboard from './HudMiniLeaderboard';
+import SpectatorCamSelector, { type SpectatorCamMode } from './SpectatorCamSelector';
+import SpectatorChatPanel from './SpectatorChatPanel';
+import EmoteButton from './EmoteButton';
+import type { ActivityChatMessage, ActivityScoreEntry } from '@/stores/activity';
+import type { BumperShellEntity } from '@/lib/three/activities/bumper-shells/bumper-shells-types';
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
 export interface EliminatedOverlayProps {
-  /** Wall-clock timestamp the elimination happened (Date.now()). */
+  /** Wall-clock millis the elimination happened (Date.now()). */
   eliminatedAt: number;
-  /** Final/current placement of self. */
+  /** Final/current placement of self (1-indexed). */
   placement: number | null;
-  /** Optional name of the player the camera is following (chunk #8). */
+  /** Self pet id — used for leaderboard self-row + chat self-tint. */
+  selfPetId: string | null;
+  /** Live leaderboard rows (top N + self). */
+  leaderboard: ActivityScoreEntry[];
+  /** Score map for `resolveName` lookups in the chat transcript. */
+  scoreLookup: Map<string, ActivityScoreEntry>;
+  /** Alive entities in stable order — for prev/next focus cycling. */
+  aliveEntities: BumperShellEntity[];
+  /** Spectator-channel chat history. */
+  spectatorChat: ActivityChatMessage[];
+  /** Server-driven round end time; null/undef → header omits the timer. */
+  roundEndsAt?: number | null;
+  /** Currently focused pet id (controlled by parent). */
+  spectatorTargetPetId: string | null;
+  /** Local cam-mode pick. */
+  spectatorCamMode: SpectatorCamMode;
+  /** Cooldown sentinel for cheer button (wall-clock millis or null). */
+  cheerCooldownUntil: number | null;
+  /** Cooldown sentinel for taunt button. */
+  tauntCooldownUntil: number | null;
+  /** Cooldown window in ms — exposed so the ring matches the rate-limit. */
+  emoteCooldownMs: number;
+
+  // ── Callbacks (parent owns intent + WS sends) ──────────────────────────
+  onSelectPrev: () => void;
+  onSelectNext: () => void;
+  onSelectFree: () => void;
+  onCamModeChange: (next: SpectatorCamMode) => void;
+  /** Returns true if the chat send succeeded (parent dispatches WS). */
+  onSendChat: (text: string) => boolean;
+  onCheer: () => void;
+  onTaunt: () => void;
+  /**
+   * Backwards-compat (chunk #4 callers): the chunk #4 stub accepted only
+   * `eliminatedAt`, `placement`, `spectatingPet`. Tests + legacy callers
+   * passing the old shape still compile but get the upgraded UI when the
+   * new props are also supplied. The field is read-only in §7's wireframe.
+   */
   spectatingPet?: string;
 }
 
-export default function EliminatedOverlay({
-  eliminatedAt,
-  placement,
-  spectatingPet,
-}: EliminatedOverlayProps) {
-  const elapsedSec = Math.max(0, Math.floor((Date.now() - eliminatedAt) / 1000));
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export default function EliminatedOverlay(props: EliminatedOverlayProps) {
+  const {
+    eliminatedAt,
+    placement,
+    selfPetId,
+    leaderboard,
+    scoreLookup,
+    aliveEntities,
+    spectatorChat,
+    roundEndsAt,
+    spectatorTargetPetId,
+    spectatorCamMode,
+    cheerCooldownUntil,
+    tauntCooldownUntil,
+    emoteCooldownMs,
+    onSelectPrev,
+    onSelectNext,
+    onSelectFree,
+    onCamModeChange,
+    onSendChat,
+    onCheer,
+    onTaunt,
+  } = props;
+
+  // Derive the spectated-pet display name for the header row.
+  const spectatedName = useMemo(() => {
+    if (spectatorCamMode === 'free') return 'Free Camera';
+    if (spectatorCamMode === 'action') return 'Action Cam';
+    if (!spectatorTargetPetId) return 'Pick a target';
+    return resolveDisplayName(spectatorTargetPetId, scoreLookup, aliveEntities);
+  }, [spectatorCamMode, spectatorTargetPetId, scoreLookup, aliveEntities]);
+
+  const remainingSec = roundEndsAt
+    ? Math.max(0, Math.round((roundEndsAt - Date.now()) / 1000))
+    : null;
+
+  const sinceElim = Math.max(0, Math.floor((Date.now() - eliminatedAt) / 1000));
+
+  // Resolver for chat names — falls back to short petId tail.
+  const resolveName = (petId: string) => resolveDisplayName(petId, scoreLookup, aliveEntities);
+
+  // Disable prev/next when there are no other alive players to switch to.
+  const canCycle = aliveEntities.length > 0;
+
   return (
-    <div
-      style={{
-        position: 'absolute',
-        inset: 0,
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        background:
-          'radial-gradient(ellipse at center, rgba(11, 18, 32, 0.55) 0%, rgba(11, 18, 32, 0.85) 100%)',
-        backdropFilter: 'grayscale(60%) brightness(0.7)',
-        WebkitBackdropFilter: 'grayscale(60%) brightness(0.7)',
-        pointerEvents: 'none',
-        zIndex: 25,
-      }}
-      role="status"
-      aria-live="polite"
-    >
+    <>
+      {/*
+       * Backdrop — covers the viewport with a soft grayscale dim. Pointer
+       * events are intentionally ALLOWED through the backdrop (transparent
+       * to clicks) so the user can still interact with the world; only
+       * the side panel + top header capture pointer input.
+       */}
       <div
-        className="claw-panel"
         style={{
-          padding: '20px 32px',
-          textAlign: 'center',
-          borderColor: 'rgba(255, 82, 82, 0.55)',
-          boxShadow: '0 0 28px rgba(255, 82, 82, 0.32)',
+          position: 'absolute',
+          inset: 0,
+          background:
+            'radial-gradient(ellipse at center, rgba(11, 18, 32, 0.45) 0%, rgba(11, 18, 32, 0.78) 100%)',
+          backdropFilter: 'grayscale(40%) brightness(0.78)',
+          WebkitBackdropFilter: 'grayscale(40%) brightness(0.78)',
+          pointerEvents: 'none',
+          zIndex: 25,
+        }}
+        role="status"
+        aria-live="polite"
+      />
+
+      {/* Top-center ELIMINATED header */}
+      <div
+        style={{
+          position: 'absolute',
+          top: 56,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 4,
+          pointerEvents: 'none',
+          zIndex: 26,
         }}
       >
         <div
+          className="claw-panel"
           style={{
-            fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
-            fontSize: 36,
-            fontWeight: 900,
-            letterSpacing: '0.12em',
-            color: '#fca5a5',
-            textShadow: '0 0 16px rgba(255, 82, 82, 0.6)',
-            marginBottom: 6,
+            padding: '14px 28px',
+            textAlign: 'center',
+            borderColor: 'rgba(255, 82, 82, 0.55)',
+            boxShadow: '0 0 24px rgba(255, 82, 82, 0.32)',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 4,
           }}
         >
-          ELIMINATED
-        </div>
-        {placement !== null && (
-          <div
+          <span
             style={{
               fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
-              fontSize: 14,
-              color: '#facc15',
+              fontSize: 28,
+              fontWeight: 900,
               letterSpacing: '0.16em',
-              marginBottom: 10,
+              color: '#fca5a5',
+              textShadow: '0 0 16px rgba(255, 82, 82, 0.6)',
+              lineHeight: 1,
             }}
           >
-            FINAL PLACEMENT · #{placement}
-          </div>
-        )}
-        <div
-          style={{
-            fontSize: 12,
-            color: 'rgba(226, 232, 240, 0.85)',
-            marginBottom: 4,
-          }}
-        >
-          {spectatingPet ? `Spectating ${spectatingPet}` : 'Spectating remaining shells…'}
-        </div>
-        <div
-          style={{
-            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
-            fontSize: 10,
-            color: 'rgba(148, 163, 184, 0.75)',
-            letterSpacing: '0.1em',
-          }}
-        >
-          {elapsedSec}s ago
+            ELIMINATED
+          </span>
+          {remainingSec !== null ? (
+            <span
+              style={{
+                fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+                fontSize: 11,
+                color: 'rgba(226, 232, 240, 0.85)',
+                letterSpacing: '0.18em',
+              }}
+            >
+              {remainingSec}s remaining in round
+            </span>
+          ) : (
+            <span
+              style={{
+                fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                fontSize: 10,
+                color: 'rgba(148, 163, 184, 0.75)',
+                letterSpacing: '0.1em',
+              }}
+            >
+              KO'd {sinceElim}s ago
+            </span>
+          )}
+          {placement !== null && (
+            <span
+              style={{
+                fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+                fontSize: 10,
+                color: '#facc15',
+                letterSpacing: '0.18em',
+                marginTop: 2,
+              }}
+            >
+              CURRENT PLACEMENT · #{placement}
+            </span>
+          )}
         </div>
       </div>
-    </div>
+
+      {/* Right-side spectator panel */}
+      <aside
+        style={{
+          position: 'absolute',
+          top: 12,
+          right: 12,
+          bottom: 12,
+          width: 320,
+          maxWidth: 'calc(100vw - 24px)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 10,
+          pointerEvents: 'none',
+          zIndex: 27,
+        }}
+        aria-label="Spectator controls"
+      >
+        {/*
+         * Spectating-target panel — prev/next cycler + cam selector.
+         * pointer-events:auto on the inner container so the buttons work
+         * while the surrounding aside stays click-through.
+         */}
+        <div
+          className="claw-panel"
+          style={{
+            padding: 10,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+            pointerEvents: 'auto',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 6,
+            }}
+          >
+            <span
+              style={{
+                fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+                fontSize: 9,
+                letterSpacing: '0.22em',
+                textTransform: 'uppercase',
+                color: 'rgba(0, 229, 255, 0.7)',
+                fontWeight: 700,
+              }}
+            >
+              Spectating
+            </span>
+            <span
+              style={{
+                fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+                fontSize: 12,
+                fontWeight: 700,
+                color: '#e0f7ff',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                maxWidth: 160,
+              }}
+            >
+              {spectatedName}
+            </span>
+          </div>
+          <div style={{ display: 'flex', gap: 4 }}>
+            <CycleButton
+              label="◀ Prev"
+              onClick={onSelectPrev}
+              disabled={!canCycle}
+              ariaLabel="Previous spectated player"
+            />
+            <CycleButton
+              label="Free Cam"
+              onClick={onSelectFree}
+              disabled={spectatorCamMode === 'free'}
+              ariaLabel="Switch to free camera"
+            />
+            <CycleButton
+              label="Next ▶"
+              onClick={onSelectNext}
+              disabled={!canCycle}
+              ariaLabel="Next spectated player"
+            />
+          </div>
+          <SpectatorCamSelector mode={spectatorCamMode} onChange={onCamModeChange} />
+        </div>
+
+        {/* Live leaderboard — reuses the active-match HudMiniLeaderboard */}
+        <div style={{ pointerEvents: 'auto' }}>
+          <HudMiniLeaderboard entries={leaderboard} selfId={selfPetId} max={5} />
+        </div>
+
+        {/* Spectator chat channel */}
+        <div
+          className="claw-panel"
+          style={{
+            padding: 10,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+            flex: 1,
+            minHeight: 220,
+            pointerEvents: 'auto',
+          }}
+        >
+          <SpectatorChatPanel
+            messages={spectatorChat}
+            resolveName={resolveName}
+            selfPetId={selfPetId}
+            onSend={onSendChat}
+            maxHeight={180}
+          />
+          <div
+            style={{
+              display: 'flex',
+              gap: 8,
+              alignItems: 'center',
+              justifyContent: 'center',
+              paddingTop: 4,
+              borderTop: '1px dashed rgba(0, 229, 255, 0.2)',
+            }}
+          >
+            <EmoteButton
+              glyph="👏"
+              label="Cheer"
+              tone="positive"
+              cooldownUntil={cheerCooldownUntil}
+              cooldownMs={emoteCooldownMs}
+              onClick={onCheer}
+              ariaLabel="Send cheer emote (rate limited 1 per 15s)"
+            />
+            <EmoteButton
+              glyph="😈"
+              label="Taunt"
+              tone="danger"
+              cooldownUntil={tauntCooldownUntil}
+              cooldownMs={emoteCooldownMs}
+              onClick={onTaunt}
+              ariaLabel="Send taunt emote (rate limited 1 per 15s)"
+            />
+          </div>
+        </div>
+      </aside>
+    </>
   );
+}
+
+// ─── Internal helpers ───────────────────────────────────────────────────────
+
+function CycleButton({
+  label,
+  onClick,
+  disabled,
+  ariaLabel,
+}: {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  ariaLabel: string;
+}) {
+  return (
+    <button
+      type="button"
+      data-hud-interactive="true"
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      style={{
+        flex: 1,
+        padding: '6px 8px',
+        borderRadius: 6,
+        border: '1px solid rgba(0, 229, 255, 0.4)',
+        background: disabled
+          ? 'rgba(15, 31, 58, 0.55)'
+          : 'linear-gradient(180deg, rgba(15, 31, 58, 0.95), rgba(6, 13, 23, 0.95))',
+        color: disabled ? 'rgba(148, 163, 184, 0.55)' : '#e0f7ff',
+        fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+        fontSize: 10,
+        fontWeight: 700,
+        letterSpacing: '0.12em',
+        textTransform: 'uppercase',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        pointerEvents: 'auto',
+        opacity: disabled ? 0.6 : 1,
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function resolveDisplayName(
+  petId: string,
+  scoreLookup: Map<string, ActivityScoreEntry>,
+  aliveEntities: BumperShellEntity[],
+): string {
+  const score = scoreLookup.get(petId);
+  if (score?.displayName) return score.displayName;
+  const ent = aliveEntities.find((e) => e.petId === petId);
+  if (ent) return shortPetId(petId);
+  return shortPetId(petId);
+}
+
+function shortPetId(petId: string): string {
+  return petId.length > 8 ? `…${petId.slice(-6)}` : petId;
 }

--- a/apps/web/src/components/game/activity/EmoteButton.tsx
+++ b/apps/web/src/components/game/activity/EmoteButton.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+/**
+ * EmoteButton — single cheer/taunt emote with a per-emote cooldown ring.
+ * Spec: frontend-spec.md §7.4 (rate-limited 1/15s per spectator).
+ *
+ * Stateless cooldown — the parent owns "last fired at" timestamps so two
+ * EmoteButton instances (cheer + taunt) don't share a single timer ref.
+ * Render math is purely derived from `cooldownUntil - Date.now()`.
+ */
+
+import { useEffect, useState } from 'react';
+
+export interface EmoteButtonProps {
+  /** Emoji glyph rendered inside the button. */
+  glyph: string;
+  /** Short label below the glyph. */
+  label: string;
+  /** Wall-clock millis when the cooldown ends; null/0 = ready. */
+  cooldownUntil: number | null;
+  /** Total cooldown window in ms (used to compute the ring fill ratio). */
+  cooldownMs: number;
+  /** Tint — 'positive' for cheers, 'danger' for taunts. */
+  tone: 'positive' | 'danger';
+  /** Click handler. Parent enforces the cooldown — we just disable while ticking. */
+  onClick: () => void;
+  /** Accessible label for screen readers. */
+  ariaLabel: string;
+}
+
+export default function EmoteButton({
+  glyph,
+  label,
+  cooldownUntil,
+  cooldownMs,
+  tone,
+  onClick,
+  ariaLabel,
+}: EmoteButtonProps) {
+  // Force a re-render at 100ms intervals while a cooldown is pending so
+  // the ring + countdown text update smoothly. Stops ticking when ready.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!cooldownUntil || cooldownUntil <= Date.now()) return;
+    const id = setInterval(() => setTick((t) => t + 1), 100);
+    return () => clearInterval(id);
+  }, [cooldownUntil]);
+
+  const now = Date.now();
+  const remaining = cooldownUntil ? Math.max(0, cooldownUntil - now) : 0;
+  const ready = remaining <= 0;
+  const ratio = ready ? 0 : Math.min(1, remaining / cooldownMs);
+
+  const accent = tone === 'positive' ? 'rgba(0, 230, 118, 0.85)' : 'rgba(255, 82, 82, 0.85)';
+  const accentDim = tone === 'positive' ? 'rgba(0, 230, 118, 0.18)' : 'rgba(255, 82, 82, 0.2)';
+
+  return (
+    <button
+      type="button"
+      data-hud-interactive="true"
+      onClick={ready ? onClick : undefined}
+      disabled={!ready}
+      aria-label={ariaLabel}
+      style={{
+        position: 'relative',
+        width: 60,
+        height: 60,
+        borderRadius: 12,
+        border: `1px solid ${ready ? accent : 'rgba(148, 163, 184, 0.25)'}`,
+        background: 'linear-gradient(180deg, rgba(15, 31, 58, 0.95), rgba(6, 13, 23, 0.95))',
+        boxShadow: ready ? `0 0 14px ${accentDim}` : 'none',
+        cursor: ready ? 'pointer' : 'not-allowed',
+        opacity: ready ? 1 : 0.55,
+        padding: 0,
+        pointerEvents: 'auto',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 2,
+        transition: 'transform 80ms ease-out, box-shadow 200ms',
+      }}
+      onMouseDown={(e) => {
+        if (ready) (e.currentTarget as HTMLButtonElement).style.transform = 'scale(0.94)';
+      }}
+      onMouseUp={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.transform = 'scale(1.0)';
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.transform = 'scale(1.0)';
+      }}
+    >
+      <span aria-hidden style={{ fontSize: 22, lineHeight: 1 }}>
+        {glyph}
+      </span>
+      <span
+        style={{
+          fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+          fontSize: 8,
+          fontWeight: 700,
+          letterSpacing: '0.14em',
+          textTransform: 'uppercase',
+          color: ready ? '#e2e8f0' : 'rgba(148, 163, 184, 0.7)',
+        }}
+      >
+        {label}
+      </span>
+      {!ready && (
+        <span
+          aria-hidden
+          style={{
+            position: 'absolute',
+            bottom: 2,
+            right: 4,
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            fontSize: 9,
+            color: 'rgba(226, 232, 240, 0.85)',
+            background: 'rgba(0, 0, 0, 0.55)',
+            borderRadius: 4,
+            padding: '1px 4px',
+          }}
+        >
+          {Math.ceil(remaining / 1000)}s
+        </span>
+      )}
+      {/*
+       * Cooldown ring (SVG arc) — scales the stroke-dashoffset from full
+       * circumference to 0 as the cooldown elapses. Rendered above the
+       * button content so the visual cue is always on top.
+       */}
+      {!ready && (
+        <svg
+          width={60}
+          height={60}
+          viewBox="0 0 60 60"
+          aria-hidden
+          style={{
+            position: 'absolute',
+            inset: 0,
+            pointerEvents: 'none',
+          }}
+        >
+          <circle
+            cx={30}
+            cy={30}
+            r={26}
+            fill="none"
+            stroke={accent}
+            strokeWidth={2}
+            strokeOpacity={0.85}
+            strokeLinecap="round"
+            strokeDasharray={2 * Math.PI * 26}
+            strokeDashoffset={2 * Math.PI * 26 * (1 - ratio)}
+            transform="rotate(-90 30 30)"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/apps/web/src/components/game/activity/SpectatorCamSelector.tsx
+++ b/apps/web/src/components/game/activity/SpectatorCamSelector.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+/**
+ * SpectatorCamSelector — three-button camera-mode toggle for the
+ * spectator overlay. Spec: frontend-spec.md §7.3 (Follow / Free / Action).
+ *
+ * Chunk #11 caveat: the underlying `<BumperShellsScene>` keeps a static
+ * orthographic camera (Iris Xe perf invariant — see
+ * `bumper-shells-config.ts` CAMERA_POSITION) and does NOT actually move
+ * the camera based on the selected mode at this chunk. The selector is
+ * still wired so spectators can EXPRESS their preference; the scene-side
+ * camera follow / free-orbit / action-pick logic ships in a future
+ * chunk paired with the 3da subagent. The label "(viewport stays fixed)"
+ * makes that explicit so testers don't file bugs against the static cam.
+ */
+
+export type SpectatorCamMode = 'follow' | 'free' | 'action';
+
+export interface SpectatorCamSelectorProps {
+  mode: SpectatorCamMode;
+  onChange: (next: SpectatorCamMode) => void;
+  /** When true, hides the helper note explaining the camera stays static. */
+  hideStaticNote?: boolean;
+}
+
+const MODES: ReadonlyArray<{
+  id: SpectatorCamMode;
+  label: string;
+  glyph: string;
+  hint: string;
+}> = [
+  { id: 'follow', label: 'Follow', glyph: '◎', hint: 'Track focused player' },
+  { id: 'free',   label: 'Free',   glyph: '✦', hint: 'Orbit centroid'      },
+  { id: 'action', label: 'Action', glyph: '⚔', hint: 'Server-picked target'},
+];
+
+export default function SpectatorCamSelector({
+  mode,
+  onChange,
+  hideStaticNote = false,
+}: SpectatorCamSelectorProps) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+        pointerEvents: 'auto',
+      }}
+      role="radiogroup"
+      aria-label="Spectator camera mode"
+    >
+      <div
+        style={{
+          display: 'flex',
+          gap: 4,
+          padding: 3,
+          borderRadius: 8,
+          background: 'rgba(6, 13, 23, 0.85)',
+          border: '1px solid rgba(0, 229, 255, 0.32)',
+        }}
+      >
+        {MODES.map((m) => {
+          const active = m.id === mode;
+          return (
+            <button
+              key={m.id}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              data-hud-interactive="true"
+              onClick={() => {
+                if (!active) onChange(m.id);
+              }}
+              title={m.hint}
+              style={{
+                flex: 1,
+                minWidth: 70,
+                padding: '6px 8px',
+                background: active
+                  ? 'linear-gradient(180deg, rgba(0, 229, 255, 0.22), rgba(0, 229, 255, 0.08))'
+                  : 'transparent',
+                border: active
+                  ? '1px solid rgba(0, 229, 255, 0.6)'
+                  : '1px solid transparent',
+                borderRadius: 6,
+                color: active ? '#e0f7ff' : 'rgba(226, 232, 240, 0.78)',
+                fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: '0.12em',
+                textTransform: 'uppercase',
+                cursor: active ? 'default' : 'pointer',
+                pointerEvents: 'auto',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 2,
+                lineHeight: 1.05,
+                boxShadow: active ? '0 0 10px rgba(0, 229, 255, 0.25)' : 'none',
+                transition: 'background 120ms, box-shadow 120ms',
+              }}
+            >
+              <span style={{ fontSize: 14, lineHeight: 1 }} aria-hidden>
+                {m.glyph}
+              </span>
+              <span>{m.label}</span>
+            </button>
+          );
+        })}
+      </div>
+      {!hideStaticNote && (
+        <span
+          style={{
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            fontSize: 9,
+            color: 'rgba(148, 163, 184, 0.7)',
+            letterSpacing: '0.08em',
+            textAlign: 'center',
+          }}
+        >
+          (viewport stays fixed — chunk #12 wires camera motion)
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/game/activity/SpectatorChatPanel.tsx
+++ b/apps/web/src/components/game/activity/SpectatorChatPanel.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+/**
+ * SpectatorChatPanel — chat input + scrolling transcript scoped to the
+ * spectator-only channel. Spec: frontend-spec.md §7.4.
+ *
+ * Chunk #11 wiring:
+ *  - Send: `onSend(text)` posts a `chat` WS frame with `spectator: true`
+ *    (additive protocol field). Server-side fan-out filtering is deferred
+ *    to a future chunk; today the spectator only sees their OWN echoes
+ *    plus any other client that also tagged `spectator: true`.
+ *  - Transcript: rows from `selectSpectatorChat(state)` rendered in time
+ *    order, newest at bottom. Auto-scrolls when a new row arrives.
+ *
+ * Sized to fit inside the EliminatedOverlay panel without taking the full
+ * viewport. Fixed height with overflow-y: auto on the transcript.
+ */
+
+import { useEffect, useRef, useState, type FormEvent } from 'react';
+import type { ActivityChatMessage } from '@/stores/activity';
+
+export interface SpectatorChatPanelProps {
+  messages: ActivityChatMessage[];
+  /** Resolves a petId to a friendly display name when available. */
+  resolveName: (petId: string) => string;
+  /** Self pet id — own messages render with a distinct tint. */
+  selfPetId: string | null;
+  /** Returns true if the send succeeded (false if WS dropped, etc.). */
+  onSend: (text: string) => boolean;
+  /** Optional override for the panel max height (default 160). */
+  maxHeight?: number;
+}
+
+/** Cap on per-message length matches `clientChatFrameSchema.text.max(140)`. */
+const MAX_MESSAGE_LEN = 140;
+
+export default function SpectatorChatPanel({
+  messages,
+  resolveName,
+  selfPetId,
+  onSend,
+  maxHeight = 160,
+}: SpectatorChatPanelProps) {
+  const [draft, setDraft] = useState('');
+  const [sendError, setSendError] = useState<string | null>(null);
+  const transcriptRef = useRef<HTMLDivElement | null>(null);
+
+  // Auto-scroll to bottom when a new message arrives.
+  useEffect(() => {
+    const el = transcriptRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [messages.length]);
+
+  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const trimmed = draft.trim();
+    if (trimmed.length === 0) return;
+    if (trimmed.length > MAX_MESSAGE_LEN) {
+      setSendError(`Max ${MAX_MESSAGE_LEN} chars`);
+      return;
+    }
+    const ok = onSend(trimmed);
+    if (!ok) {
+      setSendError('Disconnected — try reconnecting');
+      return;
+    }
+    setDraft('');
+    setSendError(null);
+  }
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+        pointerEvents: 'auto',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 8,
+        }}
+      >
+        <span
+          style={{
+            fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+            fontSize: 9,
+            letterSpacing: '0.22em',
+            textTransform: 'uppercase',
+            color: 'rgba(0, 229, 255, 0.7)',
+            fontWeight: 700,
+          }}
+        >
+          Spectator Chat
+        </span>
+        <span
+          style={{
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            fontSize: 9,
+            color: 'rgba(148, 163, 184, 0.6)',
+            letterSpacing: '0.08em',
+          }}
+        >
+          ghost-only · not visible to players
+        </span>
+      </div>
+      <div
+        ref={transcriptRef}
+        style={{
+          maxHeight,
+          minHeight: 60,
+          overflowY: 'auto',
+          padding: '6px 8px',
+          borderRadius: 6,
+          background: 'rgba(2, 6, 14, 0.7)',
+          border: '1px solid rgba(0, 229, 255, 0.18)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 3,
+        }}
+      >
+        {messages.length === 0 ? (
+          <span
+            style={{
+              fontSize: 10,
+              color: 'rgba(148, 163, 184, 0.55)',
+              fontStyle: 'italic',
+              padding: '12px 4px',
+              textAlign: 'center',
+            }}
+          >
+            No spectator chatter yet — say hi.
+          </span>
+        ) : (
+          messages.map((m, i) => {
+            const isSelf = m.petId === selfPetId;
+            const isEmote = Boolean(m.emoteId);
+            return (
+              <div
+                key={`${m.at}-${i}`}
+                style={{
+                  display: 'flex',
+                  gap: 6,
+                  alignItems: 'flex-start',
+                  fontSize: 11,
+                  lineHeight: 1.3,
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                    fontSize: 9,
+                    color: 'rgba(148, 163, 184, 0.55)',
+                    flexShrink: 0,
+                    paddingTop: 1,
+                  }}
+                >
+                  {formatTime(m.at)}
+                </span>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+                    fontWeight: 700,
+                    fontSize: 10,
+                    color: isSelf ? '#86efac' : '#7dd3fc',
+                    flexShrink: 0,
+                  }}
+                >
+                  {resolveName(m.petId)}
+                </span>
+                <span
+                  style={{
+                    color: isEmote ? '#facc15' : '#e2e8f0',
+                    fontStyle: isEmote ? 'italic' : 'normal',
+                    wordBreak: 'break-word',
+                  }}
+                >
+                  {isEmote ? `* ${m.text}` : m.text}
+                </span>
+              </div>
+            );
+          })
+        )}
+      </div>
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          display: 'flex',
+          gap: 6,
+          alignItems: 'stretch',
+        }}
+      >
+        <input
+          type="text"
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            if (sendError) setSendError(null);
+          }}
+          maxLength={MAX_MESSAGE_LEN}
+          placeholder="Spectator chat…"
+          aria-label="Spectator chat message"
+          data-hud-interactive="true"
+          style={{
+            flex: 1,
+            minWidth: 0,
+            padding: '6px 10px',
+            borderRadius: 6,
+            border: '1px solid rgba(0, 229, 255, 0.4)',
+            background: 'rgba(2, 6, 14, 0.85)',
+            color: '#e0f7ff',
+            fontFamily: 'ui-sans-serif, system-ui, sans-serif',
+            fontSize: 12,
+            outline: 'none',
+            pointerEvents: 'auto',
+          }}
+        />
+        <button
+          type="submit"
+          data-hud-interactive="true"
+          disabled={draft.trim().length === 0}
+          style={{
+            padding: '6px 14px',
+            borderRadius: 6,
+            border: '1px solid rgba(0, 229, 255, 0.6)',
+            background: draft.trim().length === 0
+              ? 'rgba(15, 31, 58, 0.6)'
+              : 'linear-gradient(180deg, rgba(0, 229, 255, 0.22), rgba(0, 229, 255, 0.08))',
+            color: '#e0f7ff',
+            fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: '0.14em',
+            textTransform: 'uppercase',
+            cursor: draft.trim().length === 0 ? 'not-allowed' : 'pointer',
+            opacity: draft.trim().length === 0 ? 0.55 : 1,
+            pointerEvents: 'auto',
+          }}
+        >
+          Send
+        </button>
+      </form>
+      {sendError && (
+        <span
+          role="alert"
+          style={{
+            fontSize: 10,
+            color: '#fca5a5',
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+          }}
+        >
+          {sendError}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function formatTime(ms: number): string {
+  const d = new Date(ms);
+  const hh = d.getHours().toString().padStart(2, '0');
+  const mm = d.getMinutes().toString().padStart(2, '0');
+  const ss = d.getSeconds().toString().padStart(2, '0');
+  return `${hh}:${mm}:${ss}`;
+}

--- a/apps/web/src/components/game/activity/index.ts
+++ b/apps/web/src/components/game/activity/index.ts
@@ -3,6 +3,9 @@
  *
  * Re-exports the reusable status / score / power-up components used by
  * `<BumperShellsHud>` (chunk #4) and `<ReefRaceHud>` (chunk #6).
+ *
+ * Chunk #11 adds the spectator-mode atoms:
+ *   SpectatorCamSelector, SpectatorChatPanel, EmoteButton.
  */
 export { default as HudTile } from './HudTile';
 export type { HudTileProps, HudTileTone } from './HudTile';
@@ -23,3 +26,9 @@ export { default as EliminatedOverlay } from './EliminatedOverlay';
 export type { EliminatedOverlayProps } from './EliminatedOverlay';
 export { default as PingIndicator } from './PingIndicator';
 export type { PingIndicatorProps } from './PingIndicator';
+export { default as SpectatorCamSelector } from './SpectatorCamSelector';
+export type { SpectatorCamMode, SpectatorCamSelectorProps } from './SpectatorCamSelector';
+export { default as SpectatorChatPanel } from './SpectatorChatPanel';
+export type { SpectatorChatPanelProps } from './SpectatorChatPanel';
+export { default as EmoteButton } from './EmoteButton';
+export type { EmoteButtonProps } from './EmoteButton';

--- a/apps/web/src/components/game/bumper-shells-hud.tsx
+++ b/apps/web/src/components/game/bumper-shells-hud.tsx
@@ -8,13 +8,24 @@
  * The overall containers are pointer-events:none so 3D click-through
  * works; individual interactive bits set `pointer-events: auto` via
  * `data-hud-interactive="true"` (see PowerUpBar).
+ *
+ * Chunk #11 — spectator mode wiring:
+ *   - When self is eliminated mid-match, render the upgraded
+ *     <EliminatedOverlay> with prev/next/free-cam controls, a separate
+ *     spectator chat channel, and cheer/taunt emotes.
+ *   - Spectator state (target petId, cam mode, emote cooldowns) is held
+ *     LOCALLY here — these are per-spectator UI choices, not match state.
+ *   - The page wires `sendChat` + `sendEmote` callbacks so we can post
+ *     `chat` / `emote` WS frames without the HUD owning the WS hook.
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   useActivityStore,
   selectLeaderboard,
   selectSelfAlive,
+  selectSpectatorChat,
+  selectAliveEntities,
   type ActivityState,
 } from '@/stores/activity';
 import {
@@ -25,8 +36,28 @@ import {
   RoundCountdown,
   EliminatedOverlay,
   PingIndicator,
+  type SpectatorCamMode,
 } from './activity';
 import ActivityResultsModal from './activity-results-modal';
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/**
+ * Spectator emote cooldown — chunk #11 ships client-side rate-limit only.
+ * Server-side enforcement (per spec §7.4 "1 per 15s per spectator") will
+ * mirror this constant in a future chunk.
+ */
+const EMOTE_COOLDOWN_MS = 15_000;
+
+const CHEER_EMOTE_ID = 'cheer-clap';
+const TAUNT_EMOTE_ID = 'taunt-laugh';
+
+const EMOTE_GLYPHS: Record<string, string> = {
+  [CHEER_EMOTE_ID]: '👏 Cheer',
+  [TAUNT_EMOTE_ID]: '😈 Taunt',
+};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
 
 function formatTime(secondsRemaining: number): string {
   const s = Math.max(0, Math.round(secondsRemaining));
@@ -43,6 +74,8 @@ function useTickClock(intervalMs = 250) {
   }, [intervalMs]);
 }
 
+// ─── Public API ─────────────────────────────────────────────────────────────
+
 export interface BumperShellsHudProps {
   /** Optional callback to leave the match — page wires to navigate back. */
   onLeave?: () => void;
@@ -57,6 +90,18 @@ export interface BumperShellsHudProps {
    * Page wires this to navigate back to /game with `?quickQueue=bumper-shells`.
    */
   onPlayAgain?: () => void;
+  /**
+   * Chunk #11 — spectator chat send. Returns true on successful WS send.
+   * When omitted (legacy callers), the spectator chat input is rendered
+   * but submissions silently fail-then-error to the user.
+   */
+  sendChat?: (text: string, opts: { spectator: boolean }) => boolean;
+  /**
+   * Chunk #11 — emote send (cheers + taunts). Returns true on successful
+   * WS send. When omitted, emote buttons still cooldown locally so the
+   * UX feels responsive even without a wire.
+   */
+  sendEmote?: (emoteId: string, opts: { spectator: boolean }) => boolean;
 }
 
 export default function BumperShellsHud({
@@ -64,6 +109,8 @@ export default function BumperShellsHud({
   activityId,
   roomId,
   onPlayAgain,
+  sendChat,
+  sendEmote,
 }: BumperShellsHudProps) {
   // Re-render every 250ms so the round timer counts down smoothly without
   // requiring server frames.
@@ -84,9 +131,13 @@ export default function BumperShellsHud({
   const powerUpInventory = useActivityStore((s) => s.powerUpInventory);
   const eliminations = useActivityStore((s) => s.events.eliminations);
   const selfPetId = useActivityStore((s) => s.selfPetId);
+  const scores = useActivityStore((s) => s.scores);
+  const pushChatLocal = useActivityStore((s) => s.pushChatLocal);
 
   const leaderboard = useActivityStore((s: ActivityState) => selectLeaderboard(s, 5));
   const selfAlive = useActivityStore(selectSelfAlive);
+  const aliveEntities = useActivityStore(selectAliveEntities);
+  const spectatorChat = useActivityStore(selectSpectatorChat);
 
   // Derive round seconds remaining — server emits `endsAt` in `snapshot.init`.
   // During pregame we show the countdown; during live we show the timer.
@@ -96,6 +147,116 @@ export default function BumperShellsHud({
     selfPetId && !selfAlive
       ? eliminations.find((e) => e.petId === selfPetId) ?? null
       : null;
+
+  // ── Spectator local state (chunk #11) ──────────────────────────────────
+  const [spectatorCamMode, setSpectatorCamMode] = useState<SpectatorCamMode>('action');
+  const [spectatorTargetPetId, setSpectatorTargetPetId] = useState<string | null>(null);
+  const [cheerCooldownUntil, setCheerCooldownUntil] = useState<number | null>(null);
+  const [tauntCooldownUntil, setTauntCooldownUntil] = useState<number | null>(null);
+
+  // Auto-pick an initial spectator target when we first become a spectator
+  // (action-cam mode picks server-side per spec §7.3, but we still hold a
+  // current target so swapping to follow mode has a sane default).
+  useEffect(() => {
+    if (selfAlive) {
+      // Reset spectator state when the user is alive again (e.g. next match).
+      if (spectatorTargetPetId !== null) setSpectatorTargetPetId(null);
+      return;
+    }
+    if (aliveEntities.length === 0) return;
+    if (spectatorTargetPetId && aliveEntities.some((e) => e.petId === spectatorTargetPetId)) {
+      return;
+    }
+    // Action-cam heuristic — pick the most recently-credited eliminator,
+    // falling back to the highest-score alive pet, then to the first alive.
+    const recentElim = [...eliminations].reverse().find(
+      (e) => e.petId !== selfPetId && aliveEntities.some((a) => a.petId === e.petId),
+    );
+    if (recentElim) {
+      setSpectatorTargetPetId(recentElim.petId);
+      return;
+    }
+    type BestRef = { petId: string; score: number } | null;
+    let best: BestRef = null;
+    for (const e of aliveEntities) {
+      const s = scores.get(e.petId);
+      const score = s?.score ?? 0;
+      if (best === null || score > best.score) {
+        best = { petId: e.petId, score };
+      }
+    }
+    setSpectatorTargetPetId((best as BestRef)?.petId ?? aliveEntities[0].petId);
+  }, [selfAlive, aliveEntities, eliminations, scores, selfPetId, spectatorTargetPetId]);
+
+  // ── Spectator action callbacks ─────────────────────────────────────────
+  const cycleTarget = useCallback(
+    (direction: 1 | -1) => {
+      if (aliveEntities.length === 0) return;
+      const currentIdx = spectatorTargetPetId
+        ? aliveEntities.findIndex((e) => e.petId === spectatorTargetPetId)
+        : -1;
+      const baseIdx = currentIdx >= 0 ? currentIdx : 0;
+      const nextIdx = (baseIdx + direction + aliveEntities.length) % aliveEntities.length;
+      setSpectatorTargetPetId(aliveEntities[nextIdx].petId);
+      setSpectatorCamMode('follow');
+    },
+    [aliveEntities, spectatorTargetPetId],
+  );
+
+  const handleSelectPrev = useCallback(() => cycleTarget(-1), [cycleTarget]);
+  const handleSelectNext = useCallback(() => cycleTarget(1), [cycleTarget]);
+  const handleSelectFree = useCallback(() => {
+    setSpectatorCamMode('free');
+  }, []);
+
+  const handleSendChat = useCallback(
+    (text: string): boolean => {
+      // Always echo locally so the spectator sees their own line even if
+      // the server doesn't yet fan out a separate spectator channel.
+      pushChatLocal({
+        petId: selfPetId ?? 'you',
+        text,
+        spectator: true,
+      });
+      if (!sendChat) return true;
+      const ok = sendChat(text, { spectator: true });
+      // If the wire dropped, the local echo still stands — caller sees a
+      // disconnected banner via the network status pill.
+      return ok;
+    },
+    [pushChatLocal, selfPetId, sendChat],
+  );
+
+  const fireEmote = useCallback(
+    (emoteId: string, isCheer: boolean) => {
+      const now = Date.now();
+      // Rate-limit guard — UI also disables the button via cooldownUntil,
+      // but we double-check here in case both buttons are clicked rapidly
+      // through the keyboard.
+      if (isCheer) {
+        if (cheerCooldownUntil && cheerCooldownUntil > now) return;
+        setCheerCooldownUntil(now + EMOTE_COOLDOWN_MS);
+      } else {
+        if (tauntCooldownUntil && tauntCooldownUntil > now) return;
+        setTauntCooldownUntil(now + EMOTE_COOLDOWN_MS);
+      }
+      // Local echo into the spectator chat as a system-style row so the
+      // player gets immediate confirmation the emote fired.
+      pushChatLocal({
+        petId: selfPetId ?? 'you',
+        text: EMOTE_GLYPHS[emoteId] ?? emoteId,
+        spectator: true,
+        emoteId,
+      });
+      sendEmote?.(emoteId, { spectator: true });
+    },
+    [cheerCooldownUntil, tauntCooldownUntil, pushChatLocal, selfPetId, sendEmote],
+  );
+
+  const handleCheer = useCallback(() => fireEmote(CHEER_EMOTE_ID, true), [fireEmote]);
+  const handleTaunt = useCallback(() => fireEmote(TAUNT_EMOTE_ID, false), [fireEmote]);
+
+  const scoreLookup = useMemo(() => scores, [scores]);
 
   return (
     <>
@@ -148,30 +309,36 @@ export default function BumperShellsHud({
         )}
       </div>
 
-      {/* Top-right — placement + mini-leaderboard + alive counter */}
-      <div
-        style={{
-          position: 'absolute',
-          top: 12,
-          right: 12,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 8,
-          alignItems: 'flex-end',
-          pointerEvents: 'none',
-          zIndex: 20,
-          maxWidth: 280,
-        }}
-      >
-        <HudPlacement rank={placement} total={total} highlight={placement === 1 && matchPhase === 'live'} />
-        <HudTile
-          label="Alive"
-          value={`${alive}/${total}`}
-          tone={alive <= 2 ? 'danger' : alive <= 4 ? 'warning' : 'neutral'}
-          icon="🦞"
-        />
-        <HudMiniLeaderboard entries={leaderboard} selfId={selfPetId} max={5} />
-      </div>
+      {/*
+       * Top-right — placement + mini-leaderboard + alive counter.
+       * Hidden while the spectator overlay is active because it owns the
+       * right rail real estate (its own leaderboard atom + cam controls).
+       */}
+      {!eliminatedSelfEvent && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 12,
+            right: 12,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+            alignItems: 'flex-end',
+            pointerEvents: 'none',
+            zIndex: 20,
+            maxWidth: 280,
+          }}
+        >
+          <HudPlacement rank={placement} total={total} highlight={placement === 1 && matchPhase === 'live'} />
+          <HudTile
+            label="Alive"
+            value={`${alive}/${total}`}
+            tone={alive <= 2 ? 'danger' : alive <= 4 ? 'warning' : 'neutral'}
+            icon="🦞"
+          />
+          <HudMiniLeaderboard entries={leaderboard} selfId={selfPetId} max={5} />
+        </div>
+      )}
 
       {/* Bottom-center — power-up bar + control hint */}
       <div
@@ -239,11 +406,29 @@ export default function BumperShellsHud({
         <RoundCountdown secondsRemaining={countdownSecondsRemaining} />
       )}
 
-      {/* Eliminated overlay */}
+      {/* Eliminated/spectator overlay — chunk #11 upgrade. */}
       {matchPhase === 'live' && eliminatedSelfEvent && (
         <EliminatedOverlay
           eliminatedAt={eliminatedSelfEvent.at}
           placement={placement}
+          selfPetId={selfPetId}
+          leaderboard={leaderboard}
+          scoreLookup={scoreLookup}
+          aliveEntities={aliveEntities}
+          spectatorChat={spectatorChat}
+          roundEndsAt={roundEndsAt}
+          spectatorTargetPetId={spectatorTargetPetId}
+          spectatorCamMode={spectatorCamMode}
+          cheerCooldownUntil={cheerCooldownUntil}
+          tauntCooldownUntil={tauntCooldownUntil}
+          emoteCooldownMs={EMOTE_COOLDOWN_MS}
+          onSelectPrev={handleSelectPrev}
+          onSelectNext={handleSelectNext}
+          onSelectFree={handleSelectFree}
+          onCamModeChange={setSpectatorCamMode}
+          onSendChat={handleSendChat}
+          onCheer={handleCheer}
+          onTaunt={handleTaunt}
         />
       )}
 

--- a/apps/web/src/stores/activity.ts
+++ b/apps/web/src/stores/activity.ts
@@ -110,6 +110,27 @@ export interface MatchWinner {
   placement: number;
 }
 
+// ─── Chat / emote messages (chunk #11 spectator channel) ────────────────────
+
+/**
+ * Chat or emote message captured from a server `chat` frame. Chunk #11
+ * keeps these in a small ring buffer so the spectator overlay can render
+ * a transcript even though the server doesn't yet fan out a separate
+ * spectator channel — local-self echo only at this chunk.
+ */
+export interface ActivityChatMessage {
+  /** Wall-clock millis the message landed locally. */
+  at: number;
+  /** Sender pet id (server fills this in). */
+  petId: string;
+  /** Either chat text or rendered emote glyph + label. */
+  text: string;
+  /** When true, message belongs to the spectator-only channel. */
+  spectator: boolean;
+  /** Set when this row originated from an `emote` (cheer/taunt). */
+  emoteId?: string;
+}
+
 // ─── Store interface ────────────────────────────────────────────────────────
 
 export interface ActivityState {
@@ -149,6 +170,12 @@ export interface ActivityState {
   rewardPreview: RewardPreview | null;
   /** Last server `error` frame (HUD displays inline if set). */
   errorBanner: { code: string; message: string } | null;
+  /**
+   * Chunk #11 — chat + emote ring buffer for the spectator overlay.
+   * Stored client-side only at this chunk (server-side spectator-channel
+   * fan-out is a future chunk). The HUD reads via `selectSpectatorChat`.
+   */
+  chatLog: ActivityChatMessage[];
 
   // ── Writer API ──────────────────────────────────────────────────────────
 
@@ -163,6 +190,13 @@ export interface ActivityState {
   pushHit: (hit: BumperHitEvent) => void;
   pushElimination: (ev: BumperEliminationEvent) => void;
   clearError: () => void;
+  /**
+   * Chunk #11 — local-only chat append. Used by the HUD when the user
+   * sends a spectator chat / emote so the transcript shows immediately
+   * without waiting for the server echo (server may not echo at all
+   * until the spectator channel ships).
+   */
+  pushChatLocal: (msg: Omit<ActivityChatMessage, 'at'> & { at?: number }) => void;
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -170,6 +204,8 @@ export interface ActivityState {
 /** Trim the events.* arrays so they don't grow unbounded across a long match. */
 const HIT_RING_BUFFER = 64;
 const ELIM_RING_BUFFER = 32;
+/** Chat ring buffer size — covers a typical 90s round + spectator phase. */
+const CHAT_RING_BUFFER = 64;
 
 /** Map server `kind` strings (free-form for forward-compat) onto our enum. */
 function normalizePickupKind(raw: string): BumperPickupKind {
@@ -299,6 +335,7 @@ function emptyState(): Pick<
   | 'errorBanner'
   | 'room'
   | 'ping'
+  | 'chatLog'
 > {
   return {
     entities: new Map(),
@@ -318,6 +355,7 @@ function emptyState(): Pick<
     errorBanner: null,
     room: null,
     ping: 0,
+    chatLog: [],
   };
 }
 
@@ -345,6 +383,18 @@ export const useActivityStore = create<ActivityState>()(
       const next = get().events.eliminations.slice(-ELIM_RING_BUFFER + 1);
       next.push(ev);
       set({ events: { ...get().events, eliminations: next } });
+    },
+
+    pushChatLocal: (msg) => {
+      const next = get().chatLog.slice(-CHAT_RING_BUFFER + 1);
+      next.push({
+        at: msg.at ?? Date.now(),
+        petId: msg.petId,
+        text: msg.text,
+        spectator: msg.spectator,
+        emoteId: msg.emoteId,
+      });
+      set({ chatLog: next });
     },
 
     reset: (roomId) => {
@@ -576,9 +626,22 @@ export const useActivityStore = create<ActivityState>()(
           break;
 
         // ── Chat / pong / error ─────────────────────────────────────────
-        case 'chat':
-          // Chat surface ships in chunk #8 polish — capture for future wiring.
+        case 'chat': {
+          // Chunk #11: append to ring buffer so the spectator overlay can
+          // render a transcript. The active-player chat surface itself is
+          // not rendered yet (chunk #8 polish), but spectators MUST see at
+          // minimum their own outbound messages — captured here on echo.
+          const next = state.chatLog.slice(-CHAT_RING_BUFFER + 1);
+          next.push({
+            at: Date.now(),
+            petId: frame.petId,
+            text: frame.text,
+            spectator: Boolean(frame.spectator),
+            emoteId: frame.emote?.emoteId,
+          });
+          set({ chatLog: next });
           break;
+        }
 
         case 'pong':
           // Ping computation lives in `useActivityWs` because it tracks the
@@ -629,4 +692,27 @@ export function selectSelfAlive(state: ActivityState): boolean {
   const e = state.entities.get(state.selfPetId);
   if (!e) return true;
   return e.alive;
+}
+
+/**
+ * Chunk #11 — spectator-channel chat slice. Filters the chat ring buffer
+ * to only spectator-tagged rows (chat + emote echoes from the spectator
+ * overlay). Used by `<SpectatorChatPanel>`.
+ */
+export function selectSpectatorChat(state: ActivityState): ActivityChatMessage[] {
+  return state.chatLog.filter((m) => m.spectator);
+}
+
+/**
+ * Chunk #11 — list of currently-alive entities, used by the spectator
+ * overlay's prev/next focus cycler. Stable order by petId so cycling
+ * through is predictable across snapshot ticks.
+ */
+export function selectAliveEntities(state: ActivityState): BumperShellEntity[] {
+  const out: BumperShellEntity[] = [];
+  state.entities.forEach((e) => {
+    if (e.alive) out.push(e);
+  });
+  out.sort((a, b) => (a.petId < b.petId ? -1 : a.petId > b.petId ? 1 : 0));
+  return out;
 }

--- a/packages/shared/src/activities/protocol.ts
+++ b/packages/shared/src/activities/protocol.ts
@@ -56,11 +56,27 @@ export const clientPingFrameSchema = z.object({
 export const clientChatFrameSchema = z.object({
   type: z.literal('chat'),
   text: z.string().min(1).max(140),
+  /**
+   * Chunk #11 (spectator mode) — when `true`, the server should route
+   * this chat to spectator-only subscribers (eliminated players watching
+   * the round). When omitted/false the chat targets the active-player
+   * room channel (existing behavior). Server-side filtering is deferred
+   * to a future chunk; the client tags every spectator-channel message
+   * with `spectator: true` so the backend can split the channels later.
+   */
+  spectator: z.boolean().optional(),
 });
 
 export const clientEmoteFrameSchema = z.object({
   type: z.literal('emote'),
   emoteId: z.string().min(1).max(64),
+  /**
+   * Chunk #11 — spectator-originated emotes (cheers / taunts) tagged so
+   * the server can later choose to broadcast them above the spectated
+   * player's avatar instead of the spectator. 3D rendering of cheers is
+   * deferred to chunk #12 polish.
+   */
+  spectator: z.boolean().optional(),
 });
 
 export const clientLeaveFrameSchema = z.object({
@@ -222,7 +238,24 @@ export type ServerFrame =
       spawnId: string;
       collectorPetId: string;
     }
-  | { type: 'chat'; petId: string; text: string }
+  | {
+      type: 'chat';
+      petId: string;
+      text: string;
+      /**
+       * Chunk #11 — when `true`, indicates the chat originated on the
+       * spectator channel. Clients route to the spectator chat panel
+       * instead of the active-player chat. Backwards-compatible (legacy
+       * server emissions omit the field, treated as active-player chat).
+       */
+      spectator?: boolean;
+      /**
+       * Chunk #11 — emote channel marker. When set, the chat is the
+       * server's broadcast of an `emote` frame (cheer/taunt). Clients
+       * may render with an emote icon instead of a chat bubble.
+       */
+      emote?: { emoteId: string };
+    }
   | { type: 'pong'; sentAt: number; serverTime: number }
   | { type: 'error'; code: string; message: string };
 


### PR DESCRIPTION
## Summary

Chunk #11 of the Q2 Activity Portals — gives Bumper Shells players a real spectator UX after they're knocked off, instead of the chunk #4 dead-screen stub.

- `<EliminatedOverlay>` rebuilt: dimmed (still see-through) overlay + remaining-time header + right-side panel with prev/next/free-cam target cycler, three-mode `<SpectatorCamSelector>`, live `<HudMiniLeaderboard>` (atom reuse), separate `<SpectatorChatPanel>`, and Cheer (👏) / Taunt (😈) `<EmoteButton>` pair with 15s client cooldown.
- New atoms: `SpectatorCamSelector`, `SpectatorChatPanel`, `EmoteButton`.
- Spectator chat channel uses an additive `spectator: true` field on the existing `chat` WS frame (`packages/shared/src/activities/protocol.ts`) — protocol changes are purely additive, no breaking shape changes. Server-side fan-out filtering is deferred (today the spectator only sees their own local-echo).
- Cheer/Taunt fire `emote` WS frames with the same additive `spectator: true` flag. Server enforcement of the 15s rate-limit is deferred — chunk #11 ships client-side cooldown only.
- Store gains `chatLog` ring buffer + `pushChatLocal` action + `selectSpectatorChat` / `selectAliveEntities` selectors.

## What I punted (and why)

The spec §7.3 defines three camera modes (Follow / Free / Action). The underlying `BumperShellsScene` static OrthographicCamera is intentionally locked (`matrixAutoUpdate=false`, `CAMERA_POSITION=[0,1100,300]`) for the Iris Xe perf invariant set in chunk #4. Touching the camera would need 3da pairing per the project's MANDATORY 3D-work rule. **The selector captures the user's pick + persists local state**, but the scene-side camera-motion wiring is deferred to a 3da-paired chunk #12. The selector renders a small note explaining the viewport stays fixed so testers don't file bugs.

3D rendering of cheer/taunt glyphs above the spectated pet is also chunk #12 polish (would require new geometry — Iris Xe constraint).

## Test plan

- [ ] Manual: knock self off in a Bumper Shells match → verify the spectator overlay renders with full panel (header, cycler, leaderboard, chat, emotes), and the original top-right HUD stack is hidden so they don't collide
- [ ] Manual: prev/next cycle through alive opponents, verify "Spectating: <name>" updates
- [ ] Manual: switch to Free Cam → spectated label flips to "Free Camera"; viewport stays fixed (this is the documented punt)
- [ ] Manual: send chat message → appears in own transcript immediately; another spectator who hits the same room should see your message after server-side spectator fan-out lands (not yet wired)
- [ ] Manual: cheer + taunt — both rate-limit independently to 15s, ring + countdown display correctly
- [ ] Verify `bun run typecheck` passes
- [ ] Verify `bun run --cwd apps/web build` succeeds
- [ ] Verify `clientChatFrameSchema` and `clientEmoteFrameSchema` still accept legacy frames (omitted `spectator` field) — additive only

Plan: `.claude/plans/phase-quest-gamification-q2-activity-portals.md`
Frontend spec: `.claude/plans/q2-research/frontend-spec.md` §7
GameFeatures.md update: §19.15 (lives in main checkout — gitignored from this worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)