### PR TITLE
fix(build): drop dead .catch on void playActivitySound

### DIFF
--- a/apps/web/src/lib/three/activities/bumper-shells/BumperShellsScene.tsx
+++ b/apps/web/src/lib/three/activities/bumper-shells/BumperShellsScene.tsx
@@ -478,7 +478,7 @@ function HitEventProcessor({ selfPetId, onSelfHit }: HitEventProcessorProps) {
       if (len > _elimCheckScratch.lastElimCount) {
         for (let i = _elimCheckScratch.lastElimCount; i < len; i++) {
           const e = elims[i];
-          playActivitySound('knockout').catch(() => {});
+          playActivitySound('knockout');
           // Bigger burst for elimination impact
           triggerBurst(
             state.entities?.get(e.petId)?.x ?? 0,


### PR DESCRIPTION
PR #53 web build error — playActivitySound returns void, can't chain .catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)