### PR TITLE
fix(activity): joystick+WASD set thrust from dir mag — controls now move you

### DIFF
--- a/apps/web/src/hooks/useActivityInput.ts
+++ b/apps/web/src/hooks/useActivityInput.ts
@@ -260,16 +260,30 @@ export function useActivityInput({ send, enabled }: UseActivityInputOptions): vo
       oneShotBitsRef.current = 0;
 
       const dir = dirRef.current;
-      const moving = dir.x !== 0 || dir.y !== 0;
+      const dirMag = Math.hypot(dir.x, dir.y);
+      const moving = dirMag > 0;
 
       seqRef.current = (seqRef.current + 1) >>> 0;
+
+      // Thrust derives from joystick magnitude when moving — analog mobile
+      // input + WASD (which writes a unit vector) both produce sensible
+      // values. Boost overrides to full thrust regardless of stick deflection.
+      // Previously thrust was ONLY set on boost, which made joystick + WASD
+      // alone send dir={x,y} with thrust=undefined → server clamped to 0 →
+      // body never moved. That's why "the controls don't work" on mobile and
+      // desktop alike — players had to hold the boost key to make the player
+      // move at all.
+      const thrust = moving
+        ? bits & ACTION_BIT_BOOST
+          ? 1
+          : Math.min(1, dirMag)
+        : 0;
 
       const frame: ClientFrame = {
         type: 'input',
         seq: seqRef.current,
         dt,
-        ...(moving ? { dir: { x: dir.x, y: dir.y } } : {}),
-        ...(bits & ACTION_BIT_BOOST ? { thrust: 1 } : {}),
+        ...(moving ? { dir: { x: dir.x, y: dir.y }, thrust } : {}),
         ...(bits ? { actionBits: bits } : {}),
       };
 


### PR DESCRIPTION
## Bug
User reports mobile joystick + A/B buttons don't move the player. **Same bug exists on desktop** — WASD doesn't move the player either unless you also hold Space.

## Root cause
`useActivityInput.ts:272` only includes `thrust` in the outbound input frame when the BOOST action bit is held:

```ts
...(bits & ACTION_BIT_BOOST ? { thrust: 1 } : {}),
```

Without boost held, `thrust` is `undefined` → server's `applyInput` clamps `safe.thrust ?? 0` → `targetVx = nx * 0 * topSpeed = 0` → body never accelerates. The dir intent was recorded but lost to the zero thrust multiplier.

## Fix
Derive thrust from joystick magnitude when moving. Boost overrides to 1 regardless of stick deflection.

```ts
const dirMag = Math.hypot(dir.x, dir.y);
const thrust = moving
  ? (bits & ACTION_BIT_BOOST ? 1 : Math.min(1, dirMag))
  : 0;
```

Mobile analog joystick → graduated speed. WASD (unit vector) → full speed. Boost button → sprint override.

## Test plan
- [ ] Mobile: drag joystick — player slides in that direction
- [ ] Desktop: press WASD — player moves
- [ ] Hold A button (mobile) / Space (desktop) — player goes max speed even with light joystick
- [ ] Bots still move (they call applyInput directly server-side, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)