### PR TITLE
feat(3d): Bumper Shells scene rebuild — perspective cam, arena, VFX

### DIFF
--- a/apps/web/src/lib/three/activities/bumper-shells/BumperShellsArena.tsx
+++ b/apps/web/src/lib/three/activities/bumper-shells/BumperShellsArena.tsx
@@ -3,21 +3,20 @@
 /**
  * BumperShellsArena.tsx
  *
- * Static arena geometry: platform disc, rim glow torus, danger ring, void backdrop.
- * All meshes are static — matrixAutoUpdate=false after mount.
+ * REBUILT 2026-04-24 — Real 3D arena geometry for perspective chase camera.
  *
- * Draw calls: 4 (platform, rim, danger ring, void backdrop).
+ * Draw calls: 8
+ *   platform (1) + tile overlay (1) + rim torus (1) + bumper wall torus (1) +
+ *   danger ring (1) + void backdrop (1) + starfield (1) + [4 point lights = 0 dc]
+ *
  * Iris Xe invariants:
- *   - MeshBasicNodeMaterial for the rim glow (no lighting = no ShaderMaterial needed).
- *   - MeshStandardMaterial for platform and danger ring (no ShaderMaterial).
- *   - Void backdrop at y=-2000 — MeshBasicNodeMaterial ignores fog, safe at any depth.
- *   - matrixAutoUpdate=false on every mesh — these never move.
- *
- * 2026-04-24 visibility fix: platform colour brightened from '#1a2a3a' (near-black)
- * to '#1e3a5f' (readable ocean-blue). See bumper-shells-config.ts fog/light comments.
+ *   - MeshStandardMaterial for lit surfaces; MeshBasicMaterial for unlit/emissive.
+ *   - NO ShaderMaterial anywhere.
+ *   - matrixAutoUpdate=false on every static mesh after mount.
+ *   - No per-frame allocations — module-scope elapsed only.
  */
 
