### PR TITLE
chore(memory): persist 3da session learnings from FPS + VRM work

### DIFF
--- a/.claude/memory/threejs/MEMORY.md
+++ b/.claude/memory/threejs/MEMORY.md
@@ -78,8 +78,15 @@
 - [Staggered GPU texture uploads via initTexture()](performance/staggered-texture-upload.md) — renderer.initTexture(tex) per-frame (2/rAF) spreads 400ms+ WebP decode+upload long task; works on both WebGL r170 and WebGPU r182
 
 - [2026-04-21 perf sweep — static mesh freezing + scratch patterns](performance/perf-sweep-2026-04-21.md) — matrixAutoUpdate=false on all static scene objects; module-scope scratch vectors/matrices in hot loops; intersectObject(mesh,false) over scene traversal; distanceFactor removal from <Html>; narrowed Zustand subscriptions; gl.setPixelRatio() override removal. Est. ~4-6ms/frame saved → 60+ FPS target.
+- [Zustand re-render storm fixes (B5+B6+B7)](performance/zustand-re-render-storm-fixes.md) — useShallow on array selectors; petPositionRef module-scope + 10Hz throttled reactive write eliminates 60Hz Minimap rebuild; NPC object identity preservation in updateFromSnapshot restores React.memo bailout. (2026-04-24)
 - [Idle animation throttle to 20Hz](performance/idle-animation-throttle.md) — `(frame + seed) % 3 === 0` gate on slow procedural animations (≤1.3 rad/s); walk stays 60Hz; stagger by seed prevents batch spikes; saves ~40% trig ops on 12-30 NPC instances.
 - [VRM spring-bone physics throttle — 30Hz for idle NPCs](performance/vrm-spring-bone-throttle.md) — split VRMCharacterAnimator into updateMixerOnly (60Hz) + updateSpringOnly (30Hz idle); accumulate delta between spring ticks; walking stays full 60Hz; 50-100 spring joint ops/frame → halved for idle VRMs.
+- [VRM draw-call reductions — MToon outline off, removeUnnecessaryJoints, lookAt/expressionManager disable, skeleton.update batching](performance/vrm-draw-call-reductions.md) — 4 load/init-time techniques; halves draw calls per VRM mesh; cuts bone CPU 20-40%; eliminates 3× redundant skeleton.update calls per VRM. Do NOT apply to SpongeBob GLBs — they are not VRMs.
+
+## Gotchas (continued)
+- [VRM half-rate early-return gate kills mixer at mid-distance](gotchas/vrm-half-rate-gate-kills-mixer.md) — early-return above animator calls throttles the mixer too, not just spring bones; always gate spring-bone only, keep mixer call unconditional at 60Hz.
+- [skeleton.update restore must use Map, not index-aligned Array](gotchas/skeleton-update-array-traversal-order.md) — index-aligned Array misaligns if scene graph mutates between construction and disposal; use Map<THREE.Skeleton, fn> + Map.forEach in dispose; also `for...of map` iterates [k,v] pairs — use `.values()` to iterate functions.
+- [useLayoutEffect not useEffect for VRM property mutations — closes 1-frame R3F race](gotchas/uselayouteffect-vs-useeffect-vrm-frame-race.md) — R3F useFrame runs in rAF before useEffect fires; use useLayoutEffect to null vrm.lookAt/expressionManager before first frame paints.
 
 ## Solutions
 - [mergeGeometries dispose-after-merge is safe — data is copied](solutions/merge-geometries-dispose-order-safe.md) — mergeAttributes() uses TypedArray.set() to copy; dispose only removes GPU buffers; merged geo is independent
@@ -87,3 +94,4 @@
 - [Avatar scale-down pass 2026-04-16](solutions/avatar-scale-down-2026-04-16.md) — PET_SCALE 55→33, TARGET_NPC_HEIGHT 120→75, CHARACTER_HEIGHT 140→90, SPEED 200→320; HARD_MAX and scaleOverride must update proportionally when target heights change
 
 - [Full movement audit 2026-04-14 — screen-relative verified correct](patterns/full-movement-audit-2026-04-13.md) — screen-relative movement confirmed; camera-relative revert documented; -Z model formulas verified
+- [merged-seaweed already uses MeshBasicNodeMaterial — no Lambert swap needed](gotchas/merged-seaweed-already-meshbasic.md) — merged-seaweed.tsx uses MeshBasicNodeMaterial (zero lighting cost, cheaper than Lambert); verified 2026-04-24; B8 "Lambert swap" was already superseded.

--- a/.claude/memory/threejs/gotchas/merged-seaweed-already-meshbasic.md
+++ b/.claude/memory/threejs/gotchas/merged-seaweed-already-meshbasic.md
@@ -1,0 +1,22 @@
+---
+title: merged-seaweed already uses MeshBasicNodeMaterial — no Lambert swap needed
+category: gotcha
+tags: [seaweed, material, performance, MeshBasicNodeMaterial, Lambert]
+date: 2026-04-24
+confidence: high
+threejs_version: r170+
+---
+
+## Summary
+
+`apps/web/src/lib/three/merged-seaweed.tsx` uses `MeshBasicNodeMaterial` — not `MeshStandardMaterial`. No Lambert swap is needed.
+
+## Details
+
+The FPS plan B8 item called for "MeshStandardMaterial → MeshLambertMaterial" on merged-seaweed. When the file was read, `createSeaweedMaterial()` returns a `THREE.MeshBasicNodeMaterial` — which skips ALL lighting calculations (no diffuse model, no ambient, nothing). This is cheaper than Lambert (which still computes a diffuse dot product per fragment). The TSL `positionNode` wind animation runs regardless of material type.
+
+No code change was needed. The file was already at the correct material class.
+
+## Context
+
+Verified 2026-04-24 during Pod 2+3 implementation pass. If future sessions suggest swapping seaweed material, check this first — the material is already optimal.

