### PR TITLE
fix(3d): Bumper Shells arena visibility — fog kills entire scene on mobile

### DIFF
--- a/apps/web/src/lib/three/activities/bumper-shells/BumperShellsArena.tsx
+++ b/apps/web/src/lib/three/activities/bumper-shells/BumperShellsArena.tsx
@@ -10,9 +10,11 @@
  * Iris Xe invariants:
  *   - MeshBasicNodeMaterial for the rim glow (no lighting = no ShaderMaterial needed).
  *   - MeshStandardMaterial for platform and danger ring (no ShaderMaterial).
- *   - Void backdrop at y=-2000 — MeshBasicNodeMaterial ignores fog, so we place it
- *     far enough that the edge is never visible (fog kills everything past 900wu).
+ *   - Void backdrop at y=-2000 — MeshBasicNodeMaterial ignores fog, safe at any depth.
  *   - matrixAutoUpdate=false on every mesh — these never move.
+ *
+ * 2026-04-24 visibility fix: platform colour brightened from '#1a2a3a' (near-black)
+ * to '#1e3a5f' (readable ocean-blue). See bumper-shells-config.ts fog/light comments.
  */
 
 import { useRef, useEffect, useMemo } from 'react';
@@ -64,10 +66,12 @@ const dangerGeo = new THREE.CylinderGeometry(
 
 const voidGeo = new THREE.PlaneGeometry(VOID_BACKDROP_SIZE, VOID_BACKDROP_SIZE);
 
+// Platform disc colour: brighter blue-grey so it reads clearly under the PBR
+// lighting rig. Old '#1a2a3a' was near-black — invisible at this light level.
 const platformMat = new THREE.MeshStandardMaterial({
-  color: new THREE.Color('#1a2a3a'),
+  color: new THREE.Color('#1e3a5f'),
   roughness: 0.85,
-  metalness: 0.0,
+  metalness: 0.1,
 });
 
 const dangerMat = new THREE.MeshStandardMaterial({

--- a/apps/web/src/lib/three/activities/bumper-shells/BumperShellsScene.tsx
+++ b/apps/web/src/lib/three/activities/bumper-shells/BumperShellsScene.tsx
@@ -22,7 +22,9 @@
  *   - No per-frame allocations in useFrame (module-scope scratch vectors only).
  *   - 1 shadow map at 512×512.
  *   - 0 post-processing passes.
- *   - Fog far (900) < camera.far (1500).
+ *   - Fog near (1400) / far (1500) — pushed past camera distance (~1140wu) so
+ *     fog only touches clip-plane fringe, not the arena. Old 200/900 made the
+ *     entire arena invisible (all geometry was > FOG_FAR from the ortho cam).
  *   - OrbitControls added only for 'free' mode; disabled on mode exit.
  *   - ONE camera per client across all modes — no extra shadow frusta.
  *
@@ -352,10 +354,22 @@ function BumperLight() {
         position={DIR_POSITION}
         castShadow
       />
+      {/*
+       * Fill light: secondary directional from below/behind — no shadow cast.
+       * Lifts PBR lobster shells out of shadow on their underside when viewed
+       * top-down from the ortho camera. Intensity kept low (0.6) to avoid
+       * washing out the key light's depth cues.
+       */}
+      <directionalLight
+        color="#aaccff"
+        intensity={0.6}
+        position={[-150, -200, -100]}
+        castShadow={false}
+      />
       {/* Neon accent point lights — no shadows, static position. */}
-      <pointLight color="#00ccff" intensity={0.6} distance={400} decay={2} position={[400,  80,  0]}  castShadow={false} />
-      <pointLight color="#ff66aa" intensity={0.6} distance={400} decay={2} position={[-300, 80, 350]} castShadow={false} />
-      <pointLight color="#aa44ff" intensity={0.5} distance={350} decay={2} position={[0,    80, -400]} castShadow={false} />
+      <pointLight color="#00ccff" intensity={1.2} distance={600} decay={2} position={[400,  80,  0]}  castShadow={false} />
+      <pointLight color="#ff66aa" intensity={1.2} distance={600} decay={2} position={[-300, 80, 350]} castShadow={false} />
+      <pointLight color="#aa44ff" intensity={1.0} distance={550} decay={2} position={[0,    80, -400]} castShadow={false} />
     </>
   );
 }

--- a/apps/web/src/lib/three/activities/bumper-shells/bumper-shells-config.ts
+++ b/apps/web/src/lib/three/activities/bumper-shells/bumper-shells-config.ts
@@ -73,25 +73,39 @@ export const CAMERA_LOOK_AT = [0, 0, 0] as const;
 /** Fog color hex — deep ocean dark blue. */
 export const FOG_COLOR = '#050a14';
 
-/** Fog near distance. Keep ≤ ARENA_RADIUS so center is always fog-free. */
-export const FOG_NEAR = 200;
-
 /**
- * Fog far distance. MUST be ≤ CAMERA_FAR.
- * Iris Xe rule: fog.far > camera.far → 90→50 FPS drop.
- * 900 < 1500 ✓
+ * Fog near distance.
+ *
+ * BUG FIX (2026-04-24): The ortho camera sits at [0, 1100, 300] → distance to
+ * arena floor ≈ sqrt(1100²+300²) ≈ 1140wu. The old FOG_NEAR=200/FOG_FAR=900
+ * made every scene object 100% fogged (all ≥1140wu from camera > FAR=900).
+ * Result: black void on mobile. Fix: push fog well past CAMERA_FAR so it only
+ * kills geometry right at the clip plane, not the visible arena.
+ *
+ * Iris Xe perf note: fog.far > camera.far IS a fragment-count risk in the open
+ * world (see performance/fog-density-iris-xe-regression.md). In THIS scene it's
+ * fine — fog.far=CAMERA_FAR-50 clamps fog to clip-plane fringe only.
  */
-export const FOG_FAR = 900;
+export const FOG_NEAR = 1400;
+export const FOG_FAR  = 1500; // == CAMERA_FAR — fog only touches clip-plane geometry
 
 // ─── Lighting ────────────────────────────────────────────────────────────────
 
-export const HEMI_SKY_COLOR = '#1a3a5c';
-export const HEMI_GROUND_COLOR = '#050a14';
-export const HEMI_INTENSITY = 0.4;
+/**
+ * Lighting fix (2026-04-24): previous values were tuned as if the camera were
+ * close to the arena (normal scene). With a ~1140wu camera-to-floor distance
+ * and PBR materials that receive ambient + diffuse, the old HEMI_INTENSITY=0.4
+ * with a near-black sky colour (#1a3a5c) produced near-black lobsters even when
+ * the fog bug was absent. Brightness raised to match what looks correct at this
+ * distance with MeshStandardMaterial.
+ */
+export const HEMI_SKY_COLOR    = '#4488cc'; // visible blue — was '#1a3a5c' (near-black)
+export const HEMI_GROUND_COLOR = '#1a2a3a'; // dark ocean floor — was '#050a14'
+export const HEMI_INTENSITY    = 1.4;       // was 0.4 — PBR models need ≥1.0 to read clearly
 
-export const DIR_COLOR = '#80d4ff';
-export const DIR_INTENSITY = 1.1;
-export const DIR_POSITION = [200, 600, 150] as const;
+export const DIR_COLOR     = '#ffffff';     // white — was '#80d4ff' (dim blue)
+export const DIR_INTENSITY = 2.0;           // was 1.1 — need strong key for lobster PBR shells
+export const DIR_POSITION  = [200, 600, 150] as const;
 export const DIR_SHADOW_MAP_SIZE = 512;
 export const DIR_SHADOW_NEAR = 1;
 export const DIR_SHADOW_FAR = 1200;


### PR DESCRIPTION
## Root cause

Three.js `Fog` measures distance in **world-space from the camera** (not screen depth). The Bumper Shells orthographic camera sits at `(0, 1100, 300)`. Distance to the arena floor at origin:

```
sqrt(0² + 1100² + 300²) ≈ 1140 wu
```

Old config had `FOG_NEAR=200, FOG_FAR=900`. Every piece of scene geometry was ~1140wu from the camera — **past FOG_FAR** — so Three.js applied 100% fog opacity to all fragments. The arena rendered as a black void. Only 2D HUD overlays (dom elements, not WebGL) were visible.

## Fixes applied

### `bumper-shells-config.ts`
- `FOG_NEAR`: 200 → 1400
- `FOG_FAR`: 900 → 1500 (== CAMERA_FAR — fog only clips geometry at the clip plane, not the arena)
- `HEMI_SKY_COLOR`: `#1a3a5c` (near-black) → `#4488cc` (readable blue)
- `HEMI_GROUND_COLOR`: `#050a14` → `#1a2a3a`
- `HEMI_INTENSITY`: 0.4 → 1.4 (PBR materials need ≥1.0 ambient to read clearly)
- `DIR_COLOR`: `#80d4ff` (dim blue) → `#ffffff` (white)
- `DIR_INTENSITY`: 1.1 → 2.0
- Accent point light distances: 350–400 → 550–600, intensities 0.5–0.6 → 1.0–1.2

### `BumperShellsArena.tsx`
- Platform disc colour: `#1a2a3a` (near-black) → `#1e3a5f` (visible ocean blue)

### `BumperShellsScene.tsx`
- Added fill directional light `#aaccff` intensity 0.6 from below/behind (`-150, -200, -100`, no shadow cast) — lifts PBR lobster shell undersides out of shadow when viewed top-down
- Updated JSDoc to document corrected fog range

## Iris Xe invariants maintained
- No InstancedMesh + ShaderMaterial
- No drei Text/Billboard
- Shadow map still 1×512²
- 0 post-processing passes
- `fog.far = CAMERA_FAR` is intentional here (open-world rule "fog.far ≤ camera.far for FPS" does not apply — fog only clips clip-plane fringe, no fragment-count inflation)

## Memory saved
New gotcha: `.claude/memory/threejs/gotchas/ortho-camera-fog-world-distance.md`

## Test plan
- [ ] Queue a Bumper Shells match on mobile — arena floor, rim glow, lobster models, danger ring should all be clearly visible
- [ ] FPS ≥ 50 (no fog overdraw regression — fog only activates past 1400wu, clip plane at 1500wu)
- [ ] Rim torus still pulses cyan
- [ ] Lobster silhouettes show full red-orange shell colour, not black

🤖 Generated with [Claude Code](https://claude.com/claude-code)