### PR TITLE
fix(activity): sweeper races + invalid FSM + diagnostics

### DIFF
--- a/apps/api/src/services/activity/activity-room-manager.ts
+++ b/apps/api/src/services/activity/activity-room-manager.ts
@@ -351,11 +351,17 @@ class ActivityRoomManager {
           // actually advances state, so before this fix every match sat
           // in COUNTDOWN forever. The timer is room-scoped + cleared on
           // any transition out of countdown (above) and on evictRoom().
+          console.log(
+            `[activity-room-manager] room ${roomId} → COUNTDOWN (will auto-advance to LIVE in ${COUNTDOWN_DURATION_MS}ms; ${room.participants.size} participants, hasBots=${room.hasBots})`,
+          );
           {
             const timer = setTimeout(() => {
               this.countdownTimers.delete(roomId);
               const r = this.rooms.get(roomId);
               if (!r || r.state !== 'countdown') return; // already aborted/transitioned
+              console.log(
+                `[activity-room-manager] room ${roomId} countdown timer fired → transitioning to LIVE (connectedCount=${this.connectedCount(r)})`,
+              );
               this.transitionRoom(roomId, 'live').catch((err) => {
                 console.error(
                   `[activity-room-manager] auto countdown→live failed for ${roomId}:`,
@@ -413,6 +419,11 @@ class ActivityRoomManager {
   async roomSweeper(): Promise<void> {
     const now = Date.now();
     const toAbort: Room[] = [];
+    // LIVE rooms with no WS connections must use `aborted_crash` (the
+    // FSM does not allow live → aborted; only live → aborted_crash).
+    // Tracked separately so the dispatch loop below picks the right
+    // target state per room.
+    const toAbortCrash: Room[] = [];
     const toGc: Room[] = [];
 
     for (const room of this.rooms.values()) {
@@ -427,7 +438,17 @@ class ActivityRoomManager {
           break;
         }
         case 'countdown': {
-          if (this.connectedCount(room) === 0) {
+          // Grace period — the client has to navigate from the lobby
+          // page to /activity/.../<roomId> and open a WebSocket. On
+          // mobile that easily takes 1-3 seconds. The original
+          // unguarded check raced the client and aborted rooms before
+          // the user could connect (manifested as "Match Starting…"
+          // sticking forever after the client finally connected to a
+          // room that was already aborted server-side).
+          if (
+            this.connectedCount(room) === 0 &&
+            now - (room.countdownStartedAt ?? room.createdAt) > 10_000
+          ) {
             toAbort.push(room);
           }
           break;
@@ -437,7 +458,7 @@ class ActivityRoomManager {
             this.connectedCount(room) === 0 &&
             now - room.lastTouchedAt > LIVE_NO_WS_TTL_MS
           ) {
-            toAbort.push(room);
+            toAbortCrash.push(room);
           }
           break;
         }
@@ -466,12 +487,28 @@ class ActivityRoomManager {
           payload: {
             activityId: room.activityId,
             roomId: room.id,
-            reason: room.state === 'live' ? 'live_no_ws' : 'pending_empty',
+            reason: 'pending_empty',
             playerCount: room.participants.size,
           },
         });
       } catch (err) {
         console.error('[activity-room-manager] sweeper abort failed:', err);
+      }
+    }
+    for (const room of toAbortCrash) {
+      try {
+        await this.transitionRoom(room.id, 'aborted_crash');
+        await logEvent({
+          eventType: 'activity.match.swept',
+          payload: {
+            activityId: room.activityId,
+            roomId: room.id,
+            reason: 'live_no_ws',
+            playerCount: room.participants.size,
+          },
+        });
+      } catch (err) {
+        console.error('[activity-room-manager] sweeper abort_crash failed:', err);
       }
     }
     for (const room of toGc) {
@@ -651,12 +688,19 @@ class ActivityRoomManager {
     // Invoke the sim-start hook AFTER the DB row is live so the sim
     // never runs against a countdown row. Registered by the sim
     // dispatcher in `apps/api/src/index.ts` at boot.
+    console.log(
+      `[activity-room-manager] room ${room.id} → LIVE — invoking liveTransitionFn (registered=${!!this.liveTransitionFn}, activityId=${room.activityId}, participantCount=${room.participants.size})`,
+    );
     if (this.liveTransitionFn) {
       try {
         this.liveTransitionFn(room);
       } catch (err) {
         console.error('[activity-room-manager] liveTransitionFn threw:', err);
       }
+    } else {
+      console.error(
+        `[activity-room-manager] CRITICAL: room ${room.id} reached LIVE but no liveTransitionFn registered — sim will never start`,
+      );
     }
   }
 

--- a/apps/api/src/services/activity/sim/bumper-shells-sim.ts
+++ b/apps/api/src/services/activity/sim/bumper-shells-sim.ts
@@ -365,12 +365,24 @@ class BumperShellsSim {
       });
     }
 
+    console.log(
+      `[bumper-shells-sim] startRoom ${roomId} — ${participantPetIds.length} participants (${botControllers.size} bots) — tick=${BUMPER_TICK_MS.toFixed(2)}ms`,
+    );
+
     // Boot the tick loop. Drift-correcting via Date.now() inside the
     // handler instead of a high-resolution accumulator — ample at 60Hz
     // for the round length we care about.
     state.intervalHandle = setInterval(() => {
       try {
         this.tickRoom(state);
+        // One-shot diagnostic: log first tick so we can confirm the sim
+        // is actually advancing. Subsequent ticks are silent (60Hz =
+        // log spam). Remove once stable in prod.
+        if (state.tick === 1) {
+          console.log(
+            `[bumper-shells-sim] room ${roomId} first tick complete — ${state.bodies.size} bodies, ${state.botControllers.size} bots active`,
+          );
+        }
       } catch (err) {
         console.error('[bumper-shells-sim] tick exception:', err);
         // Mark ended so the WS hub stops trying to broadcast — chunk #2's


### PR DESCRIPTION
## Bugs surfaced once guests started queueing real matches

### 1. COUNTDOWN abort race
Sweeper aborted any COUNTDOWN room with `connectedCount === 0` immediately, no time threshold. Mobile clients take 1-3s to navigate from lobby to /activity/.../<roomId> and open the WS. The sweeper beat the client every time → `transitionRoom('aborted')` → user lands on a dead room. Manifested as "MATCH Starting…" hanging forever.

**Fix:** require 10s elapsed since `countdownStartedAt` before aborting a no-WS COUNTDOWN room.

### 2. Invalid `live → aborted` FSM transition
Sweeper called `transitionRoom('aborted')` for LIVE rooms with no WS, but FSM only allows `live → results | aborted_crash`. Spammed the logs with **Invalid transition live → aborted** on every sweep, and the room never actually got cleaned up.

**Fix:** split `toAbort` / `toAbortCrash` and route LIVE rooms through `aborted_crash` (the legal transition).

### 3. Diagnostics
Added critical-path-only logs (no per-tick spam):
- COUNTDOWN entry + timer scheduled
- Countdown timer fire (or "never" via re-check)
- LIVE entry + liveTransitionFn invocation (with explicit error if hook missing)
- `bumperShellsSim.startRoom` entry
- First tick of the sim

This lets us confirm the FSM/sim chain on prod instead of inferring from snapshot side-effects.

## Test plan
- [ ] Solo guest queues Bumper Shells → 7s wait → COUNTDOWN log → 5s later "countdown timer fired" → LIVE log → startRoom log → "first tick complete"
- [ ] Server logs no longer show "Invalid transition live → aborted"
- [ ] If a queue completes but no human ever connects, room aborts cleanly after 10s grace

Pairs with #42 (3da's bumper-shells fog/lighting fix) — together they should restore the playable arena.

🤖 Generated with [Claude Code](https://claude.com/claude-code)