--- a/.claude/memory/threejs/gotchas/skeleton-update-array-traversal-order.md
+++ b/.claude/memory/threejs/gotchas/skeleton-update-array-traversal-order.md
@@ -1,0 +1,36 @@
+---
+title: skeleton.update restore must use Map keyed on Skeleton, not index-aligned Array
+category: gotcha
+tags: [skeleton, vrm, dispose, scene-graph, traversal-order]
+date: 2026-04-24
+confidence: high
+threejs_version: r170+
+---
+
+## Summary
+`dispose()` that re-walks the scene to restore `skeleton.update` using an index-aligned `Array<fn>` will silently restore the wrong function if any scene graph mutation happened between construction and disposal.
+
+## Details
+The Verse Engine skeleton-batching pattern (cache original `skeleton.update` per unique skeleton, replace with no-op, call once manually per frame) was originally implemented with an `Array<() => void>`. `dispose()` re-traversed `vrm.scene` a second time with a fresh `seenSkeletons` Set and incremented `fnIdx` to pair each skeleton with the cached function.
+
+Problem: if any reparenting, node removal, or insertion happens between construction and disposal, the second traversal visits skeletons in a different order. `fnIdx` misaligns — skeleton A gets skeleton B's original function restored, or a skeleton is skipped entirely (leaving its `update` permanently as the no-op). The bug is silent: no error, the skeleton just never gets updated.
+
+Fix: use `Map<THREE.Skeleton, () => void>` keyed by the skeleton object itself.
+```ts
+private _skeletonUpdateFns: Map<THREE.Skeleton, () => void> = new Map();
+
+// constructor — replace Array push:
+this._skeletonUpdateFns.set(sm.skeleton, sm.skeleton.update.bind(sm.skeleton));
+
+// iterate in update/updateMixerOnly:
+for (const fn of this._skeletonUpdateFns.values()) fn();
+
+// dispose — no traversal needed:
+this._skeletonUpdateFns.forEach((fn, skel) => { skel.update = fn; });
+this._skeletonUpdateFns.clear();
+```
+
+Also: when `for...of` a Map, it iterates `[key, value]` pairs. Call `.values()` to iterate just the functions. Calling `for (const fn of map) fn()` passes a `[key, value]` tuple to `fn`, which is a runtime crash.
+
+## Context
+Surfaced during Sakura's code review of the VRM wanderer PR (commit 51a022e). Applicable to any pattern that caches per-object functions for later restoration.

--- a/.claude/memory/threejs/gotchas/uselayouteffect-vs-useeffect-vrm-frame-race.md
+++ b/.claude/memory/threejs/gotchas/uselayouteffect-vs-useeffect-vrm-frame-race.md
@@ -1,0 +1,35 @@
+---
+title: useLayoutEffect not useEffect for VRM property mutations — closes 1-frame R3F race
+category: gotcha
+tags: [vrm, react, useLayoutEffect, useEffect, r3f, frame-race]
+date: 2026-04-24
+confidence: high
+threejs_version: r170+
+---
+
+## Summary
+Using `useEffect` to null/mutate VRM properties (e.g. `vrm.lookAt`, `vrm.expressionManager`) leaves a 1-frame race window where R3F's `useFrame` loop runs `vrm.update()` BEFORE the mutation fires.
+
+## Details
+R3F's frame loop runs inside a `requestAnimationFrame` callback. React's `useEffect` fires after the browser has painted — meaning on the first frame after mount, `vrm.update()` processes `lookAt` and `expressionManager` before the `useEffect` null-assignment has had a chance to run.
+
+`useLayoutEffect` runs synchronously after React commits DOM mutations and BEFORE the browser paints. The R3F frame loop (rAF) is scheduled after the paint, so `useLayoutEffect` fires before any frame can call `vrm.update()`.
+
+```tsx
+// WRONG — 1-frame race:
+useEffect(() => {
+  (vrm as any).lookAt = null;
+  (vrm as any).expressionManager = null;
+}, [vrm]);
+
+// CORRECT — closes the race:
+useLayoutEffect(() => {
+  (vrm as any).lookAt = null;
+  (vrm as any).expressionManager = null;
+}, [vrm]);
+```
+
+The dependency array is identical — only the hook name changes.
+
+## Context
+Surfaced in Sakura's review of the VRM wanderer PR. Applies to any one-time property mutation on a Three.js object that must be in effect before the first render frame. The `vrm.lookAt` and `vrm.expressionManager` fields have no `dispose()` method in three-vrm 3.5.2 — setting to `null` (not `undefined`) is the correct way to disable them.

--- a/.claude/memory/threejs/gotchas/vrm-facing-atan2-sign-error.md
+++ b/.claude/memory/threejs/gotchas/vrm-facing-atan2-sign-error.md
@@ -1,0 +1,65 @@
+---
+title: VRM velocity-facing formula must be atan2(-vx, -vz) not atan2(vx, -vz)
+category: gotcha
+tags: [vrm, facing, atan2, rotation, arena-npcs, velocity, milady]
+date: 2026-04-24
+confidence: high
+threejs_version: r170+
+---
+
+## Summary
+
+`Math.atan2(vx, -vz)` as the VRM facing formula inverts east/west facing — the
+NPC faces the REVERSE of its travel direction when vx != 0. The correct formula
+is `Math.atan2(-vx, -vz)`.
+
+## Details
+
+VRM models face -Z at `rotation.y = 0` (after `VRMUtils.rotateVRM0` in vrm-loader.ts).
+
+Three.js uses a **right-hand coordinate system** with **CCW positive Y rotation**
+viewed from above. Consequence: rotating a -Z-facing model by +π/2 around Y brings
+it to face **-X**, NOT +X.
+
+### Worked example — NPC moving +X (vx=+1, vz=0)
+
+We want `rotation.y = -π/2` so the -Z face rotates 90° CW to align with +X.
+
+```
+atan2(vx=1,  -vz=0) = +π/2  ← WRONG — faces -X (away from travel)
+atan2(-vx=-1, -vz=0) = -π/2  ← CORRECT — faces +X (along travel)
+```
+
+### General derivation
+
+For a -Z-forward model to face direction (vx, vz):
+
+```
+The -Z world direction under rotation θ is: (-sin(θ), 0, -cos(θ))
+We want: -sin(θ) ∝ vx  and  -cos(θ) ∝ vz
+→ sin(θ) = -vx / |v|,  cos(θ) = -vz / |v|
+→ θ = atan2(sin(θ), cos(θ)) = atan2(-vx, -vz)  ✓
+```
+
+### GLB path is different — do NOT negate there
+
+GLB crustaceans (lobster, hermitcrab, sweet_crab, etc.) face **+Z** at rest.
+Their facing formula `Math.atan2(glbVx, glbVz)` is correct and must NOT be
+changed. The VRM path and GLB path in `arena-npcs.tsx` are separate branches.
+
+## Context
+
+Bug surfaced 2026-04-24 when user reported "Miladys walk backwards". The previous
+formula `atan2(vx, -vz)` was introduced during the velocity-driven facing rewrite
+(2026-04-23) as an intuitive-but-wrong conversion of the "VRM faces -Z" statement.
+
+The fix is a one-character change on line ~935 of
+`apps/web/src/lib/three/arena-npcs.tsx`:
+```ts
+// Before (wrong):
+const targetRot = Math.atan2(vx, -vz);
+// After (correct):
+const targetRot = Math.atan2(-vx, -vz);
+```
+
+The rotation lerp block (`diff` normalisation + `12*dt` slerp) is unchanged.

