### PR TITLE
fix(3d): register Flying Dutchman + Pearl as proximity talk targets

### DIFF
--- a/apps/web/src/lib/three/character-positions.ts
+++ b/apps/web/src/lib/three/character-positions.ts
@@ -89,6 +89,8 @@ const CHARACTER_NAMES: Record<string, string> = {
   'skill-forge':       'Plankton',
   'channel-bridge':    'Sandy',
   'security-fortress': 'Patrick',
+  'webhook-gateway':   'Flying Dutchman',
+  'cron-hub':          'Pearl',
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bug
User reported: *"nothing happens when i go up to the salty spittoon"*

## Root cause
`CHARACTER_NAMES` in `apps/web/src/lib/three/character-positions.ts` was missing two entries:
- `webhook-gateway` (Salty Spitoon → Bumper Shells)
- `cron-hub` (Downtown Building)

Because `CHARACTER_POSITIONS` is built from `CHARACTER_NAMES` at module load, those buildings were never indexed. `findNearestCharacter()` never returned them as proximity matches, `nearLocation` never fired, and pressing **E** in NPC mode never triggered `enterBuilding()` → portal modal never opened.

## Fix
Add the two missing entries (Flying Dutchman, Pearl) to the registry.

The NPCs themselves already render correctly via `LOCATION_NPCS` in `arena-location-npcs.tsx` — this was purely a talk-target registration gap.

## Test plan
- [ ] Toggle to NPC mode, walk up to Salty Spitoon → "Press E to enter" prompt appears
- [ ] Press E → Bumper Shells lobby opens
- [ ] Walk up to Downtown Building → prompt appears
- [ ] Existing 8 buildings still work (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)