### PR TITLE
fix(activity): schedule COUNTDOWN→LIVE timer so matches start

### DIFF
--- a/apps/api/src/services/activity/activity-room-manager.ts
+++ b/apps/api/src/services/activity/activity-room-manager.ts
@@ -126,6 +126,20 @@ class ActivityRoomManager {
   private liveTransitionFn: ((room: Room) => void) | null = null;
 
   /**
+   * Per-room countdown timers. Set when a room transitions into COUNTDOWN
+   * and cleared when it transitions out (LIVE / ABORTED). Each timer
+   * fires `transitionRoom(roomId, 'live')` after `COUNTDOWN_DURATION_MS`
+   * — without this, the FSM would sit in COUNTDOWN forever (no other
+   * code path moves rooms to LIVE in production; chunk #3 added the
+   * COUNTDOWN state machine but never wired the timer that exits it).
+   * Discovered 2026-04-24 when the first guests actually queued matches.
+   */
+  private countdownTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+
+  /**
    * Eviction hook registered by chunk #10's bot pool wiring so reserved
    * bot petIds are returned to the pool when a room ends (any path —
    * RESULTS→GC, ABORTED, ABORTED_CRASH). Chunk #10.
@@ -316,11 +330,41 @@ class ActivityRoomManager {
     room.state = toState;
     room.lastTouchedAt = now;
 
+    // Any transition out of COUNTDOWN must cancel the pending auto-live
+    // timer — otherwise an aborted-during-countdown room would still
+    // try to flip itself to LIVE after the participant fled.
+    if (fromState === 'countdown' && toState !== 'countdown') {
+      const pending = this.countdownTimers.get(roomId);
+      if (pending) {
+        clearTimeout(pending);
+        this.countdownTimers.delete(roomId);
+      }
+    }
+
     try {
       switch (toState) {
         case 'countdown':
           room.countdownStartedAt = now;
           await this.persistCountdownTransition(room);
+          // Schedule the COUNTDOWN→LIVE auto-transition. Chunk #3 added
+          // every other piece of this FSM but missed the timer that
+          // actually advances state, so before this fix every match sat
+          // in COUNTDOWN forever. The timer is room-scoped + cleared on
+          // any transition out of countdown (above) and on evictRoom().
+          {
+            const timer = setTimeout(() => {
+              this.countdownTimers.delete(roomId);
+              const r = this.rooms.get(roomId);
+              if (!r || r.state !== 'countdown') return; // already aborted/transitioned
+              this.transitionRoom(roomId, 'live').catch((err) => {
+                console.error(
+                  `[activity-room-manager] auto countdown→live failed for ${roomId}:`,
+                  err,
+                );
+              });
+            }, COUNTDOWN_DURATION_MS);
+            this.countdownTimers.set(roomId, timer);
+          }
           break;
         case 'live':
           room.startedAt = now;
@@ -769,6 +813,15 @@ class ActivityRoomManager {
       } catch (err) {
         console.error('[activity-room-manager] evictionFn threw:', err);
       }
+    }
+    // Defense in depth — a room being evicted while still mid-countdown
+    // (e.g. ABORTED during the 5s window) would otherwise leave its
+    // setTimeout dangling. The transitionRoom guard above handles the
+    // happy path; this catches eviction paths that bypass it.
+    const pendingTimer = this.countdownTimers.get(room.id);
+    if (pendingTimer) {
+      clearTimeout(pendingTimer);
+      this.countdownTimers.delete(room.id);
     }
     this.rooms.delete(room.id);
     this.shortCodeIndex.delete(room.shortCode);


### PR DESCRIPTION
## Bug
Guest queues Bumper Shells. WS connects (4/4 ALIVE, 36ms ping). Countdown shows **3** and never decrements. `MATCH: Starting…` forever. Single static lobster in a black void; no other bots, no arena lighting, no movement.

## Root cause
Chunk #3 added the FSM (`pending → countdown → live → results`) and registered the sim hook to fire on the `LIVE` transition. **But nothing in production code ever calls `transitionRoom('live')`.** Only callers:

| State | Caller |
|---|---|
| `countdown` | `createRoom()` |
| `results` | sim's `endedFn` |
| `aborted` | room sweeper |
| `gc` | room sweeper |

`COUNTDOWN` had no exit path. Tests called `transitionRoom('live')` directly so no test caught it. With WS auth fixed (PR #39), this surfaced the next layer.

## Fix
Schedule a `setTimeout` inside the `transitionRoom('countdown')` case that fires after `COUNTDOWN_DURATION_MS` (5s) and calls `transitionRoom(roomId, 'live')`. Track the timer in a per-manager `countdownTimers` Map so:

- Any transition out of countdown clears it (aborted-during-countdown doesn't auto-flip to LIVE)
- `evictRoom()` clears it as defense in depth
- The timer body re-checks `room.state === 'countdown'` before firing (race-safe)

The chunk #10 bot backfill + chunk #3 sim wiring + bot AI controllers were all correct already — they just never ran because nothing reached LIVE.

## Test plan
- [ ] Queue Bumper Shells solo → 7s wait → countdown 3-2-1 → match goes LIVE → bots move + ram → match ends after 90s with results screen
- [ ] Existing tests pass (they call `transitionRoom('live')` directly, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)