--- a/.claude/memory/threejs/gotchas/vrm-half-rate-gate-kills-mixer.md
+++ b/.claude/memory/threejs/gotchas/vrm-half-rate-gate-kills-mixer.md
@@ -1,0 +1,37 @@
+---
+title: VRM half-rate early-return gate kills mixer at mid-distance
+category: gotcha
+tags: [vrm, animation, mixer, performance, throttle, early-return]
+date: 2026-04-24
+confidence: high
+threejs_version: r170+
+---
+
+## Summary
+An early-return gate meant to throttle spring-bone updates accidentally kills the entire useFrame including the mixer update, halving keyframe frame rate at mid-distance.
+
+## Details
+Pattern that looks reasonable but is broken:
+```ts
+if (camDistSq > HALF_RATE_DIST_SQ && (frame + seed) % 2 !== 0) {
+  return; // WRONG: also kills mixer.update below
+}
+// ...
+animator.updateMixerOnly(dt, isMoving); // never runs on odd mid-dist frames
+```
+
+The early-return is placed above the animator call, so the mixer only runs every other frame when the NPC is at mid-distance. Result: 30Hz keyframe animation with visible jank. Nori (town-guide.tsx) never had this gate and runs at 60Hz unconditional.
+
+Fix: remove the early-return entirely. Tier the spring-bone throttle instead:
+```ts
+// Mixer is ALWAYS 60Hz
+animator.updateMixerOnly(dt, isMoving);
+// Spring-bone is tiered: close=30Hz, mid-dist=15Hz
+const springMod = camDistSq > HALF_RATE_DIST_SQ ? 4 : 2;
+if ((frame + seed) % springMod === 0) {
+  animator.updateSpringOnly(acc);
+}
+```
+
+## Context
+arena-npcs.tsx VRMNpcMesh, B9 fix 2026-04-24. The split between mixer (60Hz) and spring (30Hz) was correct in intent, but the early-return gate was placed before both calls instead of only gating the spring call.

--- a/.claude/memory/threejs/patterns/fbx-loader-parallel-clips.md
+++ b/.claude/memory/threejs/patterns/fbx-loader-parallel-clips.md
@@ -1,0 +1,109 @@
+---
+title: FBXLoader parallel multi-file clip extraction pattern
+category: pattern
+tags: [fbx, FBXLoader, AnimationMixer, AnimationClip, Mixamo, SkeletonUtils, React19]
+date: 2026-04-23
+confidence: medium
+threejs_version: r170+
+---
+
+## Summary
+
+Loading a Mixamo-rigged FBX character with N separate animation FBX files (one clip per file) — module-scope parallel `Promise.all`, clip renaming, `SkeletonUtils.clone`, `AnimationMixer` with `LoopOnce` pose holding. React 19 `use()` for suspension.
+
+## Details
+
+### Load pattern
+
+```typescript
+// Module scope — kick ALL loads on first import, no rAF deferral needed (single component)
+const _assetsPromise: Promise<GuideAssets> = (async () => {
+  const loader = new FBXLoader();
+  const [character, ...animFbxs] = await Promise.all([
+    loader.loadAsync('/models/guide-rigged.fbx'),
+    ...ANIM_PATHS.map((p) => loader.loadAsync(p)),
+  ]);
+  animFbxs.forEach((fbx, i) => {
+    if (fbx.animations[0]) {
+      fbx.animations[0].name = CLIP_NAMES[i]; // Mixamo default name is "mixamo.com"
+      clips.push(fbx.animations[0]);
+    }
+  });
+  character.animations = clips;   // attach so SkeletonUtils.clone carries them
+  return { template: character, clips };
+})();
+```
+
+### React 19 suspension
+
+```typescript
+// Inside memo component — suspends until promise resolves
+const { template, clips } = use(_assetsPromise);
+```
+
+Works cleanly with Next.js 15 App Router + `'use client'` + `<Suspense fallback={null}>`.
+
+### Skeleton clone + AnimationMixer
+
+```typescript
+const cloned = useMemo(() => {
+  const c = skeletonClone(template) as THREE.Group;
+  c.traverse(obj => { obj.frustumCulled = false; }); // MANDATORY for SkinnedMesh
+  return c;
+}, [template]);
+
+const mixer = useMemo(() => new THREE.AnimationMixer(cloned), [cloned]);
+```
+
+After `SkeletonUtils.clone`, the cloned group does NOT carry its own `AnimationClip` copies — clips are shared data. FBXLoader writes bone-name-based tracks (not UUID), so `mixer.clipAction(clip, cloned)` resolves correctly from the cloned skeleton by bone name. This is the standard Three.js Mixamo pattern.
+
+### Single-frame pose hold (1-frame FBX)
+
+```typescript
+const action = mixer.clipAction(idleClip, cloned);
+action.setLoop(THREE.LoopOnce, 1);
+action.clampWhenFinished = true;  // stay at last frame
+action.timeScale = 0;             // don't advance — hold at frame 0
+action.weight = 1.0;
+action.play();
+```
+
+### Wave crossfade (click → play once → return)
+
+```typescript
+// On click:
+wave.reset(); wave.enabled = true; wave.weight = 0; wave.play();
+idle.crossFadeTo(wave, FADE, false);
+
+// On 'finished':
+idle.enabled = true; idle.weight = 1;
+wave.crossFadeTo(idle, FADE, false);
+```
+
+### Mixer update in useFrame
+
+```typescript
+useFrame(({ clock }, delta) => {
+  mixer.update(delta);
+  // Procedural breathing additive over mixer (mixer only writes rotation/position from Mixamo):
+  if (spineBone) spineBone.scale.y = 1 + Math.sin(clock.elapsedTime * 1.8) * 0.008;
+});
+```
+
+### Cleanup
+
+```typescript
+mixer.stopAllAction();
+mixer.uncacheRoot(cloned);
+// Dispose cloned geometry + materials — NOT the shared AnimationClip objects
+```
+
+## Context
+
+First FBX usage in ClawVille. Used in `town-guide.tsx` for the Mixamo-rigged anime guide at world center south (z=+240). 11 animation FBX files (one Mixamo clip each) loaded in parallel into a single module-scope Promise.
+
+## Caveats
+
+- **FBX embedded textures**: FBXLoader extracts embedded textures into `THREE.Texture` objects. Works in most browsers. If character renders flat/black, textures failed to embed — add a MeshStandardMaterial fallback on SkinnedMesh nodes.
+- **FBX file size on Iris Xe**: total ~5-6MB of FBX to parse. FBX is text-parsed (the binary variant) — more CPU-intensive than glTF. On Iris Xe this runs fine as a single character load; the parse happens off the main thread via the Loader's internal callback chain. First-visit parse takes ~1-2s; Suspense hides the stall.
+- **Clip bone-name resolution**: `mixer.clipAction(clip, cloned)` needs bone names in tracks to match the cloned skeleton's bone names. Mixamo exports with `mixamorig:*` names which match between character FBX and animation FBXs — resolution works automatically. If you mix non-Mixamo clips, you'll need a bone-name rewrite step.

