### PR TITLE
feat(activity): A/B button press feedback (ring pulse + squash)

### DIFF
--- a/apps/web/src/components/game/activity-mobile-controls.tsx
+++ b/apps/web/src/components/game/activity-mobile-controls.tsx
@@ -26,7 +26,7 @@
  * Spec: `.claude/plans/q2-research/frontend-spec.md` §11.1.
  */
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { JoystickManager } from 'nipplejs';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useGameStore } from '@/stores/game';
@@ -76,6 +76,12 @@ export default function ActivityMobileControls({ active }: ActivityMobileControl
   const isMobile = useIsMobile();
   const leftContainerRef = useRef<HTMLDivElement>(null);
   const leftJoystickRef = useRef<JoystickManager | null>(null);
+
+  // Per-button "just pressed" flash — drives the expanding glow ring via CSS.
+  // Cleared after FEEDBACK_MS so repeated rapid presses re-trigger the anim.
+  const [boostFlash, setBoostFlash] = useState(0);
+  const [powerupFlash, setPowerupFlash] = useState(0);
+  const FEEDBACK_MS = 280;
 
   // Left joystick — same plumbing as `mobile-controls.tsx`. We write into
   // the same `joystickVelocity` slot so `useActivityInput` picks it up
@@ -139,12 +145,16 @@ export default function ActivityMobileControls({ active }: ActivityMobileControl
     if (!active) return;
     vibrate(HAPTIC_PRESS_MS);
     dispatchActionBit(ACTION_BIT_BOOST);
+    // Monotonic counter flips the glow-ring key so the CSS anim restarts
+    // even on rapid repeat taps.
+    setBoostFlash((n) => n + 1);
   }, [active]);
 
   const handlePowerUpPress = useCallback(() => {
     if (!active) return;
     vibrate(HAPTIC_PRESS_MS);
     dispatchActionBit(ACTION_BIT_USE_POWERUP);
+    setPowerupFlash((n) => n + 1);
   }, [active]);
 
   if (!isMobile) return null;
