### PR TITLE
fix(build): commit missing camera-cull helper

### DIFF
--- a/apps/web/src/lib/three/utils/camera-cull.ts
+++ b/apps/web/src/lib/three/utils/camera-cull.ts
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------------------
+// camera-cull.ts — behind-camera dot-product helper
+//
+// Used to imperatively hide drei <Html> DOM portals when their 3D anchor
+// is behind the camera. drei's calculatePosition does manual projection and
+// still emits screen XY even when NDC z > 1 (anchor behind near plane),
+// producing ghost labels floating over empty world space.
+//
+// Pattern: call anchorInFrontOfCamera(anchorWorldPos, camera) each useFrame.
+// If it returns false, set labelRef.current.style.display = 'none'.
+//
+// PERF: module-scope temporaries reused every call — zero per-frame allocs.
+// ---------------------------------------------------------------------------
+
+import * as THREE from 'three';
+
+// Module-scoped reusable temporaries — DO NOT allocate per-frame.
+const _tmpCamFwd = new THREE.Vector3();
+const _tmpToAnchor = new THREE.Vector3();
+
+/**
+ * Returns true when `anchorWorldPos` is in front of the camera
+ * (i.e. the dot product of (anchor - cameraPos) · cameraForward > 0).
+ *
+ * Use in useFrame to gate drei <Html> label visibility:
+ *
+ *   if (!anchorInFrontOfCamera(groupRef.current.position, camera)) {
+ *     if (label && label.style.display !== 'none') label.style.display = 'none';
+ *   }
+ */
+export function anchorInFrontOfCamera(
+  anchorWorldPos: THREE.Vector3,
+  camera: THREE.Camera,
+): boolean {
+  _tmpCamFwd.set(0, 0, -1).applyQuaternion(camera.quaternion);
+  _tmpToAnchor.copy(anchorWorldPos).sub(camera.position);
+  return _tmpToAnchor.dot(_tmpCamFwd) > 0;
+}


### PR DESCRIPTION
## Bug
Web build still failing after PR #44 with **Module not found: Can't resolve '@/lib/three/utils/camera-cull'**.

## Root cause
`apps/web/src/lib/three/arena-npcs.tsx:26` imports the helper, but the file `apps/web/src/lib/three/utils/camera-cull.ts` was never tracked by git — it exists in someone's local working tree only. PR #44 resolved the merge conflict to the helper-based version, which depends on this missing file.

## Fix
Commit the helper. It's a pure 38-line module with one exported function (`anchorInFrontOfCamera`) used to imperatively hide drei `<Html>` DOM portals when the 3D anchor goes behind the camera. Reuses module-scope Vector3 temporaries — zero per-frame allocs.

Unblocks #42 (3da's bumper-shells fog/lighting fix) and #43 (sweeper) from reaching prod web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)