--- a/.claude/memory/threejs/patterns/procedural-skirt-bone-parenting.md
+++ b/.claude/memory/threejs/patterns/procedural-skirt-bone-parenting.md
@@ -1,0 +1,40 @@
+---
+title: Procedural skirt mesh parented to hip bone on SkinnedMesh rig
+category: pattern
+tags: [skinned-mesh, bone, procedural-geometry, cloth, skirt, SkeletonUtils]
+date: 2026-04-22
+confidence: high
+threejs_version: r170+
+---
+
+## Summary
+Attach a CylinderGeometry cone mesh directly to a SkinnedMesh's hip bone so it follows the bone's world transform without any custom shader or simulation.
+
+## Details
+
+```ts
+// After SkeletonUtils.clone(gltfScene):
+clone.traverse((obj) => {
+  if ((obj as THREE.Bone).isBone && obj.name === 'Hips_04') {
+    const skirtMesh = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.08, 0.25, 0.42, 20, 1, true), // open=true = no caps
+      new THREE.MeshStandardMaterial({ color: 0x1e3a5f, side: THREE.DoubleSide })
+    );
+    // Hang below hip joint. Y sign depends on rig convention:
+    //   guide.glb uses +Y-up spine, so -Y hangs toward feet.
+    skirtMesh.position.set(0, -0.22, 0); // half the skirt height ≈ 0.42/2
+    skirtMesh.name = 'ProceduralSkirt';
+    obj.add(skirtMesh); // bone.add() — follows bone transform every frame
+  }
+});
+```
+
+Key notes:
+- Works in native model-space units (guide.glb is in meters at scale=1). Scale the parent group to 100 to get ~149wu.
+- `open=true` skips the top/bottom caps, looks like fabric instead of a bucket.
+- `DoubleSide` is required because looking up from below would see back faces.
+- Dispose: the geometry/material are module-scope singletons — do NOT dispose them in the unmount cleanup. Only the mesh itself is per-instance.
+- Do NOT use `SkinnedMesh` for the skirt itself — it only needs to follow the parent bone rigidly; no vertex weight binding needed.
+
+## Context
+Used in `town-guide.tsx` for the town-center guide character. The GLB's cloth material (coat/pants/scarf) has `opacity=0`; a procedural skirt is the only safe way to add minimal clothing without editing the asset.

--- a/.claude/memory/threejs/patterns/reef-race-scene.md
+++ b/.claude/memory/threejs/patterns/reef-race-scene.md
@@ -1,0 +1,61 @@
+---
+title: Reef Race 3D scene — per-client chase-cam + track + ghost
+category: pattern
+tags: [reef-race, chase-cam, TubeGeometry, CatmullRomCurve3, InstancedMesh, ghost, activity]
+date: 2026-04-23
+confidence: high
+threejs_version: r170+
+---
+
+## Summary
+
+Full scene architecture for the Reef Race activity. Key decisions: per-client chase-cam (one frustum), TubeGeometry track (radialSegs=4), merged checkpoint gates, InstancedMesh pickups with zero-scale hiding.
+
+## Details
+
+### Chase-cam
+- One PerspectiveCamera per client, follows self player only.
+- `CAMERA_OFFSET = (0, 200, -350)` in player-local space; rotated by player heading each frame.
+- Lerp factor: `lerpFactor = Math.min(1, 5.0 * delta)` — smooth without overshoot.
+- No OrbitControls — fully procedural in `useFrame`.
+- Module-scope scratch vectors (`_targetPos`, `_camPos`, `_lookAt`, `_rotatedOffset`) — no per-frame allocations.
+
+### Track
+- `TubeGeometry(CatmullRomCurve3, 200, 150, 4, true)` — radialSegs=4 keeps quad count minimal.
+- Guardrails: 64 segment BoxGeometry slices per side, `applyMatrix4()` for world position, then `mergeGeometries()` → 2 draw calls.
+- DO NOT create a `THREE.Mesh` just to get a matrix — compute `Matrix4.compose(pos, quat, scale)` directly, avoids TS BoxGeometry type constraint.
+- Coral decorations: 3 InstancedMesh (one per GLB type), seed-based deterministic placement.
+
+### Checkpoint gates
+- All 18 geometry pieces (2 pillars + 1 bar per gate) merged by material color → 2 draw calls.
+- `mergeGeometries()` from `three/examples/jsm/utils/BufferGeometryUtils.js` — dispose input geos after merge (data is copied, safe per solutions/merge-geometries-dispose-order-safe.md).
+
+### Ghost kart
+- `SkeletonUtils.clone()` + immediate `frustumCulled=false` traverse.
+- Semi-transparent: traverse all mesh children, `material.clone()`, set `transparent=true`, `opacity=0.45`.
+- 10Hz GhostFrame[] path — linear interpolation with ring-buffer-aware sequential scan (O(1) amortized).
+- Path looped with modulo: `ghostMs = path[0].t + (elapsedMs % pathDuration)`.
+- `drei <Html>` label — no `distanceFactor` (causes per-frame recompute).
+
+### Pickup boxes
+- `InstancedMesh(BoxGeometry, MeshStandardMaterial, 16)` — safe on WebGPU.
+- Hidden via `mesh.setMatrixAt(i, zeroScaleMatrix)` — instance stays in draw call, just invisible.
+- `mesh.rotation.y += delta * 0.8` — 1 mutation for all 16 instances per frame.
+- Canvas texture created at module scope (not per-mount): `getPickupTexture()` pattern.
+
+### Boost FX
+- Trail: pre-allocated `BufferGeometry` with `TRAIL_MAX_POINTS * 2` vertices (ribbon quad strip).
+  Ring buffer head advances per frame; positions mutated in-place, `posAttr.needsUpdate = true`.
+- Speed cones: `InstancedMesh(CylinderGeometry, MeshBasicNodeMaterial, 12)`.
+  TSL `opacityNode: sin(time.mul(8).add(instanceIndex.toFloat().mul(0.5))).mul(0.5).add(0.5)`.
+  Wrap in try/catch — `instanceIndex` TSL node may not be available in all build contexts; degrade to `mat.opacity = 0.5`.
+
+### Store extension (additive)
+- Add `reefRace: ReefRaceState` field to ActivityState.
+- Add `reefRace` to `emptyState()` pick list.
+- `event.lap_completed` case was a no-op — update it to push into `reefRace.laps`.
+- `pushLap()` and `setGhostPath()` actions added.
+
+## Context
+Shipped in chunk #6 of Q2 Activity Portals. Pairs with chunk #5 (sim, PR #23).
+Performance: ≤70 draw calls, ≤220k tris, 1×512² shadow, 0 post-processing.

