### PR TITLE
fix(activity): resolve Lucia cookie at WS upgrade — guests can connect to matches

### DIFF
--- a/apps/api/src/routes/activities.ts
+++ b/apps/api/src/routes/activities.ts
@@ -34,6 +34,7 @@ import {
   pets,
 } from '@clawville/database';
 import { sessionMiddleware } from '../middleware/auth';
+import { lucia } from '../lib/auth';
 import { requireAuthOrAgentSession } from '../middleware/require-auth-or-agent';
 import type { ActivityAuthContext } from '../middleware/require-auth-or-agent';
 import { createRateLimiter, getClientIp } from '../middleware/rate-limit';
@@ -545,6 +546,7 @@ function getOrMakeAdapter(
     raw: unknown;
   },
   roomId: string,
+  preauthLuciaSessionId: string | null,
 ): HubWs {
   const keyObj = (wsContext.raw as object) ?? (wsContext as object);
   let existing = hubAdapters.get(keyObj);
@@ -556,7 +558,7 @@ function getOrMakeAdapter(
       const raw = wsContext.raw as { getBufferedAmount?: () => number } | null;
       return raw?.getBufferedAmount?.() ?? 0;
     },
-    data: activityWsHub.makeConnectionData(roomId),
+    data: activityWsHub.makeConnectionData(roomId, preauthLuciaSessionId),
   };
   hubAdapters.set(keyObj, transport);
   return transport;
@@ -579,6 +581,18 @@ activitiesV2Routes.get(
       throw new HTTPException(404, { message: 'Room not in activity' });
     }
 
+    // Snapshot the Lucia session id from the upgrade request's Cookie
+    // header. The handshake auth-frame sends a literal `'cookie'`
+    // placeholder when the browser cookie is the auth source (the WS
+    // upgrade attaches it automatically), and the hub swaps in this
+    // resolved session id. Headless agent callers will leave this null
+    // and pass their own session id in the auth frame instead. Captured
+    // in this closure so each per-connection `onMessage` call sees the
+    // same value (Hono's `c` is request-scoped, so the cookie reading
+    // must happen here, not inside the message handler).
+    const luciaCookieSessionId =
+      lucia.readSessionCookie(c.req.header('Cookie') ?? '') ?? null;
+
     return {
       async onMessage(evt, ws) {
         const adapter = getOrMakeAdapter(
@@ -588,6 +602,7 @@ activitiesV2Routes.get(
             raw: ws.raw ?? ws,
           },
           roomId,
+          luciaCookieSessionId,
         );
         const raw: string | ArrayBuffer | Uint8Array =
           typeof evt.data === 'string'

--- a/apps/api/src/services/activity/activity-ws-hub.ts
+++ b/apps/api/src/services/activity/activity-ws-hub.ts
@@ -90,6 +90,16 @@ export interface WsConnectionData {
   shortCode: string | null;
   /** Close code the hub set internally — Bun close events don't always carry it */
   internalCloseCode: number | null;
+  /**
+   * Lucia session id extracted from the upgrade request's Cookie header.
+   * The client sends the literal placeholder `'cookie'` in the auth frame
+   * when relying on the browser cookie (see `useActivityWs.ts` — the WS
+   * upgrade attaches the cookie automatically, but the auth-frame schema
+   * requires a non-empty string). The hub then resolves identity using
+   * this value instead of the placeholder. Null when no Lucia cookie was
+   * attached (agent-session callers, who pass their own session id).
+   */
+  preauthLuciaSessionId: string | null;
 }
 
 export type HubWs = HubWsTransport;
@@ -117,8 +127,18 @@ class ActivityWsHub {
       this.safeClose(ws, ACTIVITY_WS_CLOSE_CODES.UNAUTHORIZED, 'first frame must be auth');
       return false;
     }
+    // The client sends the literal string `'cookie'` (see
+    // `useActivityWs.ts:166`) when relying on the browser cookie that the
+    // WS upgrade attaches automatically. In that case, swap in the Lucia
+    // session id we resolved at upgrade time. Real session tokens (raw
+    // Lucia ids minted via `/api/auth/guest` or magic-link, or agent
+    // session ids passed by headless callers) pass through unchanged.
+    const tokenForResolve =
+      firstFrame.sessionToken === 'cookie' && ws.data.preauthLuciaSessionId
+        ? ws.data.preauthLuciaSessionId
+        : firstFrame.sessionToken;
     const identity = await resolveActivityIdentity({
-      sessionToken: firstFrame.sessionToken,
+      sessionToken: tokenForResolve,
     });
     if (!identity) {
       this.safeClose(ws, ACTIVITY_WS_CLOSE_CODES.UNAUTHORIZED, 'invalid session');
@@ -571,7 +591,10 @@ class ActivityWsHub {
    * Factory used by the route's upgradeWebSocket factory. Called for
    * every incoming WS upgrade to bootstrap the per-connection state.
    */
-  makeConnectionData(roomId: string): WsConnectionData {
+  makeConnectionData(
+    roomId: string,
+    preauthLuciaSessionId: string | null = null,
+  ): WsConnectionData {
     return {
       identity: null,
       roomId,
@@ -584,6 +607,7 @@ class ActivityWsHub {
       skippedBroadcasts: 0,
       shortCode: null,
       internalCloseCode: null,
+      preauthLuciaSessionId,
     };
   }
 }


### PR DESCRIPTION
## Bug
Guest queues Bumper Shells, room creates (post-fast-backfill), client navigates to `/activity/bumper-shells/<roomId>`, WS upgrades — and then **NETWORK: Disconnected** + **MATCH: Starting…** forever. The auth handshake fails 100% of the time for cookie-based callers.

## Root cause
`useActivityWs.ts:166` sends the literal string `'cookie'` as `sessionToken` when relying on the browser's Lucia cookie (the auth-frame schema requires `min(1)` non-empty string, and the WS upgrade is supposed to attach the cookie automatically).

But `registerConnection` in the hub passes that `'cookie'` directly to `resolveActivityIdentity`, which calls `lucia.validateSession('cookie')` — guaranteed to throw → falls through to agent-session path → also fails → returns null → close 4001.

There was never any code path that actually USED the upgrade-attached cookie.

## Fix

`routes/activities.ts`:
- At WS upgrade time, read the Lucia session id from the request `Cookie` header via `lucia.readSessionCookie(...)` and capture it in the `upgradeWebSocket` factory closure.
- Pass it into `getOrMakeAdapter()` so every per-connection adapter gets it on `WsConnectionData`.

`services/activity/activity-ws-hub.ts`:
- `WsConnectionData` gains `preauthLuciaSessionId: string | null`.
- `makeConnectionData()` accepts it as optional second arg (default null preserves existing test caller).
- `registerConnection()` swaps `'cookie'` → `preauthLuciaSessionId` before resolving identity. Real tokens (raw Lucia ids, agent session ids) pass through unchanged.

## Test plan
- [ ] Guest queues Bumper Shells → 7s wait → room created → navigate to /activity/.../bumper-shells/<roomId> → **NETWORK: Connected** appears, MATCH transitions countdown→live, ALIVE 4/4
- [ ] Authed user (real Lucia session) still queues + connects (regression)
- [ ] Existing WS hub unit tests still pass (`makeConnectionData` second arg is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)