### PR TITLE
fix(build): setMeshoptDecoder on direct GLTFLoader instances

### DIFF
--- a/apps/web/src/lib/three/vrm-character-animator.ts
+++ b/apps/web/src/lib/three/vrm-character-animator.ts
@@ -33,6 +33,7 @@
 
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { MeshoptDecoder } from 'three-stdlib';
 import type { VRM } from '@pixiv/three-vrm';
 import { retargetMixamoClip, type MixamoGltf } from './mixamo-retarget';
 
@@ -74,6 +75,10 @@ let _animLoader: GLTFLoader | null = null;
 function getAnimLoader(): GLTFLoader {
   if (_animLoader) return _animLoader;
   _animLoader = new GLTFLoader();
+  // Mixamo-sourced anim GLBs may be meshopt-compressed (gltfpack -cc).
+  // Same fix as vrm-loader.ts — without the decoder the whole /game
+  // route bails at first loadBufferView call.
+  _animLoader.setMeshoptDecoder(MeshoptDecoder());
   return _animLoader;
 }
 

--- a/apps/web/src/lib/three/vrm-loader.ts
+++ b/apps/web/src/lib/three/vrm-loader.ts
@@ -20,6 +20,7 @@
 
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { MeshoptDecoder } from 'three-stdlib';
 import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
 import { MToonMaterialLoaderPlugin } from '@pixiv/three-vrm-materials-mtoon';
 import type { VRM } from '@pixiv/three-vrm';
@@ -94,6 +95,15 @@ let _loader: GLTFLoader | null = null;
 function getLoader(): GLTFLoader {
   if (_loader) return _loader;
   _loader = new GLTFLoader();
+  // VRM files may ship with EXT_meshopt_compression buffers (the asset
+  // pipeline runs gltfpack -cc for skinned meshes). Without this line
+  // GLTFLoader throws "setMeshoptDecoder must be called before loading
+  // compressed files" at loadBufferView, which blocks the whole /game
+  // route and shows Next's "This page couldn't load" error page.
+  // three-stdlib's MeshoptDecoder is a callable that returns the decoder
+  // object; GLTFLoader accepts either, but three-stdlib's signature is
+  // `() => API` so we invoke it.
+  _loader.setMeshoptDecoder(MeshoptDecoder());
   _loader.register((parser) => new VRMLoaderPlugin(parser, {
     mtoonMaterialPlugin: new MToonMaterialLoaderPlugin(parser),
   }));


### PR DESCRIPTION
## Bug
`/game` route was crashing with Next's "This page couldn't load" (Chrome, incognito, mobile — everywhere). Console:

```
Uncaught Error: THREE.GLTFLoader: setMeshoptDecoder must be called before loading compressed files
  at S.loadBufferView (...)
  ...
  at j.loadSkin (...)
```

## Root cause
`vrm-loader.ts` and `vrm-character-animator.ts` each `new GLTFLoader()` directly (bypassing drei's `useGLTF` which wires meshopt via `extendLoader`). Neither called `setMeshoptDecoder`. When either loader hits a skinned mesh or accessor compressed with `EXT_meshopt_compression` — the Milady VRMs and Mixamo anim GLBs both come from the `gltfpack -cc` pipeline — GLTFLoader refuses to decode and throws synchronously. The exception escapes Suspense and Next renders the generic error page.

## Fix
Wire `three-stdlib`'s `MeshoptDecoder` onto both direct loaders. Invoke it as a callable because three-stdlib's signature is `() => API`.

Everything else goes through `useGLTF` which already defaults `useMeshopt: true`.

## Test plan
- [ ] Fresh incognito + regular Chrome → `/game` loads, no "couldn't load"
- [ ] No `setMeshoptDecoder` errors in console
- [ ] Milady VRMs + NPC Mixamo animations render

🤖 Generated with [Claude Code](https://claude.com/claude-code)