--- a/.claude/memory/threejs/patterns/route-isolated-activity-scene.md
+++ b/.claude/memory/threejs/patterns/route-isolated-activity-scene.md
@@ -1,0 +1,59 @@
+---
+title: Route-isolated activity scene pattern (Bumper Shells / Reef Race)
+category: pattern
+tags: [activity, scene, isolation, webgpu, orthographic, particle-pool, canvas-key]
+date: 2026-04-23
+confidence: high
+threejs_version: r170+
+---
+
+## Summary
+
+Pattern for route-isolated R3F scenes in Next.js for minigame activities, sharing no GPU state with the open world.
+
+## Details
+
+### Route isolation
+- Activity scenes live at `/activity/:activityId/:roomId` — separate Next.js route unmounts the open world.
+- `key={roomId}` on `<Canvas>` forces full WebGPU context recreation between rooms (guards StrictMode double-mount).
+- No imports between `apps/web/src/lib/three/` (world) and `apps/web/src/lib/three/activities/`.
+
+### Static orthographic camera (Bumper Shells)
+- `OrthographicCamera` configured in a `useEffect` inside a child component (not via Canvas `camera` prop).
+- `camera.matrixAutoUpdate = false` after `lookAt()` + `updateMatrix()` — zero per-frame camera matrix work.
+- Config: `left=-700, right=700, near=1, far=1500`, position `(0, 1100, 300)`, lookAt `(0,0,0)`.
+- This sidesteps Iris Xe's multi-frusta shadow ceiling for 8 players (one fixed frustum = one shadow pass).
+
+### Module-scope particle burst pool
+- Pool size at module scope (not React state) — `triggerBurst()` is imperative, callable outside React.
+- Pre-compute random spread directions at module load — no per-burst RNG.
+- `Float32BufferAttribute` mutated in-place; `needsUpdate=true` per active slot.
+- Pool of 4 slots × 16 Points = 64 particles max (Iris Xe fragment budget constraint).
+- Steal oldest slot when all active (vs. dropping the burst).
+
+### Static mesh freeze pattern
+Every static mesh: `mesh.matrixAutoUpdate = false; mesh.updateMatrix()` in `useEffect(() => {}, [])`.
+For InstancedMesh: `instanceMatrix.needsUpdate = true` after all `setMatrixAt()` calls, then freeze.
+
+### Html pickup labels
+- NO `distanceFactor` — causes per-frame camera-distance recompute (perf-sweep 2026-04-21 Pattern E).
+- Label visibility toggled via `labelRef.current.style.display` imperatively in useFrame.
+- NOT via React state or `group.visible` (drei Html ignores parent visible).
+
+### InstancedMesh safety note
+- `InstancedMesh + MeshStandardMaterial` = SAFE on WebGPU.
+- `InstancedMesh + ShaderMaterial` = SILENT BLANK CANVAS on WebGPU. Never use ShaderMaterial with InstancedMesh.
+
+### PreCompilePipelines placement
+- Must be the LAST child inside SceneContents (after all meshes are in the scene).
+- Same pattern as World3DCanvas.tsx: `useEffect(() => { rAF(() => { gl.compileAsync(scene, camera) }) })`.
+
+### Store coordination contract
+- Scene reads `Map<petId, entity>` for O(1) useFrame lookup — NOT array.find().
+- High-frequency WS state lives in a separate `@/stores/activity` (not polluting `game.ts`).
+- Scene is READER only; WS hook (general-purpose) is the WRITER.
+
+## Context
+
+Bumper Shells (chunk #4, 2026-04-23). Same pattern applies to Reef Race (chunk #6).
+See `apps/web/src/lib/three/activities/bumper-shells/` for full implementation.

--- a/.claude/memory/threejs/patterns/spectator-camera-modes.md
+++ b/.claude/memory/threejs/patterns/spectator-camera-modes.md
@@ -1,0 +1,101 @@
+---
+title: Spectator camera modes — follow/free/action in activity scenes
+category: pattern
+tags: [camera, spectator, OrbitControls, PerspectiveCamera, bumper-shells, activity]
+date: 2026-04-23
+confidence: medium
+threejs_version: r170+
+---
+
+## Summary
+
+Activity scenes that need spectator cameras (follow / free orbit / action auto-target)
+use a dual-canvas strategy: active play uses the static ortho canvas, spectators get
+a PerspectiveCamera canvas. ONE camera per client — no extra shadow frusta.
+
+## Details
+
+### Key architectural decision
+
+R3F Canvas `orthographic` prop is STATIC — cannot swap between ortho/perspective after
+mount. Solution: branch on `spectatorCamMode` prop to render different `<Canvas>` elements.
+Use `key={roomId + '-' + mode}` on Canvas to force context recreation on mode switches.
+
+```tsx
+if (spectatorCamMode) {
+  return (
+    <Canvas key={`${roomId}-${spectatorCamMode}`}
+      camera={{ fov: 55, near: 1, far: 1500, position: [0, 900, 600] }}
+      shadows gl={{ antialias: false }} dpr={[1, 1.5]}>
+      <SpectatorCamera mode={spectatorCamMode} targetPetId={spectatorTargetPetId} entities={entities} />
+      {/* ... rest of scene ... */}
+    </Canvas>
+  );
+}
+// Active play: static ortho canvas
+return <Canvas orthographic ...>
+```
+
+### SpectatorCamera component
+
+Module-scope scratch vectors (zero allocations):
+```ts
+const _camTargetPos  = new THREE.Vector3();
+const _camDesiredPos = new THREE.Vector3();
+const _camLookAt     = new THREE.Vector3();
+const _entityPos     = new THREE.Vector3();
+const FOLLOW_OFFSET  = new THREE.Vector3(0, 400, 350); // above + behind
+```
+
+Frame-rate independent lerp: `alpha = 1 - Math.exp(-CAMERA_LERP_ALPHA * dt)` where
+`CAMERA_LERP_ALPHA = 4.0`.
+
+OrbitControls for 'free' mode — created/disposed on mode change in useEffect:
+```ts
+useEffect(() => {
+  if (mode === 'free') {
+    const oc = new OrbitControls(camera, gl.domElement);
+    oc.minDistance = 600; oc.maxDistance = 1500; oc.enablePan = false;
+    orbitRef.current = oc;
+  } else {
+    orbitRef.current?.dispose();
+    orbitRef.current = null;
+  }
+  return () => { orbitRef.current?.dispose(); };
+}, [mode, camera, gl]);
+```
+
+'action' mode retargets every 3s to alive entity closest to arena center:
+```ts
+actionTimerRef.current += dt;
+if (actionTimerRef.current >= 3.0) {
+  let bestDist = Infinity;
+  for (const e of entities.values()) {
+    if (!e.alive) continue;
+    const distSq = e.x * e.x + e.y * e.y;
+    if (distSq < bestDist) { bestDist = distSq; bestId = e.petId; }
+  }
+  actionTargetRef.current = bestId;
+  actionTimerRef.current = 0;
+}
+```
+
+### Props added to BumperShellsScene
+
+```ts
+export type SpectatorCamMode = 'follow' | 'free' | 'action';
+
+export interface BumperShellsSceneProps {
+  roomId: string;
+  selfPetId?: string | null;
+  spectatorCamMode?: SpectatorCamMode;         // undefined = active-play static ortho
+  spectatorTargetPetId?: string | null;         // 'follow' mode target
+}
+```
+
+## Context
+
+Bumper Shells arena (chunk #12a). Spec: `3d-spec.md §1.5`. The static ortho camera must
+be preserved for active players — Iris Xe perf budget assumes one fixed frustum. Spectators
+only need a camera switch after elimination, which is when they have a UI overlay showing.
+The SpectatorCamSelector UI (3 buttons) is owned by the non-3D agent and passes the mode prop.

--- a/.claude/memory/threejs/performance/idle-animation-throttle.md
+++ b/.claude/memory/threejs/performance/idle-animation-throttle.md
@@ -1,0 +1,42 @@
+---
+title: Idle animation throttle — 20Hz for slow procedural animations
+category: performance
+tags: [useFrame, throttle, procedural-animation, NPC, sin, trig, CPU-bound]
+date: 2026-04-23
+confidence: high
+threejs_version: r170+
+---
+
+## Summary
+
+Throttle slow procedural idle animations to 20Hz using `(frame + seed) % 3 === 0` — imperceptible visually, saves ~40% trig ops for large NPC counts.
+
+## Details
+
+When a scene is CPU-bound (hiding 90% of geometry gives only +3 FPS), the bottleneck is per-frame JS work in useFrame hooks, not GPU draw calls.
+
+**Pattern:** Idle animation functions that evaluate multiple Math.sin/cos calls at low frequencies (≤1.3 rad/s ≈ 0.21 Hz) can be safely throttled to 20Hz. Walk animations that use fast squash/stretch (8 rad/s bob cycle) need full 60Hz.
+
+**Gate condition:**
+```typescript
+const frame = Math.floor(clock.elapsedTime * 60); // already computed for raycasts
+if ((frame + seed) % 3 === 0) {
+  applyIdleAnimation({ ... });
+}
+```
+
+**Why `seed` matters:** Without stagger, all 12 location NPCs update on the same 3-frame slot → CPU spike every 50ms instead of smooth 1 NPC/frame spread.
+
+**Applied in ClawVille:**
+- `arena-location-npcs.tsx NpcMesh.useFrame`: `applyStationaryIdleAnimation` → 20Hz
+- `arena-npcs.tsx GLBNpcMesh.useFrame`: `applyIdleAnimation` (idle state only) → 20Hz
+- Walk `applyWalkAnimation` stays at 60Hz
+- AnimationMixer (Pearl Krabs) stays at 60Hz (pose discontinuities if skipped)
+
+**Cost math:** 12 location NPCs × 5 sin calls × 60fps = 3600 trig ops/sec → 1200/sec at 20Hz. Saves 2400 trig evaluations/second.
+
+**Nyquist check:** animation max frequency = 1.3 rad/s. To avoid aliasing: sample > 2 × max_freq = 2.6 Hz. 20Hz provides 48× margin.
+
+## Context
+
+ClawVille 2026-04-23 perf iteration. CDP baseline was 26 FPS (CPU-bound confirmed by A/B: hiding 3186 meshes only +3 FPS). Applied after confirming the scene had no more cheap GPU wins.

--- a/.claude/memory/threejs/performance/perf-sweep-2026-04-21.md
+++ b/.claude/memory/threejs/performance/perf-sweep-2026-04-21.md
@@ -1,0 +1,135 @@
+---
+title: 2026-04-21 Comprehensive Perf Sweep — 14 three/ files
+category: performance
+tags: [matrixAutoUpdate, scratch-objects, raycast, Html, Zustand, dpr, particle-system, useFrame]
+date: 2026-04-21
+confidence: high
+threejs_version: r170+
+---
+
+## Summary
+
+Full audit of every file in `apps/web/src/lib/three/` and `apps/web/src/components/three/` against 13 known R3F/Three.js performance patterns. Baseline ~50 FPS on Intel Iris Xe; target 60+ FPS floor.
+
+## Details
+
+### Pattern A — matrixAutoUpdate=false on static meshes
+
+The following objects never move at runtime and were missing the freeze:
+
+| File | Objects frozen |
+|---|---|
+| `bounty-board-object.tsx` | 2 posts, crossbar, hitbox (4 meshes) |
+| `arena-terrain.tsx` | 80 SingleDecoration groups + all traversed cloned children |
+| `underwater-atmosphere.tsx` | CausticPlane mesh, DepthBackdrop mesh, DustParticles Points |
+| `underwater-light-rays.tsx` | 7 LightRay cone meshes |
+| `auction-podium.tsx` (rewritten 2026-04-24) | Dome GLB + jellyfish GLB replace old stepped cylinders. `matrixAutoUpdate=false` applied via traverse on clone in `bazaar-stall.tsx` and `marketplace-stall.tsx` too. |
+| ~~`bazaar-pedestals.tsx`~~ | DELETED 2026-04-24 — replaced by `bazaar-stall.tsx` (fish market GLB) and `marketplace-stall.tsx` (food stall GLB). |
+
+Pattern for each:
+```typescript
+const meshRef = useRef<THREE.Mesh>(null);
+useEffect(() => {
+  if (meshRef.current) {
+    meshRef.current.matrixAutoUpdate = false;
+    meshRef.current.updateMatrix();
+  }
+}, []);
+```
+
+For groups with children (arena-terrain decorations):
+```typescript
+groupRef.current.matrixAutoUpdate = false;
+groupRef.current.updateMatrix();
+groupRef.current.traverse((obj) => {
+  obj.matrixAutoUpdate = false;
+  (obj as THREE.Mesh).updateMatrix?.();
+});
+```
+
+### Pattern B — Raycast scope (arena-location-npcs.tsx)
+
+`getTerrainY()` was calling `intersectObjects(scene.children, true)` — scene-wide traversal on every location NPC raycast tick (every 3rd frame, 10 NPCs).
+
+Fix: added `_locCachedTerrainMesh` module-scope cache + `findLocTerrainMesh(scene)` with early-exit on first mesh found (same pattern as arena-npcs.tsx had already).
+
+```typescript
+let _locCachedTerrainMesh: THREE.Object3D | null = null;
+function findLocTerrainMesh(scene: THREE.Scene): THREE.Object3D | null {
+  if (_locCachedTerrainMesh && _locCachedTerrainMesh.parent) return _locCachedTerrainMesh;
+  _locCachedTerrainMesh = null;
+  scene.traverse((obj) => {
+    if (_locCachedTerrainMesh) return;
+    if ((obj as THREE.Mesh).isMesh && obj.layers.test(_locRaycaster.layers)) {
+      _locCachedTerrainMesh = obj;
+    }
+  });
+  return _locCachedTerrainMesh;
+}
+// then: raycaster.intersectObject(terrain, false)
+```
+
+### Pattern E — drei Html distanceFactor removal (npc-speech-bubbles.tsx)
+
+`<Html distanceFactor={300}>` causes per-frame camera-distance recompute + CSS transform write + browser Layout pass. Was causing ~0.5-1 ms per visible speech bubble. Removed; labels now render at constant CSS size, 3D positioning still works.
+
+### Pattern D — Module-scope scratch objects
+
+**click-to-move.tsx** — PathDots `useFrame` was calling `new THREE.Vector3(...)` and `new THREE.Matrix4().makeRotationX(-Math.PI/2)` per dot per frame:
+```typescript
+// module scope:
+const _toWorldScratch = new THREE.Vector3();
+const _dotMatrix = new THREE.Matrix4();
+const _dotRotation = new THREE.Matrix4().makeRotationX(-Math.PI / 2); // pre-computed once
+```
+
+**trail-renderer.tsx** — `new THREE.Vector3()` on every trail advance when trail is full:
+```typescript
+const _trailScratch = new THREE.Vector3(); // module scope
+// in useFrame when trail full:
+const recycled = historyRef.current.shift()!;
+recycled.set(position[0], position[1], position[2]);
+historyRef.current.push(recycled); // reuse, no new allocation
+```
+
+### Pattern J — Particle pool filter in render body (particle-system.tsx)
+
+`pool.filter((p) => p.active)` was in the JSX render body — ran on every React reconcile, not just on particle state change. Fix: maintain `activeParticles` state, update it in useFrame only when count changes.
+
+```typescript
+const [activeParticles, setActiveParticles] = useState<Particle[]>([]);
+const prevActiveCountRef = useRef(0);
+// in useFrame:
+const currentActive = pool.filter((p) => p.active);
+const newCount = currentActive.length;
+if (newCount !== prevActiveCountRef.current) {
+  prevActiveCountRef.current = newCount;
+  setActiveParticles([...currentActive]);
+}
+// render body: const active = activeParticles (stable between count-invariant frames)
+```
+
+### Pattern I — Narrowed Zustand subscription (activity-indicators.tsx)
+
+Was subscribing to full NPC array (`useNpcStore((s) => s.npcs)`) — re-rendered on every SSE position update (~100ms cadence) even when no NPC had changed indicator state.
+
+Fix: selector filters to only NPCs with active indicators and maps to a minimal snapshot:
+```typescript
+const npcSnapshots = useNpcStore((s) => {
+  const arr = s.npcs;
+  if (arr.length === 0) return EMPTY_SNAPSHOTS;
+  return arr.filter((n) => n.isDead || n.inCombat || n.inConversation)
+            .map((n) => ({ id: n.id, x: n.x, y: n.y,
+              isDead: n.isDead, inCombat: n.inCombat, inConversation: n.inConversation }));
+});
+```
+
+### Pattern K — DPR cap (World3DCanvas.tsx)
+
+`gl.setPixelRatio(Math.min(window.devicePixelRatio, 1))` in `onCreated` was overriding the `dpr={[0.75, 1]}` prop. R3F resolves `dpr` before `onCreated` fires; the manual call raised DPR back to 1.0 on 1.0-DPR devices, defeating the minimum cap. Fix: remove the `setPixelRatio()` call entirely.
+
+## Context
+
+Committed as `32010ef` (master). TypeScript: 0 errors. Coolify web redeploy: `mwkghugf28ssk7b9lngn2d2v`.
+
+Files NOT changed (already compliant): arena-npcs.tsx, arena-buildings.tsx, player-pet.tsx, merged-seaweed.tsx, npc-controller.tsx, World3DCanvas.tsx (scratch vectors already present).

--- a/.claude/memory/threejs/performance/vrm-draw-call-reductions.md
+++ b/.claude/memory/threejs/performance/vrm-draw-call-reductions.md
@@ -1,0 +1,68 @@
+---
+title: VRM draw-call reduction techniques
+category: performance
+tags: [vrm, mtoon, skeleton, bones, lookAt, expressionManager, draw-calls]
+date: 2026-04-24
+confidence: high
+threejs_version: r170+
+---
+
+## Summary
+Four cheap VRM load-time or init-time reductions that collectively halve draw calls and cut skeleton CPU cost per VRM.
+
+## Details
+
+### 1. MToon outline pass off (B1)
+MToon renders each mesh twice — fill + outline silhouette. Set `outlineWidthMode = 0` (None) on all MToonMaterial instances at load time:
+```ts
+vrm.scene.traverse((obj) => {
+  const mat = (obj as THREE.Mesh).material as any;
+  if (!mat) return;
+  const mats: any[] = Array.isArray(mat) ? mat : [mat];
+  for (const m of mats) {
+    if (m?.isMToonMaterial) m.outlineWidthMode = 0;
+  }
+});
+```
+Halves draw calls per VRM mesh. Reversible: 1 = World, 2 = Screen.
+
+### 2. removeUnnecessaryJoints (B3)
+VRoid VRMs ship with finger/toe/face bones Mixamo clips never drive:
+```ts
+VRMUtils.removeUnnecessaryJoints(vrm.scene);
+```
+Reduces bone count 20-40%. Call after `removeUnnecessaryVertices`, before `rotateVRM0`. Safe — preserves all 54 mandatory humanoid bones.
+
+### 3. Disable lookAt + expressionManager on wanderers (B4)
+Wandering NPCs don't lipsync or eye-track. Disable in a useEffect:
+```ts
+useEffect(() => {
+  if (!vrm) return;
+  (vrm as any).lookAt = undefined;
+  (vrm as any).expressionManager = undefined;
+}, [vrm]);
+```
+three-vrm checks truthiness before calling each module — safe at runtime. Do NOT do this for the player pet.
+
+### 4. Verse Engine skeleton.update batching (B2)
+Three.js calls skeleton.update() once per SkinnedMesh before draw. A VRM shares one skeleton across 3-4 meshes = 3× redundant calls. Replace with a no-op and call once manually:
+```ts
+// In constructor:
+const seenSkeletons = new Set<THREE.Skeleton>();
+vrm.scene.traverse((obj) => {
+  const sm = obj as THREE.SkinnedMesh;
+  if (!sm.isSkinnedMesh || !sm.skeleton) return;
+  if (seenSkeletons.has(sm.skeleton)) { sm.skeleton.update = () => {}; return; }
+  seenSkeletons.add(sm.skeleton);
+  const orig = sm.skeleton.update.bind(sm.skeleton);
+  this._skeletonUpdateFns.push(orig);
+  sm.skeleton.update = () => {};
+});
+
+// In update() and updateMixerOnly() after mixer.update():
+for (const fn of this._skeletonUpdateFns) fn();
+```
+Restore originals in dispose() for safe re-construction.
+
+## Context
+ClawVille arena-npcs.tsx + vrm-loader.ts + vrm-character-animator.ts. Phase A+B initial perf fixes 2026-04-24. These apply to wandering Milady VRMs; the 10 building SpongeBob GLBs are NOT VRMs and must not get VRM-specific changes.

--- a/.claude/memory/threejs/performance/zustand-re-render-storm-fixes.md
+++ b/.claude/memory/threejs/performance/zustand-re-render-storm-fixes.md
@@ -1,0 +1,84 @@
+---
+title: Zustand re-render storm — three-part fix (B5 + B6 + B7)
+category: performance
+tags: [zustand, react, re-render, useShallow, petPosition, NPC, memo, SSE, minimap]
+date: 2026-04-24
+confidence: high
+threejs_version: r170+
+---
+
+## Summary
+Three independent sources of React re-render storms in ClawVille, each with a targeted fix.
+
+## Details
+
+### B5 — useShallow on array-returning selectors
+Any `useNpcStore((s) => s.npcs.filter(...).map(...))` returns a new array reference on every
+store update, defeating shallow equality. Fix: `useShallow` from `zustand/react/shallow` wraps
+the selector and does element-by-element comparison.
+
+Also applies to multi-field object selectors where multiple store slices are needed:
+```ts
+// Before: three subscriptions, each re-renders independently
+const npcs = useNpcStore((s) => s.npcs);
+const combatLog = useNpcStore((s) => s.combatLog);
+const connected = useNpcStore((s) => s.connected);
+
+// After: one subscription, useShallow compares fields by value
+const { npcs, combatLog, connected } = useNpcStore(
+  useShallow((s) => ({ npcs: s.npcs, combatLog: s.combatLog, connected: s.connected }))
+);
+```
+
+Direct array slice selectors (no transform) also benefit when paired with B7:
+```ts
+const allNpcs = useNpcStore(useShallow((s) => s.npcs));
+```
+
+### B6 — petPosition module ref + 10Hz throttled reactive write
+`setPetPosition` was called 60Hz from `useFrame`, firing all React subscribers
+(Minimap SVG rebuilds 60×/sec while walking). Fix: export a mutable module-scope ref
+and throttle the reactive write to 10Hz.
+
+```ts
+// stores/game.ts
+export const petPositionRef: { x: number; y: number } = { x: 2560, y: 2940 };
+let lastReactiveWriteAt = 0;
+
+setPetPosition: (x, y) => {
+  petPositionRef.x = x;
+  petPositionRef.y = y;
+  const now = performance.now();
+  if (now - lastReactiveWriteAt >= 100) {
+    lastReactiveWriteAt = now;
+    set({ petPosition: { x, y } });
+  }
+},
+```
+
+Per-frame consumers (player-pet.tsx, use-game-loop.ts, camera follow, MinimapPositionTracker
+diff-check) switched to `petPositionRef` reads — zero React overhead, always current at 60Hz.
+Reactive subscribers (Minimap) continue using the zustand field, now at ≤10Hz.
+
+### B7 — NPC object identity preservation in updateFromSnapshot
+`updateFromSnapshot` was rebuilding every NPC object every SSE tick (~10Hz), even for unchanged
+NPCs. New object references broke `React.memo` bailout in `GLBNpcMesh`/`VRMNpcMesh`.
+
+Fix: build the candidate object, then compare every flat field against `prev` with `Object.is`.
+If equal, return `prev` (same reference). `npcFieldsEqual()` covers 18 fields + inventory array.
+
+```ts
+const candidate: NpcSpriteState = { ...built from snapshot... };
+if (prev && npcFieldsEqual(prev, candidate)) {
+  return prev; // preserve reference — React.memo sees no prop change
+}
+return candidate;
+```
+
+## Context
+ClawVille had two re-render storms:
+1. 60Hz: movement → `setPetPosition` → Minimap SVG rebuild every frame
+2. 10Hz: SSE NPC snapshot → `updateFromSnapshot` → every NpcMesh re-renders
+
+B5+B7 together eliminate the SSE storm. B6 eliminates the movement storm.
+Filed as Pod 1 performance work (branch `pod1-zustand-wins`, commit `2419909`).


### PR DESCRIPTION
## Summary

15 memory files sitting loose from recent 3da sessions — bundling into a PR per CLAUDE.md's rule that `.claude/memory/threejs/` is project-scoped and versioned.

**No source code changes.** Markdown only.

## What's here

**Gotchas (5 new) — bugs caught that future sessions must not re-learn:**
- `vrm-half-rate-gate-kills-mixer` — early-return silently throttled the mixer, not just spring-bone (PR #30)
- `skeleton-update-array-traversal-order` — traversal order isn't stable; Map-keyed restore required (PR #33)
- `uselayouteffect-vs-useeffect-vrm-frame-race` — useEffect runs post-paint, stale vrm state for one frame (PR #33)
- `vrm-facing-atan2-sign-error` — ping-ponged between `atan2(-vx,-vz)` and `atan2(vx,-vz)`; landed empirically
- `merged-seaweed-already-meshbasic` — stale grep led to a no-op optimization attempt (PR #37)

**Patterns (5 new):** `reef-race-scene`, `route-isolated-activity-scene`, `spectator-camera-modes`, `procedural-skirt-bone-parenting`, `fbx-loader-parallel-clips`

**Performance (4 new):** `vrm-draw-call-reductions` (PR #30), `zustand-re-render-storm-fixes` (PR #35), `idle-animation-throttle`, `perf-sweep-2026-04-21`

**Index:** `MEMORY.md` pointers to new entries.

## Why ship

Per CLAUDE.md: `.claude/memory/threejs/` is project-scoped and versioned so every session starts with the full accumulated knowledge. Files were written but never committed — fresh clones would lose them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)