@@ -168,6 +178,17 @@ export default function ActivityMobileControls({ active }: ActivityMobileControl
       />
 
       {/* Right thumb cluster — A (boost) + B (power-up) */}
+      <style>{`
+        @keyframes cv-btn-pulse {
+          0%   { transform: translate(-50%, -50%) scale(1);   opacity: 0.9; }
+          100% { transform: translate(-50%, -50%) scale(1.9); opacity: 0;   }
+        }
+        @keyframes cv-btn-press {
+          0%   { transform: scale(1); }
+          30%  { transform: scale(0.88); }
+          100% { transform: scale(1); }
+        }
+      `}</style>
       <div
         className="absolute pointer-events-auto"
         style={{
@@ -178,60 +199,100 @@ export default function ActivityMobileControls({ active }: ActivityMobileControl
           alignItems: 'flex-end',
         }}
       >
-        <button
-          type="button"
-          onPointerDown={(e) => {
-            e.preventDefault();
-            handleBoostPress();
-          }}
-          aria-label="Boost"
-          style={{
-            width: 64,
-            height: 64,
-            borderRadius: '50%',
-            background:
-              'radial-gradient(circle at 35% 30%, rgba(125, 211, 252, 0.95), rgba(56, 189, 248, 0.65) 60%, rgba(15, 31, 58, 0.95) 100%)',
-            border: '2px solid rgba(186, 230, 253, 0.85)',
-            color: '#0c1830',
-            fontWeight: 900,
-            fontSize: 22,
-            fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
-            letterSpacing: '0.05em',
-            boxShadow: '0 4px 18px rgba(56, 189, 248, 0.45)',
-            cursor: 'pointer',
-            touchAction: 'manipulation',
-            opacity: active ? 1 : 0.5,
-          }}
-        >
-          A
-        </button>
-        <button
-          type="button"
-          onPointerDown={(e) => {
-            e.preventDefault();
-            handlePowerUpPress();
-          }}
-          aria-label="Use power-up"
-          style={{
-            width: 64,
-            height: 64,
-            borderRadius: '50%',
-            background:
-              'radial-gradient(circle at 35% 30%, rgba(252, 211, 77, 0.95), rgba(245, 158, 11, 0.7) 60%, rgba(58, 31, 6, 0.95) 100%)',
-            border: '2px solid rgba(254, 243, 199, 0.9)',
-            color: '#1f1503',
-            fontWeight: 900,
-            fontSize: 22,
-            fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
-            letterSpacing: '0.05em',
-            boxShadow: '0 4px 18px rgba(245, 158, 11, 0.5)',
-            cursor: 'pointer',
-            touchAction: 'manipulation',
-            opacity: active ? 1 : 0.5,
-          }}
-        >
-          B
-        </button>
+        <div style={{ position: 'relative', width: 64, height: 64 }}>
+          {boostFlash > 0 && (
+            <span
+              key={`boost-flash-${boostFlash}`}
+              aria-hidden
+              style={{
+                position: 'absolute',
+                left: '50%',
+                top: '50%',
+                width: 64,
+                height: 64,
+                borderRadius: '50%',
+                border: '3px solid rgba(125, 211, 252, 0.95)',
+                pointerEvents: 'none',
+                animation: `cv-btn-pulse ${FEEDBACK_MS}ms ease-out forwards`,
+              }}
+            />
+          )}
+          <button
+            type="button"
+            onPointerDown={(e) => {
+              e.preventDefault();
+              handleBoostPress();
+            }}
+            aria-label="Boost"
+            style={{
+              width: 64,
+              height: 64,
+              borderRadius: '50%',
+              background:
+                'radial-gradient(circle at 35% 30%, rgba(125, 211, 252, 0.95), rgba(56, 189, 248, 0.65) 60%, rgba(15, 31, 58, 0.95) 100%)',
+              border: '2px solid rgba(186, 230, 253, 0.85)',
+              color: '#0c1830',
+              fontWeight: 900,
+              fontSize: 22,
+              fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+              letterSpacing: '0.05em',
+              boxShadow: '0 4px 18px rgba(56, 189, 248, 0.45)',
+              cursor: 'pointer',
+              touchAction: 'manipulation',
+              opacity: active ? 1 : 0.5,
+              animation: boostFlash > 0 ? `cv-btn-press ${FEEDBACK_MS}ms ease-out` : undefined,
+            }}
+          >
+            A
+          </button>
+        </div>
+        <div style={{ position: 'relative', width: 64, height: 64 }}>
+          {powerupFlash > 0 && (
+            <span
+              key={`powerup-flash-${powerupFlash}`}
+              aria-hidden
+              style={{
+                position: 'absolute',
+                left: '50%',
+                top: '50%',
+                width: 64,
+                height: 64,
+                borderRadius: '50%',
+                border: '3px solid rgba(252, 211, 77, 0.95)',
+                pointerEvents: 'none',
+                animation: `cv-btn-pulse ${FEEDBACK_MS}ms ease-out forwards`,
+              }}
+            />
+          )}
+          <button
+            type="button"
+            onPointerDown={(e) => {
+              e.preventDefault();
+              handlePowerUpPress();
+            }}
+            aria-label="Use power-up"
+            style={{
+              width: 64,
+              height: 64,
+              borderRadius: '50%',
+              background:
+                'radial-gradient(circle at 35% 30%, rgba(252, 211, 77, 0.95), rgba(245, 158, 11, 0.7) 60%, rgba(58, 31, 6, 0.95) 100%)',
+              border: '2px solid rgba(254, 243, 199, 0.9)',
+              color: '#1f1503',
+              fontWeight: 900,
+              fontSize: 22,
+              fontFamily: 'var(--font-orbitron, ui-sans-serif), sans-serif',
+              letterSpacing: '0.05em',
+              boxShadow: '0 4px 18px rgba(245, 158, 11, 0.5)',
+              cursor: 'pointer',
+              touchAction: 'manipulation',
+              animation: powerupFlash > 0 ? `cv-btn-press ${FEEDBACK_MS}ms ease-out` : undefined,
+              opacity: active ? 1 : 0.5,
+            }}
+          >
+            B
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Why
User reported mobile A/B buttons felt broken. They're firing server-side (logs confirm action bits), but the user saw no visual response so it felt discarded.

## Fix
Add two CSS-only feedback layers on tap:
1. **Ring burst** — same-sized circle grows to 1.9× + fades over 280ms. Cyan for A, amber for B.
2. **Squash** — button scales 1 → 0.88 → 1 over the same window.

Keyed on a monotonic counter so rapid repeat taps re-fire the keyframe cleanly. Pure CSS — no new deps.

Pairs with #51 (position interpolation) to stop the 'dead button + teleporting lobsters' feel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)