### PR TITLE
fix(build): resolve unmerged conflict markers in arena-npcs.tsx

### DIFF
--- a/apps/web/src/lib/three/arena-npcs.tsx
+++ b/apps/web/src/lib/three/arena-npcs.tsx
@@ -548,25 +548,11 @@ const GLBNpcMesh = memo(function GLBNpcMesh({ npc }: { npc: NpcSpriteState }) {
     }
     group.visible = true;
     {
-<<<<<<< Updated upstream
-      // Behind-camera cull: drei <Html> calculatePosition still projects a screen
-      // XY when the anchor NDC z > 1 (anchor behind near plane), producing ghost
-      // labels for buildings/NPCs behind the camera. Zero-allocation test using
-      // camera.matrixWorldInverse — viewZ < 0 means the anchor is in front.
-      // group.matrixWorld.elements[12/13/14] = world translation (no Vector3 alloc).
-      const m = camera.matrixWorldInverse.elements;
-      const wx = group.matrixWorld.elements[12];
-      const wy = group.matrixWorld.elements[13];
-      const wz = group.matrixWorld.elements[14];
-      const viewZ = m[2] * wx + m[6] * wy + m[10] * wz + m[14];
-      const inFront = viewZ < 0;
-=======
       // Behind-camera cull: drei <Html> does not hide when the 3D anchor is behind
       // the near plane — calculatePosition still emits a screen XY, producing ghost
       // labels. Dot-product test hides the label when the anchor is behind the camera.
       group.getWorldPosition(_npcAnchorWorldPos);
       const inFront = anchorInFrontOfCamera(_npcAnchorWorldPos, camera);
->>>>>>> Stashed changes
       const label = labelRef.current;
       if (!inFront) {
         if (label && label.style.display !== 'none') label.style.display = 'none';
@@ -916,22 +902,11 @@ const VRMNpcMesh = memo(function VRMNpcMesh({ npc }: { npc: NpcSpriteState }) {
     }
     group.visible = true;
     {
-<<<<<<< Updated upstream
-      // Behind-camera cull: same zero-allocation test as GLBNpcMesh above.
-      // viewZ < 0 → anchor is in front of camera → show label.
-      const m = camera.matrixWorldInverse.elements;
-      const wx = group.matrixWorld.elements[12];
-      const wy = group.matrixWorld.elements[13];
-      const wz = group.matrixWorld.elements[14];
-      const viewZ = m[2] * wx + m[6] * wy + m[10] * wz + m[14];
-      const inFront = viewZ < 0;
-=======
       // Behind-camera cull: drei <Html> does not hide when the 3D anchor is behind
       // the near plane — calculatePosition still emits a screen XY, producing ghost
       // labels. Dot-product test hides the label when the anchor is behind the camera.
       group.getWorldPosition(_npcAnchorWorldPos);
       const inFront = anchorInFrontOfCamera(_npcAnchorWorldPos, camera);
->>>>>>> Stashed changes
       const label = labelRef.current;
       if (!inFront) {
         if (label && label.style.display !== 'none') label.style.display = 'none';


### PR DESCRIPTION
## Bug
Web build has been failing since an earlier merge committed unresolved git conflict markers in `apps/web/src/lib/three/arena-npcs.tsx` at lines 551/563/569 and 919/928/934. Turbopack hits **Merge conflict marker encountered** at parse time and bails. PR #42 (3da fog/lighting) and PR #43 (sweeper) are both blocked from reaching prod web until this lands.

## Fix
Both blocks were the same drei `<Html>` behind-camera cull with two competing implementations:

- **Updated upstream** — inline matrix math (zero alloc)
- **Stashed changes** — `anchorInFrontOfCamera(_npcAnchorWorldPos, camera)` helper

Resolved to the helper version. The file already imports `anchorInFrontOfCamera` from `@/lib/three/utils/camera-cull` (line 26) and declares `_npcAnchorWorldPos` at module scope (line 373), so this is consistent with the rest of the codebase.

The inline-matrix version referenced no missing symbols — this is a behavior-equivalent pick modulo one Vector3 write per draw. Acceptable for readability.

## Test plan
- [ ] Web build no longer fails with "Merge conflict marker encountered"
- [ ] Bumper Shells deploy lands (#42 fog, #43 sweeper take effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)