### PR TITLE
fix(build): drop unused @ts-expect-error on TownDirectorySign

### DIFF
--- a/apps/web/src/lib/three/town-directory-sign.tsx
+++ b/apps/web/src/lib/three/town-directory-sign.tsx
@@ -105,11 +105,9 @@ const plankGeo = new THREE.BoxGeometry(PLANK_W, PLANK_H, PLANK_D);
 const textPlaneGeo = new THREE.PlaneGeometry(PLANK_W - 40, PLANK_H - 40);
 
 const woodMat = new THREE.MeshBasicNodeMaterial();
-// @ts-expect-error — TSL color setter on node material
 woodMat.color = new THREE.Color(WOOD_COLOR);
 
 const textMat = new THREE.MeshBasicNodeMaterial();
-// @ts-expect-error — TSL material exposes `map` like WebGL path
 textMat.map = textTexture;
 textMat.transparent = false;
 


### PR DESCRIPTION
Hot-fix: unblock prod web builds.

Three.js types now accept `color` / `map` setters on `MeshBasicNodeMaterial` directly, so the two `@ts-expect-error` lines are flagged unused and tsc fails the production build at type-check (~240s in). Has been silently failing every web deploy since the type definitions changed; the salty-proximity + guest-pet PR deploys both hit it just now.

Verified at lines 108 + 112 of `apps/web/src/lib/three/town-directory-sign.tsx` — both directives removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)