-import { useRef, useEffect, useMemo } from 'react';
+import { useRef, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three/webgpu';
 import {
@@ -27,23 +26,37 @@ import {
   RIM_TUBE_RADIUS,
   RIM_RADIAL_SEGMENTS,
   RIM_TUBULAR_SEGMENTS,
-  DANGER_RING_INNER,
+  BUMPER_WALL_TUBE_RADIUS,
+  BUMPER_WALL_HEIGHT,
   VOID_BACKDROP_Y,
   VOID_BACKDROP_SIZE,
+  STAR_COUNT,
+  STAR_RADIUS,
+  STAR_Y_MIN,
+  STAR_Y_MAX,
+  RIM_LIGHT_COLOR,
+  RIM_LIGHT_INTENSITY,
+  RIM_LIGHT_DISTANCE,
 } from './bumper-shells-config';
 
-// ─── Module-scope scratch ────────────────────────────────────────────────────
-// No allocations inside useFrame.
-let _elapsedTime = 0;
+// ─── Module-scope scratch ──────────────────────────────────────────────────
+let _arenaElapsed = 0;
 
-// ─── Geometry / material singletons ─────────────────────────────────────────
-// Created once at module load, shared across HMR cycles, disposed on unmount.
+// ─── Geometry singletons (module scope) ───────────────────────────────────
+
 const platformGeo = new THREE.CylinderGeometry(
   ARENA_RADIUS,
-  ARENA_RADIUS,
+  ARENA_RADIUS * 0.96, // slight bevel at base
   ARENA_HEIGHT,
   ARENA_RADIAL_SEGMENTS,
-  1,
+  2,
+);
+
+const tileOverlayGeo = new THREE.PlaneGeometry(
+  ARENA_RADIUS * 2,
+  ARENA_RADIUS * 2,
+  20,
+  20,
 );
 
 const rimGeo = new THREE.TorusGeometry(
@@ -53,132 +66,242 @@ const rimGeo = new THREE.TorusGeometry(
   RIM_TUBULAR_SEGMENTS,
 );
 
-// Danger ring: outer radius = ARENA_RADIUS, inner = DANGER_RING_INNER.
-// Built as a thin CylinderGeometry ring (open at top/bottom).
+const bumperWallGeo = new THREE.TorusGeometry(
+  ARENA_RADIUS - BUMPER_WALL_TUBE_RADIUS * 0.5,
+  BUMPER_WALL_TUBE_RADIUS,
+  12,
+  RIM_TUBULAR_SEGMENTS,
+);
+
 const dangerGeo = new THREE.CylinderGeometry(
   ARENA_RADIUS,
   ARENA_RADIUS,
-  4, // thin disc
+  6,
   ARENA_RADIAL_SEGMENTS,
   1,
-  false, // openEnded=false so it renders as a ring cap
+  false,
 );
 
 const voidGeo = new THREE.PlaneGeometry(VOID_BACKDROP_SIZE, VOID_BACKDROP_SIZE);
 
-// Platform disc colour: brighter blue-grey so it reads clearly under the PBR
-// lighting rig. Old '#1a2a3a' was near-black — invisible at this light level.
+// Starfield: deterministic placement, no Math.random() at module scope (reproducible)
+const starGeo = (() => {
+  const geo = new THREE.BufferGeometry();
+  const pos = new Float32Array(STAR_COUNT * 3);
+  for (let i = 0; i < STAR_COUNT; i++) {
+    const angle = (i / STAR_COUNT) * Math.PI * 2 + i * 2.399;
+    const r = STAR_RADIUS * (0.25 + (((i * 6271) % 1000) / 1000) * 0.75);
+    pos[i * 3 + 0] = Math.cos(angle) * r;
+    pos[i * 3 + 1] = STAR_Y_MIN + (((i * 3491) % 1000) / 1000) * (STAR_Y_MAX - STAR_Y_MIN);
+    pos[i * 3 + 2] = Math.sin(angle) * r;
+  }
+  geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  return geo;
+})();
+
+// ─── Materials ─────────────────────────────────────────────────────────────
+
 const platformMat = new THREE.MeshStandardMaterial({
-  color: new THREE.Color('#1e3a5f'),
-  roughness: 0.85,
-  metalness: 0.1,
+  color: new THREE.Color('#0d2235'),
+  roughness: 0.9,
+  metalness: 0.05,
+});
+
+const tileOverlayMat = new THREE.MeshStandardMaterial({
+  color: new THREE.Color('#122840'),
+  roughness: 0.95,
+  metalness: 0.0,
+  polygonOffset: true,
+  polygonOffsetFactor: -1,
+  polygonOffsetUnits: -1,
+});
+
+const rimMat = new THREE.MeshBasicMaterial({
+  color: new THREE.Color('#00ccff'),
+  transparent: true,
+  depthWrite: false,
+  blending: THREE.AdditiveBlending,
+  opacity: 0.8,
+});
+
+const bumperWallMat = new THREE.MeshStandardMaterial({
+  color: new THREE.Color('#3a4a5a'),
+  roughness: 0.3,
+  metalness: 0.8,
+  emissive: new THREE.Color('#001a33'),
+  emissiveIntensity: 0.3,
 });
 
 const dangerMat = new THREE.MeshStandardMaterial({
-  color: new THREE.Color('#cc2200'),
-  roughness: 0.7,
+  color: new THREE.Color('#880000'),
+  emissive: new THREE.Color('#cc0000'),
+  emissiveIntensity: 0.6,
+  roughness: 0.6,
   metalness: 0.0,
   transparent: true,
-  opacity: 0.75,
+  opacity: 0.7,
 });
 
-// MeshBasicNodeMaterial for the rim glow — safe on WebGPU, no fog dependency.
-// Pulse via JS opacity mutation each frame (simpler than TSL opacityNode for now).
-const rimMat = new THREE.MeshBasicNodeMaterial
-  ? new (THREE as any).MeshBasicNodeMaterial({
-      color: new THREE.Color(0x00ccff),
-      transparent: true,
-      depthWrite: false,
-    })
-  : new THREE.MeshBasicMaterial({
-      color: new THREE.Color(0x00ccff),
-      transparent: true,
-      depthWrite: false,
-    });
+const voidMat = new THREE.MeshBasicMaterial({
+  color: new THREE.Color('#010205'),
+  side: THREE.DoubleSide,
+});
 
-const voidMat = new THREE.MeshBasicMaterial
-  ? (THREE as any).MeshBasicNodeMaterial
-    ? new (THREE as any).MeshBasicNodeMaterial({
-        color: new THREE.Color('#020810'),
-        transparent: true,
-        opacity: 1,
-        depthWrite: false,
-      })
-    : new THREE.MeshBasicMaterial({
-        color: new THREE.Color('#020810'),
-        side: THREE.DoubleSide,
-      })
-  : new THREE.MeshBasicMaterial({
-      color: new THREE.Color('#020810'),
-      side: THREE.DoubleSide,
-    });
+const starMat = new THREE.PointsMaterial({
+  color: new THREE.Color('#cce0ff'),
+  size: 3.5,
+  sizeAttenuation: true,
+  transparent: true,
+  opacity: 0.7,
+  blending: THREE.AdditiveBlending,
+  depthWrite: false,
+});
 
 export default function BumperShellsArena() {
   const platformRef = useRef<THREE.Mesh>(null);
-  const rimRef = useRef<THREE.Mesh>(null);
-  const dangerRef = useRef<THREE.Mesh>(null);
-  const voidRef = useRef<THREE.Mesh>(null);
+  const tileRef     = useRef<THREE.Mesh>(null);
+  const rimRef      = useRef<THREE.Mesh>(null);
+  const bumperRef   = useRef<THREE.Mesh>(null);
+  const dangerRef   = useRef<THREE.Mesh>(null);
+  const voidRef     = useRef<THREE.Mesh>(null);
+  const starsRef    = useRef<THREE.Points>(null);
 
-  // Freeze matrices after mount — these never move.
+  // Freeze all static matrices once after mount
   useEffect(() => {
-    for (const ref of [platformRef, rimRef, dangerRef, voidRef]) {
-      const m = ref.current;
-      if (!m) continue;
-      m.matrixAutoUpdate = false;
-      m.updateMatrix();
+    const objs: Array<THREE.Object3D | null> = [
+      platformRef.current, tileRef.current, rimRef.current,
+      bumperRef.current, dangerRef.current, voidRef.current, starsRef.current,
+    ];
+    for (const o of objs) {
+      if (!o) continue;
+      o.matrixAutoUpdate = false;
+      o.updateMatrix();
     }
   }, []);
 
-  // Rim glow pulse — GPU-driven: sin(t*2)*0.3+0.7.
-  // No new allocations — just write opacity.
+  // Rim pulse + danger throb — only material property mutations, no allocations
   useFrame((_, delta) => {
-    _elapsedTime += delta;
+    _arenaElapsed += delta;
+
     const rim = rimRef.current;
     if (rim) {
-      (rim.material as THREE.Material & { opacity: number }).opacity =
-        Math.sin(_elapsedTime * 2) * 0.3 + 0.7;
+      (rim.material as THREE.MeshBasicMaterial).opacity =
+        Math.sin(_arenaElapsed * 2.2) * 0.25 + 0.65;
+    }
+
+    const danger = dangerRef.current;
+    if (danger) {
+      (danger.material as THREE.MeshStandardMaterial).emissiveIntensity =
+        Math.sin(_arenaElapsed * 3.5) * 0.3 + 0.7;
     }
   });
 
+  const discTopY = ARENA_HEIGHT / 2;
+
   return (
     <group>
-      {/* Platform disc — flat at y=0 */}
+      {/* Platform disc with beveled base */}
       <mesh
         ref={platformRef}
         geometry={platformGeo}
         material={platformMat}
-        position={[0, 0, 0]}
         receiveShadow
         castShadow={false}
         frustumCulled={false}
       />
 
-      {/* Rim glow torus — top surface of disc */}
+      {/* Tile overlay on top of disc — receives key light for seam definition */}
+      <mesh
+        ref={tileRef}
+        geometry={tileOverlayGeo}
+        material={tileOverlayMat}
+        position={[0, discTopY + 0.5, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+        castShadow={false}
+        frustumCulled={false}
+      />
+
+      {/* Rim glow torus — additive cyan, pulsing */}
       <mesh
         ref={rimRef}
         geometry={rimGeo}
         material={rimMat}
-        position={[0, ARENA_HEIGHT / 2, 0]}
+        position={[0, discTopY, 0]}
         rotation={[Math.PI / 2, 0, 0]}
         frustumCulled={false}
       />
 
-      {/* Danger zone ring — outer 15% of disc, slightly above platform */}
+      {/* Bumper wall — metallic guardrail, catches key light, visible from chase cam */}
+      <mesh
+        ref={bumperRef}
+        geometry={bumperWallGeo}
+        material={bumperWallMat}
+        position={[0, discTopY + BUMPER_WALL_HEIGHT * 0.5, 0]}
+        rotation={[Math.PI / 2, 0, 0]}
+        castShadow
+        receiveShadow
+        frustumCulled={false}
+      />
+
+      {/* Danger zone ring — outer 15%, pulsing red emissive */}
       <mesh
         ref={dangerRef}
         geometry={dangerGeo}
         material={dangerMat}
-        position={[0, ARENA_HEIGHT / 2 + 1, 0]}
+        position={[0, discTopY + 2, 0]}
         frustumCulled={false}
       />
 
-      {/* Void backdrop — deep below arena, fills the view past the edge */}
+      {/* 4 rim accent point lights at cardinal positions — no shadows */}
+      <pointLight
+        color={RIM_LIGHT_COLOR}
+        intensity={RIM_LIGHT_INTENSITY}
+        distance={RIM_LIGHT_DISTANCE}
+        decay={2}
+        position={[ARENA_RADIUS, discTopY + 20, 0]}
+        castShadow={false}
+      />
+      <pointLight
+        color={RIM_LIGHT_COLOR}
+        intensity={RIM_LIGHT_INTENSITY}
+        distance={RIM_LIGHT_DISTANCE}
+        decay={2}
+        position={[-ARENA_RADIUS, discTopY + 20, 0]}
+        castShadow={false}
+      />
+      <pointLight
+        color={RIM_LIGHT_COLOR}
+        intensity={RIM_LIGHT_INTENSITY * 0.7}
+        distance={RIM_LIGHT_DISTANCE}
+        decay={2}
+        position={[0, discTopY + 20, ARENA_RADIUS]}
+        castShadow={false}
+      />
+      <pointLight
+        color={RIM_LIGHT_COLOR}
+        intensity={RIM_LIGHT_INTENSITY * 0.7}
+        distance={RIM_LIGHT_DISTANCE}
+        decay={2}
+        position={[0, discTopY + 20, -ARENA_RADIUS]}
+        castShadow={false}
+      />
+
+      {/* Void backdrop far below */}
       <mesh
         ref={voidRef}
         geometry={voidGeo}
         material={voidMat}
         position={[0, VOID_BACKDROP_Y, 0]}
         rotation={[-Math.PI / 2, 0, 0]}
+        frustumCulled={false}
+      />
+
+      {/* Starfield — 300 scattered points below the disc, 1 draw call */}
+      <points
+        ref={starsRef}
+        geometry={starGeo}
+        material={starMat}
         frustumCulled={false}
       />
     </group>

--- a/apps/web/src/lib/three/activities/bumper-shells/BumperShellsParticles.tsx
+++ b/apps/web/src/lib/three/activities/bumper-shells/BumperShellsParticles.tsx
@@ -3,19 +3,22 @@
 /**
  * BumperShellsParticles.tsx
  *
- * Module-scope burst particle pool for knockback hit VFX.
- * Pool: BURST_POOL_SIZE (4) simultaneous bursts × BURST_POINT_COUNT (16) points each.
+ * REBUILT 2026-04-24 — Module-scope burst particle pool for impact VFX.
+ *
+ * Pool: BURST_POOL_SIZE (6) simultaneous bursts × BURST_POINT_COUNT (12) points each.
+ * Each burst: quads scatter outward + upward from impact point over BURST_LIFETIME_MS.
+ * Additive blending gives a hot-plasma look without alpha sorting.
  *
  * Iris Xe invariants:
- *   - PointsNodeMaterial (TSL) — safe on WebGPU. Falls back gracefully.
- *   - 16 points per burst max — Iris Xe fragment throughput constraint.
+ *   - PointsMaterial (standard) — safe on WebGPU (no ShaderMaterial).
+ *   - ≤12 points per burst — Iris Xe fragment throughput constraint.
  *   - Float32BufferAttribute mutated in-place — no new attribute per frame.
- *   - Pool slots are mounted at scene init as visible=false — no dynamic mesh creation.
+ *   - Pool slots mounted at scene init as visible=false — no dynamic mesh creation.
  *   - No new THREE.Vector3() inside useFrame — module-scope scratch only.
  *
  * Public API:
- *   - `triggerBurst(x, y, z, color)` — imperative, called from BumperShellsScene.
- *   - `<BumperShellsParticles />` — JSX component, mount once at scene root.
+ *   - `triggerBurst(x, y, z, color)` — imperative.
+ *   - `<BumperShellsParticles />` — mount once at scene root.
  */
 
 import { useRef, useEffect } from 'react';
@@ -44,15 +47,20 @@ const _pool: BurstSlot[] = Array.from({ length: BURST_POOL_SIZE }, () => ({
   colorHex: '#ffffff',
 }));
 
-// Pre-computed random XZ directions for each slot×point.
-// Computed once at module load — no per-frame random calls.
-const _directions: Float32Array[] = Array.from({ length: BURST_POOL_SIZE }, () => {
+// Pre-computed deterministic spread directions for each slot×point.
+// Computed once at module load — no per-frame random calls, deterministic seed.
+const _directions: Float32Array[] = Array.from({ length: BURST_POOL_SIZE }, (_, si) => {
   const d = new Float32Array(BURST_POINT_COUNT * 3);
   for (let i = 0; i < BURST_POINT_COUNT; i++) {
-    const angle = (i / BURST_POINT_COUNT) * Math.PI * 2 + Math.random() * 0.5;
-    d[i * 3 + 0] = Math.cos(angle);
-    d[i * 3 + 1] = (Math.random() - 0.5) * 0.6; // slight Y scatter
-    d[i * 3 + 2] = Math.sin(angle);
+    const seed = (si * 1000 + i * 137);
+    const angle = (i / BURST_POINT_COUNT) * Math.PI * 2 + (seed % 100) * 0.063;
+    const upBias = ((seed * 7) % 100) / 100; // 0..1, biased upward for aerial look
+    d[i * 3 + 0] = Math.cos(angle) * (0.6 + upBias * 0.4);
+    d[i * 3 + 1] = 0.3 + upBias * 0.7; // more pronounced upward scatter
+    d[i * 3 + 2] = Math.sin(angle) * (0.6 + upBias * 0.4);
+    // Normalise
+    const len = Math.sqrt(d[i*3]*d[i*3] + d[i*3+1]*d[i*3+1] + d[i*3+2]*d[i*3+2]);
+    d[i*3] /= len; d[i*3+1] /= len; d[i*3+2] /= len;
   }
   return d;
 });
@@ -120,14 +128,13 @@ function BurstPoints({ slotIndex }: { slotIndex: number }) {
     );
     geometry.current = geo;
 
-    // PointsMaterial as fallback — PointsNodeMaterial would need TSL setup.
-    // Using standard PointsMaterial: transparent + additive = acceptable on Iris Xe.
+    // PointsMaterial — safe on WebGPU/WebGL; additive blending = hot-plasma look.
     const mat = new THREE.PointsMaterial({
       size: BURST_POINT_SIZE,
       sizeAttenuation: true,
       transparent: true,
       opacity: 0,
-      color: new THREE.Color('#ffffff'),
+      color: new THREE.Color('#ff8800'),
       blending: THREE.AdditiveBlending,
       depthWrite: false,
     });

--- a/apps/web/src/lib/three/activities/bumper-shells/BumperShellsPlayer.tsx
+++ b/apps/web/src/lib/three/activities/bumper-shells/BumperShellsPlayer.tsx
@@ -3,44 +3,42 @@
 /**
  * BumperShellsPlayer.tsx
  *
- * Single player shell component. Clones lobster.glb or crayfish.glb, applies
- * squash/stretch on hit, fades out on elimination.
+ * REBUILT 2026-04-24 — Player shell with full perspective-camera VFX pipeline.
  *
- * One instance per player, up to MAX_PLAYERS=8 simultaneously.
+ * Per-player features:
+ *   - Three.js GLB clone (lobster / crayfish) with LobsterAnimator locomotion
+ *   - drei <Html> name label above shell (camera-cull gated; NO drei Text — Iris Xe crash)
+ *   - Squash/stretch on hit (meshRootRef scale; orthogonal to bone rotations)
+ *   - Elimination: gravity drop (DROP_GRAVITY wu/s²) + fade over DROP_FADE_DURATION
+ *   - Self-hit flash: fires onSelfHit callback so BumperShellsScene flashes the DOM overlay
+ *   - PR #51 position interpolation fully preserved (15Hz → 60fps lerp)
  *
  * Iris Xe invariants:
  *   - SkeletonUtils.clone() + frustumCulled=false traverse immediately after clone.
  *   - Squash/stretch applied to ROOT GROUP (meshRootRef) not SkinnedMesh bones.
- *   - LobsterAnimator works on clonedScene parts — composes with squash (no bone conflict).
+ *   - NO drei Text/Billboard — Iris Xe hard GPU crash.
+ *   - drei <Html> with anchorInFrontOfCamera dot-product cull.
  *   - No per-frame allocations — module-scope scratch primitives only.
- *   - applyColorTint skipped for GLB shells (matches VRM-tinting convention from player-pet.tsx).
  *
- * Chunk #12a: LobsterAnimator wired. Locomotion blend driven by entity velocity
- * from activity store. Animator composes with squash/stretch — both applied to
- * separate groups so bone transforms and root scale never collide.
- *
- * Chunk #13 (interpolation): client-side position + facing interpolation eliminates
- * the 15Hz teleport jitter. Strategy:
- *   - Stamp each incoming entity snapshot with performance.now() at the moment the
- *     prop changes (detected by ref comparison in useFrame).
- *   - Maintain a per-component history ring of up to INTERP_HISTORY_SIZE snapshots.
- *   - Render at (now - INTERP_DELAY_MS), finding the two bracket snapshots and lerping.
- *   - Rotation uses shortest-angle lerp (never spins through 0/2π boundary).
- *   - Velocity is lerped in parallel — drives the locomotion blend smoothly.
- *   - If only one snapshot in buffer (startup), snap directly to it; no extrapolation.
- *
- * Draw calls: 1 per player (lobster.glb is 1 SkinnedMesh draw call).
+ * Draw calls: 1 per player (lobster.glb = 1 SkinnedMesh draw call).
  */
 
 import { useRef, useEffect, useMemo } from 'react';
-import { useFrame } from '@react-three/fiber';
-import { useGLTF } from '@react-three/drei';
+import { useFrame, useThree } from '@react-three/fiber';
+import { useGLTF, Html } from '@react-three/drei';
 import * as THREE from 'three/webgpu';
 import { clone as skeletonClone } from 'three/examples/jsm/utils/SkeletonUtils.js';
 import { LobsterAnimator } from '@/lib/three/lobster-animations';
 import { discoverLobsterParts } from '@/lib/three/lobster-parts';
+import { anchorInFrontOfCamera } from '@/lib/three/utils/camera-cull';
 import type { BumperShellEntity, ShellHitAnimState } from './bumper-shells-types';
-import { SHELL_SCALE, HIT_ANIM_FRAMES } from './bumper-shells-config';
+import {
+  SHELL_SCALE,
+  HIT_ANIM_FRAMES,
+  LABEL_Y_OFFSET,
+  DROP_GRAVITY,
+  DROP_FADE_DURATION,
+} from './bumper-shells-config';
 
 // ─── Preloads — fire at module scope so GLBs are warm before a round starts ──
 useGLTF.preload('/models/lobster.glb');
@@ -101,23 +99,42 @@ function lerpAngle(a: number, b: number, t: number): number {
   return a + diff * t;
 }
 
+// ─── Module-scope anchor temp (shared by all player instances) ───────────────
+// anchorInFrontOfCamera uses its own module-scope temporaries — safe.
+const _anchorPos = new THREE.Vector3();
+
 interface BumperShellsPlayerProps {
   entity: BumperShellEntity;
-  /** True if this is the local player (used for highlight, not yet used in 3D). */
+  /** True if this is the local player — triggers self-hit flash via callback. */
   isSelf?: boolean;
+  /** Called when this shell gets hit AND isSelf=true — parent adds screen flash. */
+  onSelfHit?: () => void;
+  /** Player display name — rendered as HTML label above shell. */
+  displayName?: string;
 }
 
-function BumperShellsPlayerInner({ entity, isSelf = false }: BumperShellsPlayerProps) {
+function BumperShellsPlayerInner({
+  entity,
+  isSelf = false,
+  onSelfHit,
+  displayName,
+}: BumperShellsPlayerProps) {
   const species = entity.species ?? 'lobster';
   const glbPath = species === 'crayfish' ? '/models/crayfish.glb' : '/models/lobster.glb';
 
   const { scene: srcScene } = useGLTF(glbPath);
 
+  const { camera } = useThree();
+
   const groupRef    = useRef<THREE.Group>(null);
   const meshRootRef = useRef<THREE.Group>(null);
+  const labelRef    = useRef<HTMLDivElement>(null);
 
   // Hit animation state — managed via ref (no React re-render needed).
   const hitAnim = useRef<ShellHitAnimState>({ active: false, elapsed: 0 });
+
+  // Elimination drop state
+  const dropRef = useRef({ active: false, elapsed: 0, velocityY: 0 });
 
   // Fade state for elimination.
   const fadeRef = useRef({ active: false, opacity: 1 });
@@ -321,16 +338,34 @@ function BumperShellsPlayerInner({ entity, isSelf = false }: BumperShellsPlayerP
       }
     }
 
-    // ─── Elimination fade ─────────────────────────────────────────────────
+    // ─── Elimination: gravity drop + fade ────────────────────────────────────
     if (wasAlive.current && !entity.alive) {
-      // Just eliminated — start fade.
+      // Just eliminated — start physics drop.
       wasAlive.current = false;
+      dropRef.current.active = true;
+      dropRef.current.elapsed = 0;
+      dropRef.current.velocityY = 0;
       fadeRef.current.active = true;
       fadeRef.current.opacity = 1;
+      // Fire knockout sound + hide label immediately
+      if (isSelf) onSelfHit?.();
+      if (labelRef.current) labelRef.current.style.display = 'none';
+    }
+
+    if (dropRef.current.active) {
+      dropRef.current.elapsed += dt;
+      dropRef.current.velocityY -= DROP_GRAVITY * dt;
+      group.position.y += dropRef.current.velocityY * dt;
+      if (dropRef.current.elapsed >= DROP_FADE_DURATION) {
+        dropRef.current.active = false;
+      }
     }
 
     if (fadeRef.current.active) {
-      fadeRef.current.opacity = Math.max(0, fadeRef.current.opacity - dt * 1.0);
+      fadeRef.current.opacity = Math.max(
+        0,
+        fadeRef.current.opacity - dt / DROP_FADE_DURATION,
+      );
       clonedScene.traverse((o) => {
         if ((o as THREE.Mesh).isMesh) {
           const mat = (o as THREE.Mesh).material as THREE.MeshStandardMaterial;
@@ -346,12 +381,27 @@ function BumperShellsPlayerInner({ entity, isSelf = false }: BumperShellsPlayerP
       }
     }
 
+    // ─── Name label: dot-product cull via anchorInFrontOfCamera ──────────────
+    if (labelRef.current && entity.alive && group.visible) {
+      _anchorPos.set(
+        group.position.x,
+        group.position.y + LABEL_Y_OFFSET,
+        group.position.z,
+      );
+      const inFront = anchorInFrontOfCamera(_anchorPos, camera);
+      const display = inFront ? 'flex' : 'none';
+      if (labelRef.current.style.display !== display) {
+        labelRef.current.style.display = display;
+      }
+    }
+
     // Show/hide based on alive state (after any fade completes).
     if (entity.alive && !wasAlive.current) {
       // Re-spawned (future: respawn support).
       wasAlive.current = true;
       group.visible = true;
       fadeRef.current.opacity = 1;
+      dropRef.current.active = false;
     }
   });
 
@@ -369,12 +419,57 @@ function BumperShellsPlayerInner({ entity, isSelf = false }: BumperShellsPlayerP
     };
   });
 
+  const labelText = displayName ?? entity.petId.slice(0, 8);
+
   return (
     <group ref={groupRef} scale={[SHELL_SCALE, SHELL_SCALE, SHELL_SCALE]}>
-      {/* meshRoot receives squash/stretch scale — separate from the position group.
-          clonedScene is a child of meshRoot so the animator's bone mutations
-          and the squash scale compose cleanly: worldScale = outerGroupScale × meshRootScale × boneLocal */}
+      {/* meshRoot receives squash/stretch scale — separate from position group.
+          bone mutations from animator + root scale compose cleanly. */}
       <group ref={meshRootRef} />
+
+      {/* Name label — drei <Html> DOM portal, safe on Iris Xe.
+          NO drei Text/Billboard — hard GPU crash on integrated graphics.
+          Visibility controlled imperatively via labelRef in useFrame.
+          NO distanceFactor — per-frame camera distance recompute (perf hit). */}
+      <Html
+        position={[0, LABEL_Y_OFFSET / SHELL_SCALE, 0]}
+        center
+        occlude={false}
+        zIndexRange={[20, 100]}
+        style={{ pointerEvents: 'none' }}
+      >
+        <div
+          ref={labelRef}
+          style={{
+            display: 'none',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 2,
+            userSelect: 'none',
+            pointerEvents: 'none',
+          }}
+        >
+          <span
+            style={{
+              color: isSelf ? '#00e5ff' : '#ffffff',
+              fontSize: '11px',
+              fontFamily: 'ui-sans-serif, system-ui, sans-serif',
+              fontWeight: isSelf ? 700 : 500,
+              textShadow: '0 1px 4px rgba(0,0,0,0.9), 0 0 8px rgba(0,0,0,0.7)',
+              letterSpacing: '0.04em',
+              whiteSpace: 'nowrap',
+              background: isSelf
+                ? 'rgba(0,20,40,0.75)'
+                : 'rgba(0,0,0,0.55)',
+              padding: '2px 7px',
+              borderRadius: 4,
+              border: isSelf ? '1px solid rgba(0,229,255,0.5)' : 'none',
+            }}
+          >
+            {labelText}
+          </span>
+        </div>
+      </Html>
     </group>
   );
 }

--- a/apps/web/src/lib/three/activities/bumper-shells/BumperShellsScene.tsx
+++ b/apps/web/src/lib/three/activities/bumper-shells/BumperShellsScene.tsx
@@ -3,51 +3,45 @@
 /**
  * BumperShellsScene.tsx
  *
- * Root R3F Canvas for the Bumper Shells minigame.
+ * REBUILT 2026-04-24 — Perspective chase camera + full VFX pipeline.
  *
- * Route: /activity/bumper-shells/[roomId] (page.tsx — owned by general-purpose agent)
+ * Route: /activity/bumper-shells/[roomId]
  *
  * Architecture:
- *   - Isolated from the open world — mounts on its own Next.js route.
+ *   - Isolated from open world — mounts on its own Next.js route.
  *   - `key={roomId}` on Canvas forces full WebGPU context recreation between rooms.
- *   - Static OrthographicCamera (top-down with slight isometric tilt) when no spectator mode.
- *   - Spectator modes (chunk #12a): 'follow' | 'free' | 'action' — single PerspectiveCamera,
- *     swapped in when spectatorCamMode is set. Active players always use the static ortho camera.
+ *   - ACTIVE PLAYERS: Perspective chase camera (ChaseCameraController) follows selfPetId.
+ *     Camera lerps behind player in velocity direction, tilts on acceleration.
+ *     Camera shake on hits involving self (SHAKE_MAX_DISPLACEMENT, SHAKE_DECAY).
+ *     Screen-edge red DOM flash when self is hit (FLASH_DURATION_S).
+ *   - SPECTATOR: SpectatorCamera (follow/free/action) — unchanged from chunk #12a.
  *   - <PreCompilePipelines> fires compileAsync after first R3F commit.
- *   - Reads `useActivityStore` for entity/pickup/event state (written by general-purpose WS hook).
+ *   - Reads `useActivityStore` for entity/pickup/event state.
  *
- * Iris Xe invariants enforced here:
- *   - No drei Text/Billboard anywhere.
- *   - No InstancedMesh + ShaderMaterial.
- *   - No per-frame allocations in useFrame (module-scope scratch vectors only).
- *   - 1 shadow map at 512×512.
+ * Iris Xe invariants:
+ *   - No drei Text/Billboard (hard GPU crash on integrated graphics).
+ *   - No InstancedMesh + ShaderMaterial (silent WebGPU blank canvas).
+ *   - No per-frame allocations (module-scope scratch vectors only).
+ *   - 1 shadow map at 1024×1024 (up from 512 — chase cam is much closer).
  *   - 0 post-processing passes.
- *   - Fog near (1400) / far (1500) — pushed past camera distance (~1140wu) so
- *     fog only touches clip-plane fringe, not the arena. Old 200/900 made the
- *     entire arena invisible (all geometry was > FOG_FAR from the ortho cam).
- *   - OrbitControls added only for 'free' mode; disabled on mode exit.
- *   - ONE camera per client across all modes — no extra shadow frusta.
+ *   - Fog near 900 / far 1800 — safe behind camera.far=2500.
+ *   - ONE perspective camera per client regardless of mode.
  *
  * Performance budget: ≤60 draw calls / ≤180k tris.
  *
- * Spectator camera modes (chunk #12a):
- *   undefined           → static ortho camera (default for active players)
- *   'follow'            → perspective, lerps toward spectatorTarget + offset
- *   'free'              → perspective + OrbitControls, bounded 600–1500wu
- *   'action'            → perspective, auto-follows highest kill-count / most-recent kill
- *
- * Props accepted by parent route:
+ * Props:
  *   <BumperShellsScene roomId={roomId} selfPetId={selfPetId} />
  *   <BumperShellsScene roomId={roomId} selfPetId={selfPetId}
  *     spectatorCamMode="follow" spectatorTargetPetId={petId} />
  */
 
-import { Suspense, useEffect, useRef, useMemo, useCallback } from 'react';
+import { Suspense, useEffect, useRef, useMemo, useCallback, useState } from 'react';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three/webgpu';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { extend } from '@react-three/fiber';
 import type { ThreeToJSXElements } from '@react-three/fiber';
+import { playActivitySound } from '@/lib/activity-audio';
 
 // Register Three.js WebGPU elements with R3F.
 declare module '@react-three/fiber' {
@@ -64,10 +58,14 @@ import {
   FOG_COLOR,
   FOG_NEAR,
   FOG_FAR,
-  CAMERA_ORTHO_SIZE,
+  CAMERA_FOV,
   CAMERA_NEAR,
   CAMERA_FAR,
-  CAMERA_POSITION,
+  SPECTATOR_FOV,
+  CHASE_CAM_DISTANCE,
+  CHASE_CAM_HEIGHT,
+  CHASE_CAM_LOOK_AHEAD,
+  CHASE_CAM_LERP_ALPHA,
   HEMI_SKY_COLOR,
   HEMI_GROUND_COLOR,
   HEMI_INTENSITY,
@@ -78,8 +76,13 @@ import {
   DIR_SHADOW_NEAR,
   DIR_SHADOW_FAR,
   DIR_SHADOW_CAM_BOUNDS,
+  SHAKE_MAX_DISPLACEMENT,
+  SHAKE_DECAY,
+  SHAKE_FREQ,
+  FLASH_DURATION_S,
   HAZARD_ENABLED,
   MAX_PLAYERS,
+  ARENA_HEIGHT,
 } from './bumper-shells-config';
 import type { BumperShellEntity, BumperPickup, BumperHitEvent } from './bumper-shells-types';
 
@@ -95,26 +98,29 @@ export type SpectatorCamMode = 'follow' | 'free' | 'action';
 
 // ─── Module-scope scratch — NO per-frame allocations ─────────────────────────
 const _hitCheckScratch = { lastHitCount: 0 };
+const _elimCheckScratch = { lastElimCount: 0 };
 
-// Spectator camera scratch vectors (shared across all modes).
+// Chase camera scratch vectors
+const _chaseDesiredPos = new THREE.Vector3();
+const _chaseLookAt     = new THREE.Vector3();
+const _chaseEntityPos  = new THREE.Vector3();
+const _chaseVel        = new THREE.Vector3();
+const _chaseFwd        = new THREE.Vector3();
+const _chaseShake      = new THREE.Vector3();
+
+// Spectator camera scratch vectors
 const _camTargetPos  = new THREE.Vector3();
 const _camDesiredPos = new THREE.Vector3();
-const _camOffset     = new THREE.Vector3();
 const _camLookAt     = new THREE.Vector3();
 const _entityPos     = new THREE.Vector3();
 
-// Spectator 'follow' mode: offset from target in world space.
-// Above (Y) + behind (Z in world space, since arena is top-down).
+// Spectator 'follow' offset (high up + back in world space)
 const FOLLOW_OFFSET = new THREE.Vector3(0, 400, 350);
 
-// 'action' mode: re-sample target every N seconds.
-const ACTION_RETARGET_INTERVAL = 3.0; // seconds
+// 'action' mode re-sample interval
+const ACTION_RETARGET_INTERVAL = 3.0;
 
-// Perspective camera FOV for spectator modes.
-const SPECTATOR_FOV = 55;
-
-// Lerp alpha per second for smooth camera movement.
-// 1 - Math.exp(-alpha * dt) gives frame-rate independent lerp.
+// Lerp alpha for spectator camera smoothing
 const CAMERA_LERP_ALPHA = 4.0;
 
 // ─── PreCompilePipelines ──────────────────────────────────────────────────────
@@ -135,27 +141,92 @@ function PreCompilePipelines() {
   return null;
 }
 
-// ─── Static Orthographic Camera ────────────────────────────────────────────────
-// Used when spectatorCamMode is undefined (active player default).
-// Camera never moves after mount — matrixAutoUpdate=false.
-function BumperOrthoCamera() {
-  const { camera, size } = useThree();
+// ─── Chase Camera Controller ──────────────────────────────────────────────────
+// Follows selfPetId with a CHASE_CAM_DISTANCE arm and CHASE_CAM_HEIGHT elevation.
+// Camera lerps position + lookAt with CHASE_CAM_LERP_ALPHA exp decay.
+// Camera shake applied on top of the lerped position via _chaseShake.
+
+interface ChaseCameraProps {
+  selfPetId: string | null;
+  entities: Map<string, BumperShellEntity>;
+  shakeRef: React.MutableRefObject<number>; // current shake magnitude
+}
+
+function ChaseCameraController({ selfPetId, entities, shakeRef }: ChaseCameraProps) {
+  const { camera } = useThree();
+  const cameraYawRef = useRef(0); // persists last known yaw for dead-reckoning
 
   useEffect(() => {
-    const ortho = camera as THREE.OrthographicCamera;
-    ortho.left   = -CAMERA_ORTHO_SIZE;
-    ortho.right  =  CAMERA_ORTHO_SIZE;
-    ortho.top    =  CAMERA_ORTHO_SIZE;
-    ortho.bottom = -CAMERA_ORTHO_SIZE;
-    ortho.near   = CAMERA_NEAR;
-    ortho.far    = CAMERA_FAR;
-    ortho.position.set(CAMERA_POSITION[0], CAMERA_POSITION[1], CAMERA_POSITION[2]);
-    ortho.lookAt(0, 0, 0);
-    ortho.updateProjectionMatrix();
-    // Camera is static — disable per-frame matrix updates.
-    ortho.matrixAutoUpdate = false;
-    ortho.updateMatrix();
-  }, [camera, size]);
+    const p = camera as THREE.PerspectiveCamera;
+    p.fov  = CAMERA_FOV;
+    p.near = CAMERA_NEAR;
+    p.far  = CAMERA_FAR;
+    p.updateProjectionMatrix();
+    // Initial position — behind where a player would start
+    p.position.set(0, CHASE_CAM_HEIGHT, CHASE_CAM_DISTANCE);
+    p.lookAt(0, ARENA_HEIGHT / 2, 0);
+  }, [camera]);
+
+  useFrame((_, delta) => {
+    const dt = Math.min(delta, 0.1);
+
+    // Find self entity
+    const self = selfPetId ? entities.get(selfPetId) : null;
+
+    if (!self || !self.alive) {
+      // No target — orbit to a birds-eye view above center
+      _chaseDesiredPos.set(0, CHASE_CAM_HEIGHT * 1.5, CHASE_CAM_DISTANCE * 0.5);
+      _chaseLookAt.set(0, ARENA_HEIGHT / 2, 0);
+    } else {
+      _chaseEntityPos.set(self.x, ARENA_HEIGHT / 2, self.y);
+
+      // Derive camera yaw from velocity when moving, dead-reckon otherwise
+      const speed = Math.sqrt(self.vx * self.vx + self.vy * self.vy);
+      if (speed > 20) {
+        cameraYawRef.current = Math.atan2(self.vx, self.vy);
+      }
+      const yaw = cameraYawRef.current;
+
+      // Camera arm: CHASE_CAM_DISTANCE behind player in velocity direction
+      const sinY = Math.sin(yaw);
+      const cosY = Math.cos(yaw);
+      _chaseDesiredPos.set(
+        _chaseEntityPos.x - sinY * CHASE_CAM_DISTANCE,
+        CHASE_CAM_HEIGHT,
+        _chaseEntityPos.z - cosY * CHASE_CAM_DISTANCE,
+      );
+
+      // Look-ahead: aim slightly in front of player
+      const lookAheadFrac = Math.min(speed / 200, 1) * CHASE_CAM_LOOK_AHEAD;
+      _chaseLookAt.set(
+        _chaseEntityPos.x + sinY * lookAheadFrac,
+        ARENA_HEIGHT / 2 + 30,
+        _chaseEntityPos.z + cosY * lookAheadFrac,
+      );
+    }
+
+    // Camera shake: attenuate shake ref each frame
+    const shakeAmt = shakeRef.current;
+    if (shakeAmt > 0.01) {
+      shakeRef.current = Math.max(0, shakeAmt - shakeAmt * SHAKE_DECAY * dt);
+      const t = performance.now() * SHAKE_FREQ * 0.001;
+      _chaseShake.set(
+        Math.sin(t * 1.3) * shakeAmt,
+        Math.cos(t * 0.9) * shakeAmt * 0.5,
+        Math.sin(t * 1.7) * shakeAmt * 0.3,
+      );
+    } else {
+      shakeRef.current = 0;
+      _chaseShake.set(0, 0, 0);
+    }
+
+    // Exp-decay lerp for position + lookAt
+    const alpha = 1.0 - Math.exp(-CHASE_CAM_LERP_ALPHA * dt);
+    camera.position.lerp(_chaseDesiredPos, alpha);
+    camera.position.add(_chaseShake);
+    camera.lookAt(_chaseLookAt);
+    camera.updateProjectionMatrix();
+  });
 
   return null;
 }
@@ -375,30 +446,57 @@ function BumperLight() {
 }
 
 // ─── Hit event processor ──────────────────────────────────────────────────────
-// Processes hit events from the store and calls triggerBurst imperatively.
-// Runs in useFrame to avoid re-renders.
-function HitEventProcessor() {
-  const hitsRef = useRef<BumperHitEvent[]>([]);
+// Processes hit + elimination events from the store.
+// Calls triggerBurst imperatively — no React re-renders.
 
+interface HitEventProcessorProps {
+  selfPetId: string | null;
+  onSelfHit: () => void;
+}
+
+function HitEventProcessor({ selfPetId, onSelfHit }: HitEventProcessorProps) {
   useFrame(() => {
-    const hits = useActivityStore.getState().events?.hits;
-    if (!hits) return;
+    const state = useActivityStore.getState();
 
-    // Only process new hits (appended to the array by the store).
-    const len = hits.length;
-    if (len <= _hitCheckScratch.lastHitCount) return;
-
-    for (let i = _hitCheckScratch.lastHitCount; i < len; i++) {
-      const h = hits[i];
-      triggerBurst(h.x, 6, h.y, '#ff6600');
+    // ─ Hits ─
+    const hits = state.events?.hits;
+    if (hits) {
+      const len = hits.length;
+      if (len > _hitCheckScratch.lastHitCount) {
+        for (let i = _hitCheckScratch.lastHitCount; i < len; i++) {
+          const h = hits[i];
+          triggerBurst(h.x, ARENA_HEIGHT / 2 + 4, h.y, '#ff8800');
+        }
+        _hitCheckScratch.lastHitCount = len;
+      }
     }
-    _hitCheckScratch.lastHitCount = len;
+
+    // ─ Eliminations ─ play knockout sound + self-hit callback
+    const elims = state.events?.eliminations;
+    if (elims) {
+      const len = elims.length;
+      if (len > _elimCheckScratch.lastElimCount) {
+        for (let i = _elimCheckScratch.lastElimCount; i < len; i++) {
+          const e = elims[i];
+          playActivitySound('knockout').catch(() => {});
+          // Bigger burst for elimination impact
+          triggerBurst(
+            state.entities?.get(e.petId)?.x ?? 0,
+            ARENA_HEIGHT / 2 + 4,
+            state.entities?.get(e.petId)?.y ?? 0,
+            '#ff3300',
+          );
+          if (e.petId === selfPetId) onSelfHit();
+        }
+        _elimCheckScratch.lastElimCount = len;
+      }
+    }
   });
 
   return null;
 }
 
-// ─── Scene contents (shared between ortho + perspective canvas) ───────────────
+// ─── Scene contents ────────────────────────────────────────────────────────────
 
 interface SceneContentsProps {
   entities: Map<string, BumperShellEntity>;
@@ -406,6 +504,8 @@ interface SceneContentsProps {
   selfPetId: string | null;
   spectatorCamMode?: SpectatorCamMode;
   spectatorTargetPetId?: string | null;
+  shakeRef: React.MutableRefObject<number>;
+  onSelfHit: () => void;
 }
 
 function SceneContents({
@@ -414,10 +514,12 @@ function SceneContents({
   selfPetId,
   spectatorCamMode,
   spectatorTargetPetId,
+  shakeRef,
+  onSelfHit,
 }: SceneContentsProps) {
   return (
     <>
-      {/* Camera — ortho for active play, perspective for spectators. */}
+      {/* Camera — perspective chase for active play, spectator cam when spectating */}
       {spectatorCamMode ? (
         <SpectatorCamera
           mode={spectatorCamMode}
@@ -425,29 +527,35 @@ function SceneContents({
           entities={entities}
         />
       ) : (
-        <BumperOrthoCamera />
+        <ChaseCameraController
+          selfPetId={selfPetId}
+          entities={entities}
+          shakeRef={shakeRef}
+        />
       )}
 
       {/* Atmosphere */}
       <fog args={[FOG_COLOR, FOG_NEAR, FOG_FAR]} />
       <color attach="background" args={[FOG_COLOR]} />
 
-      {/* Lighting — 1 shadow map at 512×512, 3 point lights (no shadows) */}
+      {/* Lighting — 1 shadow map, hemisphere fill */}
       <BumperLight />
 
-      {/* Arena geometry — 4 draw calls */}
+      {/* Arena geometry — 8 draw calls (platform, tile, rim, bumper wall, danger, void, stars, [lights=0]) */}
       <BumperShellsArena />
 
       {/* Central hazard — 2 draw calls */}
       <BumperShellsHazard enabled={HAZARD_ENABLED} />
 
-      {/* Player shells — up to 8 draw calls */}
+      {/* Player shells — up to 8 draw calls (1 per GLB clone) */}
       <Suspense fallback={null}>
         {Array.from(entities.values()).map((entity) => (
           <BumperShellsPlayer
             key={entity.petId}
             entity={entity}
             isSelf={entity.petId === selfPetId}
+            onSelfHit={onSelfHit}
+            displayName={entity.petId.slice(0, 10)}
           />
         ))}
       </Suspense>
@@ -455,13 +563,13 @@ function SceneContents({
       {/* Power-up pickups — up to 6 draw calls */}
       <BumperShellsPickups pickups={pickups} />
 
-      {/* Particle burst pool — 4 Points objects, max 16 pts each */}
+      {/* Particle burst pool — 6 Points objects */}
       <BumperShellsParticles />
 
-      {/* Hit event → burst trigger (no React re-renders) */}
-      <HitEventProcessor />
+      {/* Hit + elimination event processor (no React re-renders) */}
+      <HitEventProcessor selfPetId={selfPetId} onSelfHit={onSelfHit} />
 
-      {/* Pipeline pre-compilation — must be LAST inside SceneContents */}
+      {/* Pipeline pre-compilation — MUST be LAST inside SceneContents */}
       <PreCompilePipelines />
     </>
   );
@@ -472,18 +580,17 @@ function SceneContents({
 export interface BumperShellsSceneProps {
   /** Room ID — used as Canvas key to force context recreation between rooms. */
   roomId: string;
-  /** The current user's pet ID, used for self-highlighting. */
+  /** The current user's pet ID, used for chase camera + self-hit flash. */
   selfPetId?: string | null;
   /**
-   * Spectator camera mode. When undefined, the default static orthographic
-   * camera is used (active player view — Iris Xe budget: one fixed frustum).
+   * Spectator camera mode. When undefined, the perspective chase camera follows selfPetId.
    *
-   * When set, a single PerspectiveCamera replaces the ortho camera:
+   * When set, spectator camera is used:
    *   'follow' — lerps toward spectatorTargetPetId (or first alive entity).
    *   'free'   — OrbitControls, distance bounded 600–1500wu.
    *   'action' — auto-follows arena center entity, retargets every 3s.
    *
-   * ONE camera per client regardless of mode — no extra shadow frusta.
+   * ONE PerspectiveCamera per client regardless of mode.
    */
   spectatorCamMode?: SpectatorCamMode;
   /**
@@ -499,25 +606,48 @@ export default function BumperShellsScene({
   spectatorCamMode,
   spectatorTargetPetId,
 }: BumperShellsSceneProps) {
-  // Subscribe to activity store — high-frequency path, keep subscriptions narrow.
   const entities = useActivityStore((s) => s.entities as Map<string, BumperShellEntity>);
   const pickups  = useActivityStore((s) => s.pickups  as Map<string, BumperPickup>);
 
-  // Spectator camera: use a PerspectiveCamera canvas; active play uses OrthographicCamera.
-  // The canvas `orthographic` prop is static — we mount two different canvas configs.
-  // The `key` on Canvas forces context recreation when switching modes or rooms.
-  const canvasKey = `${roomId}-${spectatorCamMode ?? 'ortho'}`;
+  // Camera shake magnitude (shared between ChaseCameraController and HitEventProcessor)
+  // Stored as a mutable ref to avoid React re-renders in the hot useFrame path.
+  const shakeRef = useRef(0);
 
-  if (spectatorCamMode) {
-    // Spectator canvas: PerspectiveCamera (R3F default when orthographic is omitted).
-    return (
+  // Screen flash state — DOM overlay, not Three.js.
+  const [flashOpacity, setFlashOpacity] = useState(0);
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleSelfHit = useCallback(() => {
+    // Trigger camera shake
+    shakeRef.current = SHAKE_MAX_DISPLACEMENT;
+
+    // Trigger red screen flash
+    setFlashOpacity(0.45);
+    if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    flashTimerRef.current = setTimeout(() => {
+      setFlashOpacity(0);
+    }, FLASH_DURATION_S * 1000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    };
+  }, []);
+
+  // ALL canvas instances use PerspectiveCamera — no orthographic in the rebuild.
+  // The `key` forces context recreation between rooms and spectator mode changes.
+  const canvasKey = `${roomId}-${spectatorCamMode ?? 'chase'}`;
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       <Canvas
         key={canvasKey}
         camera={{
-          fov: SPECTATOR_FOV,
+          fov: spectatorCamMode ? SPECTATOR_FOV : CAMERA_FOV,
           near: CAMERA_NEAR,
           far: CAMERA_FAR,
-          position: [0, 900, 600],
+          position: [0, CHASE_CAM_HEIGHT, CHASE_CAM_DISTANCE],
         }}
         shadows
         gl={{ antialias: false }} // Disable MSAA for Iris Xe perf budget
@@ -530,35 +660,27 @@ export default function BumperShellsScene({
           selfPetId={selfPetId}
           spectatorCamMode={spectatorCamMode}
           spectatorTargetPetId={spectatorTargetPetId}
+          shakeRef={shakeRef}
+          onSelfHit={handleSelfHit}
         />
       </Canvas>
-    );
-  }
 
-  // Active-play canvas: OrthographicCamera (static, Iris Xe budget — one fixed frustum).
-  return (
-    <Canvas
-      key={canvasKey}
-      camera={
-        {
-          // R3F will create an OrthographicCamera when these are passed:
-          // (orthographic=true is not a valid R3F prop — we configure it in BumperOrthoCamera)
-          // Use PerspectiveCamera as default; BumperOrthoCamera overrides projection.
-          near: CAMERA_NEAR,
-          far: CAMERA_FAR,
-        } as any
-      }
-      orthographic
-      shadows
-      gl={{ antialias: false }} // Disable MSAA for Iris Xe perf budget
-      style={{ width: '100%', height: '100%' }}
-      dpr={[1, 1.5]} // Clamp pixel ratio for Iris Xe
-    >
-      <SceneContents
-        entities={entities ?? new Map()}
-        pickups={pickups ?? new Map()}
-        selfPetId={selfPetId}
+      {/* Screen-edge red flash — DOM overlay, transitions via CSS opacity.
+          Appears on self-hit, fades to 0 after FLASH_DURATION_S.
+          This is a DOM overlay on top of the canvas, not inside Three.js. */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          pointerEvents: 'none',
+          background: 'radial-gradient(ellipse at center, transparent 40%, rgba(200,0,0,0.7) 100%)',
+          opacity: flashOpacity,
+          transition: flashOpacity > 0
+            ? 'opacity 0.05s ease-in'
+            : `opacity ${FLASH_DURATION_S * 0.8}s ease-out`,
+        }}
       />
-    </Canvas>
+    </div>
   );
 }

--- a/apps/web/src/lib/three/activities/bumper-shells/bumper-shells-config.ts
+++ b/apps/web/src/lib/three/activities/bumper-shells/bumper-shells-config.ts
@@ -5,31 +5,39 @@
  * Centralised here so BumperShellsArena, BumperShellsHazard, BumperShellsPlayer,
  * BumperShellsPickups, and BumperShellsParticles all read from one source.
  *
- * Performance budget: ≤60 draw calls / ≤180k tris / 1×512² shadow map / 0 post-processing.
- * Target GPU: Intel Iris Xe (integrated).
+ * REBUILD 2026-04-24: Perspective chase camera, real arena geometry, VFX pipeline.
+ *
+ * Performance budget: ≤60 draw calls / ≤180k tris / 1×1024² shadow map / 0 post-processing.
+ * Target GPU: Intel Iris Xe (integrated) @ 30fps mobile minimum, 60fps desktop target.
  */
 
 // ─── Arena geometry ──────────────────────────────────────────────────────────
 
-/** Flat disc radius in world-units (wu). */
+/** Flat disc radius in world-units (wu). Sim boundary unchanged. */
 export const ARENA_RADIUS = 500;
 
-/** Platform cylinder height. */
-export const ARENA_HEIGHT = 12;
+/** Platform cylinder height — thicker for visual depth from perspective cam. */
+export const ARENA_HEIGHT = 24;
 
-/** Radial segments for the platform disc — 48 keeps the rim smooth at 500wu. */
-export const ARENA_RADIAL_SEGMENTS = 48;
+/** Radial segments for the platform disc — 64 for smooth silhouette. */
+export const ARENA_RADIAL_SEGMENTS = 64;
 
 // ─── Boundary / rim ──────────────────────────────────────────────────────────
 
-/** Rim glow torus outer-tube radius. */
-export const RIM_TUBE_RADIUS = 8;
+/** Rim glow torus outer-tube radius — thicker for perspective readability. */
+export const RIM_TUBE_RADIUS = 14;
 
-/** Rim glow torus radial segments (lower = fewer draw-call verts). */
+/** Rim glow torus radial segments. */
 export const RIM_RADIAL_SEGMENTS = 16;
 
 /** Rim glow torus tubular segments. */
-export const RIM_TUBULAR_SEGMENTS = 64;
+export const RIM_TUBULAR_SEGMENTS = 80;
+
+/** Bumper wall height — knee-high guardrail at arena edge visible from chase cam. */
+export const BUMPER_WALL_HEIGHT = 44;
+
+/** Bumper wall tube radius — visual thickness of the guardrail. */
+export const BUMPER_WALL_TUBE_RADIUS = 10;
 
 /** Outer fraction of arena radius considered a "danger zone" (0–1). */
 export const DANGER_ZONE_FRACTION = 0.15;
@@ -51,76 +59,111 @@ export const HAZARD_SPIKE_COUNT = 8;
 /** Hazard rotation speed in radians per second. */
 export const HAZARD_SPIN_SPEED = 0.5;
 
-// ─── Camera ──────────────────────────────────────────────────────────────────
+// ─── Camera — perspective chase ───────────────────────────────────────────────
 
-/** Orthographic camera frustum half-width/height in wu. */
-export const CAMERA_ORTHO_SIZE = 700;
+/**
+ * Perspective camera FOV in degrees.
+ * 55° gives a natural-feeling game view for competitive bumper gameplay.
+ */
+export const CAMERA_FOV = 55;
 
 /** Camera near clip plane. */
 export const CAMERA_NEAR = 1;
 
-/** Camera far clip plane. Must be > FOG_FAR. */
-export const CAMERA_FAR = 1500;
+/**
+ * Camera far clip plane.
+ * Chase cam sits ~300wu above player at ~420wu back. The void is at -2000wu.
+ * 2500wu gives margin. Fog dissolves before the clip plane.
+ */
+export const CAMERA_FAR = 2500;
 
-/** Camera position — slight isometric tilt (not pure top-down). */
-export const CAMERA_POSITION = [0, 1100, 300] as const;
+/** Chase camera horizontal arm length in wu. */
+export const CHASE_CAM_DISTANCE = 420;
 
-/** Camera look-at target. */
-export const CAMERA_LOOK_AT = [0, 0, 0] as const;
+/** Chase camera height above arena floor in wu. */
+export const CHASE_CAM_HEIGHT = 280;
+
+/** Look-ahead distance: the camera aims ahead of the player in their velocity direction. */
+export const CHASE_CAM_LOOK_AHEAD = 60;
+
+/** Camera position lerp alpha per second (frame-rate independent exp decay). */
+export const CHASE_CAM_LERP_ALPHA = 5.0;
+
+/** Spectator camera FOV in degrees (same as player for consistency). */
+export const SPECTATOR_FOV = 55;
 
 // ─── Fog ─────────────────────────────────────────────────────────────────────
 
-/** Fog color hex — deep ocean dark blue. */
-export const FOG_COLOR = '#050a14';
+/** Fog color hex — deep abyss. */
+export const FOG_COLOR = '#020508';
 
 /**
- * Fog near distance.
+ * Fog near/far for the perspective chase camera.
  *
- * BUG FIX (2026-04-24): The ortho camera sits at [0, 1100, 300] → distance to
- * arena floor ≈ sqrt(1100²+300²) ≈ 1140wu. The old FOG_NEAR=200/FOG_FAR=900
- * made every scene object 100% fogged (all ≥1140wu from camera > FAR=900).
- * Result: black void on mobile. Fix: push fog well past CAMERA_FAR so it only
- * kills geometry right at the clip plane, not the visible arena.
+ * Chase cam is ~300wu above the disc, at ~420wu behind the player.
+ * The arena disc is 500wu radius — fully visible within ~600wu of the player.
+ * Fog starts at 900wu (beyond arena edge) and completes at 1800wu.
+ * This preserves full arena visibility while hiding the void seam.
  *
- * Iris Xe perf note: fog.far > camera.far IS a fragment-count risk in the open
- * world (see performance/fog-density-iris-xe-regression.md). In THIS scene it's
- * fine — fog.far=CAMERA_FAR-50 clamps fog to clip-plane fringe only.
+ * Iris Xe perf: fog.far (1800) < camera.far (2500) — safe, no overdraw spike.
+ * See performance/fog-density-iris-xe-regression.md.
  */
-export const FOG_NEAR = 1400;
-export const FOG_FAR  = 1500; // == CAMERA_FAR — fog only touches clip-plane geometry
+export const FOG_NEAR = 900;
+export const FOG_FAR  = 1800;
 
 // ─── Lighting ────────────────────────────────────────────────────────────────
 
-/**
- * Lighting fix (2026-04-24): previous values were tuned as if the camera were
- * close to the arena (normal scene). With a ~1140wu camera-to-floor distance
- * and PBR materials that receive ambient + diffuse, the old HEMI_INTENSITY=0.4
- * with a near-black sky colour (#1a3a5c) produced near-black lobsters even when
- * the fog bug was absent. Brightness raised to match what looks correct at this
- * distance with MeshStandardMaterial.
- */
-export const HEMI_SKY_COLOR    = '#4488cc'; // visible blue — was '#1a3a5c' (near-black)
-export const HEMI_GROUND_COLOR = '#1a2a3a'; // dark ocean floor — was '#050a14'
-export const HEMI_INTENSITY    = 1.4;       // was 0.4 — PBR models need ≥1.0 to read clearly
+/** Hemisphere sky color — deep ocean blue fill. */
+export const HEMI_SKY_COLOR    = '#1a3a6a';
 
-export const DIR_COLOR     = '#ffffff';     // white — was '#80d4ff' (dim blue)
-export const DIR_INTENSITY = 2.0;           // was 1.1 — need strong key for lobster PBR shells
-export const DIR_POSITION  = [200, 600, 150] as const;
-export const DIR_SHADOW_MAP_SIZE = 512;
+/** Hemisphere ground color — dark abyss. */
+export const HEMI_GROUND_COLOR = '#050a14';
+
+/** Hemisphere intensity — fills the shadow side of shells so they read clearly. */
+export const HEMI_INTENSITY    = 1.2;
+
+/** Key directional light color — warm white for PBR shell sheen. */
+export const DIR_COLOR     = '#fff8f0';
+
+/** Key directional light intensity — strong for lobster PBR shells. */
+export const DIR_INTENSITY = 2.2;
+
+/** Key light position — above and to side for dramatic angle + good shadow direction. */
+export const DIR_POSITION  = [300, 500, 200] as const;
+
+/** Shadow map size — 1024 for soft PCF shadows visible from chase cam. */
+export const DIR_SHADOW_MAP_SIZE = 1024;
+
 export const DIR_SHADOW_NEAR = 1;
 export const DIR_SHADOW_FAR = 1200;
-export const DIR_SHADOW_CAM_BOUNDS = 600;
+
+/** Shadow frustum covers the full arena disc + some margin. */
+export const DIR_SHADOW_CAM_BOUNDS = 560;
+
+/** Rim accent point light color — cyan underwater glow. */
+export const RIM_LIGHT_COLOR = '#00ccff';
+
+/** Rim accent light intensity. */
+export const RIM_LIGHT_INTENSITY = 1.5;
+
+/** Rim accent light decay distance in wu. */
+export const RIM_LIGHT_DISTANCE = 800;
 
 // ─── Player shells ───────────────────────────────────────────────────────────
 
 /**
  * Scale applied to lobster.glb / crayfish.glb clones.
- * Matches PET_SCALE=40 from player-pet.tsx (lobster.glb bbox.max.y ≈ 1.12 native → 44.8 wu).
+ * lobster.glb native height ≈ 1.12 → SHELL_SCALE=40 → 44.8wu.
  */
 export const SHELL_SCALE = 40;
 
 /** Maximum simultaneously-rendered player shells. */
 export const MAX_PLAYERS = 8;
+
+// ─── Player name labels ───────────────────────────────────────────────────────
+
+/** Y offset of name label above player shell group origin (in wu). */
+export const LABEL_Y_OFFSET = 72;
 
 // ─── Squash/stretch animation ────────────────────────────────────────────────
 
@@ -152,19 +195,19 @@ export const PICKUP_BOB_FREQ = 2;
 export const PICKUP_SPIN_SPEED = 1.2;
 
 /** Y position of pickups above arena surface. */
-export const PICKUP_BASE_Y = 40;
+export const PICKUP_BASE_Y = 50;
 
 /**
  * Emissive colour per power-up kind.
  * Used on MeshStandardMaterial — never ShaderMaterial.
  */
 export const PICKUP_EMISSIVE: Record<string, string> = {
-  speed:       '#00e5ff',
-  shield:      '#69f0ae',
+  speed:         '#00e5ff',
+  shield:        '#69f0ae',
   'sticky-bomb': '#ff6d00',
-  whirlpool:   '#9c27b0',
-  ghost:       '#e0e0e0',
-  tractor:     '#f9a825',
+  whirlpool:     '#9c27b0',
+  ghost:         '#e0e0e0',
+  tractor:       '#f9a825',
 };
 
 /**
@@ -172,35 +215,69 @@ export const PICKUP_EMISSIVE: Record<string, string> = {
  * NO drei <Text> — Iris Xe crash.
  */
 export const PICKUP_EMOJI: Record<string, string> = {
-  speed:       '⚡',
-  shield:      '🛡',
+  speed:         '⚡',
+  shield:        '🛡',
   'sticky-bomb': '💣',
-  whirlpool:   '🌊',
-  ghost:       '👻',
-  tractor:     '🧜',
+  whirlpool:     '🌊',
+  ghost:         '👻',
+  tractor:       '🧲',
 };
 
 // ─── Particle bursts ─────────────────────────────────────────────────────────
 
 /** Number of burst pool slots — max simultaneous bursts visible. */
-export const BURST_POOL_SIZE = 4;
+export const BURST_POOL_SIZE = 6;
 
 /** Points per burst instance. Keep ≤ 16 for Iris Xe fragment budget. */
-export const BURST_POINT_COUNT = 16;
+export const BURST_POINT_COUNT = 12;
 
-/** Burst radius in wu — how far points scatter from impact point. */
-export const BURST_RADIUS = 80;
+/** Burst radius in wu — how far points scatter from impact. */
+export const BURST_RADIUS = 100;
 
 /** Burst lifetime in milliseconds. */
-export const BURST_LIFETIME_MS = 400;
+export const BURST_LIFETIME_MS = 500;
 
 /** Burst point size in pixels. */
-export const BURST_POINT_SIZE = 6;
+export const BURST_POINT_SIZE = 8;
 
-// ─── Void backdrop ───────────────────────────────────────────────────────────
+// ─── Camera shake ─────────────────────────────────────────────────────────────
 
-/** Y position of the infinite void plane below the arena. */
+/** Maximum camera shake displacement in wu on a direct hit. */
+export const SHAKE_MAX_DISPLACEMENT = 18;
+
+/** Shake decay rate per second (exp). */
+export const SHAKE_DECAY = 8.0;
+
+/** Shake oscillation frequency in Hz. */
+export const SHAKE_FREQ = 30;
+
+// ─── Screen flash ─────────────────────────────────────────────────────────────
+
+/** Red screen-edge flash duration on self-hit in seconds. */
+export const FLASH_DURATION_S = 0.35;
+
+// ─── Elimination drop ─────────────────────────────────────────────────────────
+
+/** Gravitational acceleration for eliminated player drop in wu/s². */
+export const DROP_GRAVITY = 980;
+
+/** Time to full transparent fade after drop starts. */
+export const DROP_FADE_DURATION = 1.0;
+
+// ─── Void / starfield ─────────────────────────────────────────────────────────
+
+/** Y position of the void plane below the arena. */
 export const VOID_BACKDROP_Y = -2000;
 
-/** Void backdrop quad size in wu — large enough to fill the view at CAMERA_FAR. */
-export const VOID_BACKDROP_SIZE = 8000;
+/** Void backdrop quad size in wu. */
+export const VOID_BACKDROP_SIZE = 10000;
+
+/** Number of stars in the void starfield (Points object, 1 draw call). */
+export const STAR_COUNT = 300;
+
+/** Starfield spawn radius in wu from arena center. */
+export const STAR_RADIUS = 1800;
+
+/** Y range of stars — scattered below the arena surface. */
+export const STAR_Y_MIN = -2000;
+export const STAR_Y_MAX = -100;


### PR DESCRIPTION
## What changed

Full rebuild of the Bumper Shells activity scene. The previous state was a top-down orthographic camera pointed at a flat blue ellipse with lobster GLBs standing on it — no depth, no environment, broken on mobile.

## What it looks like now

You drop into a perspective chase camera (FOV 55°) positioned 420wu behind and 280wu above your shell, looking ahead in your velocity direction. The arena is a real 3D cylinder platform lit by a directional key light with PCF shadows, surrounded by a pulsing cyan rim glow torus, a knee-high bumper wall guardrail, and a danger zone ring that throbs red as you approach the edge. Below the platform is the void — a starfield of 300 deterministic points scattered in the abyss. When shells collide, particle bursts scatter upward from the impact point with additive blending. Getting hit shakes the camera; getting eliminated drops your shell into the void with gravity before fading. Name labels float above each shell and vanish when behind the camera.

## Summary

- **ChaseCameraController** — velocity-derived yaw, exp-decay lerp (alpha=5/s), 420wu arm, 280wu height, 60wu look-ahead. Spectator cam (follow/free/action) preserved.
- **BumperShellsArena** — CylinderGeometry platform + tiled PlaneGeometry overlay + TorusGeometry rim glow (pulsed opacity) + bumper wall guardrail + danger zone ring (pulsed emissiveIntensity) + 4 rim PointLights + void backdrop + 300-star starfield. ~8 draw calls, deterministic placement (no `Math.random()`).
- **Lighting** — DirectionalLight with 1024×1024 PCF shadow map (upgraded from 512), HemisphereLight fill, cyan rim accent PointLights.
- **BumperShellsParticles** — pool expanded 4→6 slots, 16→12 pts/burst (Iris Xe fragment budget), upward-biased direction spread, AdditiveBlending PointsMaterial.
- **BumperShellsPlayer** — gravity-drop elimination (980wu/s²) replaces flat fade. drei `<Html>` name labels with dot-product cull (no drei `<Text>` — Iris Xe hard crash). PR #51 interpolation preserved exactly.
- **BumperShellsScene** — `shakeRef` (mutable ref, not state) for zero-allocation camera shake. DOM red screen-edge flash overlay via React state + CSS transition. `knockout.wav` on elimination.
- **Fog** — recomputed for perspective geometry: FOG_NEAR=900 / FOG_FAR=1800 (arena 500wu radius fully visible, void seam dissolves cleanly).

## Perf budget (Iris Xe target)

- ≤60 draw calls
- No per-frame `new THREE.Vector3()`
- No InstancedMesh + ShaderMaterial (WebGPU silent crash rule)
- `frustumCulled=false` on all GLB clones (post-SkeletonUtils.clone)
- `matrixAutoUpdate=false` on all static arena geometry
- `dpr={[1, 1.5]}` + `antialias: false` on Canvas

## Test plan

- [ ] Open the Bumper Shells activity in-game with 2+ players
- [ ] Confirm chase camera follows self shell with smooth velocity-derived yaw
- [ ] Confirm arena geometry (platform, rim glow pulse, danger zone throb, starfield void) renders correctly
- [ ] Confirm name labels appear above shells, vanish when behind camera
- [ ] Trigger a collision — confirm particle burst fires at impact point
- [ ] Confirm camera shake on self-hit + red screen-edge flash fades out
- [ ] Eliminate a player — confirm gravity drop + knockout.wav plays
- [ ] Check browser console: no errors, no "drei Text" warnings
- [ ] FPS ≥ 30 on mobile-class GPU (Intel Iris Xe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)