### PR TITLE
fix(build): use meshoptimizer decoder (fixes PR #47 tsc error)

### DIFF
--- a/apps/web/src/lib/three/vrm-character-animator.ts
+++ b/apps/web/src/lib/three/vrm-character-animator.ts
@@ -33,7 +33,9 @@
 
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
-import { MeshoptDecoder } from 'three-stdlib';
+// See vrm-loader.ts — meshoptimizer's decoder object satisfies three's
+// strict setMeshoptDecoder signature; three-stdlib's callable does not.
+import { MeshoptDecoder } from 'meshoptimizer';
 import type { VRM } from '@pixiv/three-vrm';
 import { retargetMixamoClip, type MixamoGltf } from './mixamo-retarget';
 
@@ -78,7 +80,7 @@ function getAnimLoader(): GLTFLoader {
   // Mixamo-sourced anim GLBs may be meshopt-compressed (gltfpack -cc).
   // Same fix as vrm-loader.ts — without the decoder the whole /game
   // route bails at first loadBufferView call.
-  _animLoader.setMeshoptDecoder(MeshoptDecoder());
+  _animLoader.setMeshoptDecoder(MeshoptDecoder);
   return _animLoader;
 }
 

--- a/apps/web/src/lib/three/vrm-loader.ts
+++ b/apps/web/src/lib/three/vrm-loader.ts
@@ -20,7 +20,10 @@
 
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
-import { MeshoptDecoder } from 'three-stdlib';
+// meshoptimizer's decoder object satisfies three's strict `setMeshoptDecoder`
+// type (has useWorkers + decodeGltfBufferAsync); three-stdlib's variant is
+// missing those methods and fails tsc. meshoptimizer@^0.22.0 is a root dep.
+import { MeshoptDecoder } from 'meshoptimizer';
 import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
 import { MToonMaterialLoaderPlugin } from '@pixiv/three-vrm-materials-mtoon';
 import type { VRM } from '@pixiv/three-vrm';
@@ -103,7 +106,10 @@ function getLoader(): GLTFLoader {
   // three-stdlib's MeshoptDecoder is a callable that returns the decoder
   // object; GLTFLoader accepts either, but three-stdlib's signature is
   // `() => API` so we invoke it.
-  _loader.setMeshoptDecoder(MeshoptDecoder());
+  // meshoptimizer's MeshoptDecoder is the decoder object itself (NOT a
+  // callable — three-stdlib's is `() => API`, which is what caused the
+  // PR #47 tsc break). Pass the object directly.
+  _loader.setMeshoptDecoder(MeshoptDecoder);
   _loader.register((parser) => new VRMLoaderPlugin(parser, {
     mtoonMaterialPlugin: new MToonMaterialLoaderPlugin(parser),
   }));


### PR DESCRIPTION
## Bug
PR #47 shipped `setMeshoptDecoder` with three-stdlib's decoder, whose typed export is `() => API | { supported: boolean }`. Invoking it and passing to three's `setMeshoptDecoder` fails tsc with **Type 'API' is missing useWorkers, decodeGltfBufferAsync**.

## Fix
Switch both loaders to import from `meshoptimizer` (already a root dep at ^0.22.0). Its export is the decoder object itself (not a callable), with the full surface three expects.

## Test plan
- [ ] Web build passes (no TS error at `_loader.setMeshoptDecoder(...)`)
- [ ] Runtime: `/game` loads without `setMeshoptDecoder must be called` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)