### PR TITLE
feat(landing): hero refresh — Create Agent, Milady avatar, 3D demos, gameplay grid

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,10 +5,18 @@ import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
 import { HowItWorksModal } from '@/components/landing/how-it-works-modal';
+import { CollaborationAxes } from '@/components/landing/collaboration-axes';
+import { LiveDemoStrip } from '@/components/landing/live-demo-strip';
+import { GameplayShowcase } from '@/components/landing/gameplay-showcase';
 
 const LandingScene = dynamic(() => import('@/components/three/LandingScene'), {
   ssr: false,
 });
+
+const MiladyAvatarShowcase = dynamic(
+  () => import('@/components/landing/MiladyAvatarShowcase'),
+  { ssr: false },
+);
 
 /**
  * Phase 5 — expired-magic-link banner.
@@ -127,15 +135,24 @@ export default function HomePage() {
           <strong className="text-pink-300"> Milady AI</strong> agents walk the same
           streets you do — learning from MiladyAI teachers, from each other, and from you.
         </p>
-        <p className="anim-up max-w-xl text-white/40 text-sm md:text-base mt-3 leading-relaxed font-mono" style={{ animationDelay: '0.48s' }}>
-          <span className="text-cyan-300/80">Agent ↔ Agent</span>
-          <span className="text-white/20"> · </span>
-          <span className="text-emerald-300/80">You ↔ Agent</span>
-          <span className="text-white/20"> · </span>
-          <span className="text-amber-300/80">Your Agent ↔ World</span>
-        </p>
 
+        {/* Hero showcase row — Milady avatar viewer + collaboration-axes
+            diagram side by side on desktop, stacked on mobile. */}
+        <div
+          className="anim-up mt-10 grid grid-cols-1 md:grid-cols-[280px_1fr] gap-8 md:gap-12 items-center max-w-3xl"
+          style={{ animationDelay: '0.55s' }}
+        >
+          <div className="relative w-[260px] h-[340px] sm:w-[280px] sm:h-[360px] mx-auto rounded-2xl border border-pink-400/20 bg-gradient-to-b from-pink-500/[0.06] to-transparent backdrop-blur-sm overflow-hidden shadow-[0_0_40px_rgba(236,72,153,0.12)]">
+            <MiladyAvatarShowcase />
+            <div className="absolute bottom-0 inset-x-0 px-3 py-2 bg-gradient-to-t from-[#061520]/95 to-transparent">
+              <div className="text-[9px] font-mono uppercase tracking-[0.3em] text-pink-300/70 text-center">
+                Milady Avatar · click to swap
+              </div>
+            </div>
+          </div>
 
+          <CollaborationAxes />
+        </div>
 
         {/* Stats strip — live proof of substance */}
         <div className="anim-up mt-10 flex flex-wrap justify-center gap-x-8 gap-y-3 text-center" style={{ animationDelay: '0.5s' }}>
@@ -153,11 +170,20 @@ export default function HomePage() {
           ))}
         </div>
 
-        {/* CTAs — both buttons share the same footprint (w-64 h-14) */}
-        <div className="anim-up flex flex-col sm:flex-row items-center gap-4 mt-10" style={{ animationDelay: '0.55s' }}>
+        {/* CTAs — three primary actions on equal footprint (w-60 h-14).
+            Create Agent is the first-time signup path; Enter ClawVille
+            takes you straight to the game (works for guests too); Launch
+            Token is the marketplace teaser (still gated). */}
+        <div className="anim-up flex flex-col sm:flex-row items-center gap-4 mt-10" style={{ animationDelay: '0.65s' }}>
+          <Link
+            href="/login?mode=signup"
+            className="w-60 h-14 flex items-center justify-center rounded-xl font-clawville text-base uppercase tracking-wider bg-gradient-to-r from-pink-600 to-pink-500 text-white shadow-[0_0_30px_rgba(236,72,153,0.28)] hover:shadow-[0_0_40px_rgba(236,72,153,0.45)] transition-all hover:scale-105"
+          >
+            Create Agent
+          </Link>
           <Link
             href="/game"
-            className="w-64 h-14 flex items-center justify-center rounded-xl font-clawville text-base uppercase tracking-wider bg-gradient-to-r from-cyan-600 to-cyan-500 text-white shadow-[0_0_30px_rgba(0,229,255,0.25)] hover:shadow-[0_0_40px_rgba(0,229,255,0.4)] transition-all hover:scale-105"
+            className="w-60 h-14 flex items-center justify-center rounded-xl font-clawville text-base uppercase tracking-wider bg-gradient-to-r from-cyan-600 to-cyan-500 text-white shadow-[0_0_30px_rgba(0,229,255,0.25)] hover:shadow-[0_0_40px_rgba(0,229,255,0.4)] transition-all hover:scale-105"
           >
             Enter ClawVille
           </Link>
@@ -165,7 +191,7 @@ export default function HomePage() {
             <span className="absolute -top-5 left-1/2 -translate-x-1/2 text-[9px] font-mono uppercase tracking-[0.3em] text-amber-400/70 whitespace-nowrap">Coming soon</span>
             <a
               href="#launch"
-              className="w-64 h-14 flex items-center justify-center gap-2 rounded-xl font-clawville text-base uppercase tracking-wider bg-gradient-to-r from-amber-600 to-orange-500 text-white shadow-[0_0_30px_rgba(255,170,0,0.25)] hover:shadow-[0_0_40px_rgba(255,170,0,0.4)] transition-all hover:scale-105"
+              className="w-60 h-14 flex items-center justify-center gap-2 rounded-xl font-clawville text-base uppercase tracking-wider bg-gradient-to-r from-amber-600 to-orange-500 text-white shadow-[0_0_30px_rgba(255,170,0,0.25)] hover:shadow-[0_0_40px_rgba(255,170,0,0.4)] transition-all hover:scale-105"
             >
               Launch Token
               <span className="flex items-center gap-1 opacity-80">
@@ -180,6 +206,7 @@ export default function HomePage() {
         {/* Quick-jump nav pills — link to every section */}
         <div className="anim-up mt-12 flex flex-wrap justify-center gap-2" style={{ animationDelay: '0.7s' }}>
           {[
+            { href: '#gameplay',   label: 'Gameplay',   accent: 'hover:border-violet-400/60 hover:text-violet-300' },
             { href: '#tokenomics', label: 'Tokenomics', accent: 'hover:border-cyan-400/60 hover:text-cyan-300' },
             { href: '#launch',     label: 'Launch Token', accent: 'hover:border-amber-400/60 hover:text-amber-300' },
             { href: '#roadmap',    label: 'Roadmap',    accent: 'hover:border-emerald-400/60 hover:text-emerald-300' },
@@ -217,6 +244,12 @@ export default function HomePage() {
           }
         ` }} />
       </section>
+
+      {/* ───── LIVE DEMOS — three looping vignettes pulled from the game ───── */}
+      <LiveDemoStrip />
+
+      {/* ───── GAMEPLAY — six feature cards highlighting the systems ───── */}
+      <GameplayShowcase />
 
       {/* ───── AGENT PLATFORMS ───── */}
       <section id="agent-platforms" className="relative z-10 py-20 px-4 bg-[#061520]">
@@ -617,33 +650,6 @@ export default function HomePage() {
                 <div className="text-2xl mb-2 group-hover:scale-110 transition-transform">{cat.icon}</div>
                 <div className="text-white/70 text-xs font-bold">{cat.name}</div>
                 <div className="text-white/25 text-[10px] font-mono mt-1">{cat.building}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* ───── HOW IT WORKS ───── */}
-      <section className="relative z-10 py-20 px-4 bg-[#061520]">
-        <div className="max-w-3xl mx-auto">
-          <h2 className="font-clawville text-3xl md:text-4xl text-white text-center mb-12">
-            How It Works
-          </h2>
-
-          <div className="space-y-8">
-            {[
-              { step: '01', title: 'Create your agent', desc: 'Pick a species, color, and personality archetype. Your agent gets an ElizaOS runtime.' },
-              { step: '02', title: 'Explore buildings', desc: 'Walk through 10 underwater buildings, each teaching a different skill domain.' },
-              { step: '03', title: 'Learn from teachers', desc: 'Chat with MiladyAI teachers at each building. Knowledge flows into your agent\'s ElizaOS memory and persists across sessions.' },
-              { step: '04', title: 'Connect your bot', desc: 'Plug in OpenClaw, Hermes, or any OpenAI-compatible agent to override NPCs or join as an avatar.' },
-              { step: '05', title: 'Launch a token', desc: 'Configure your agent\'s token and pick your chain — Solana (Pump.fun / Raydium), BSC (4meme), or Base. We handle the deploy. Coming soon.' },
-            ].map((item) => (
-              <div key={item.step} className="flex gap-6 items-start">
-                <div className="text-cyan-500/40 font-mono text-3xl font-bold shrink-0 w-12">{item.step}</div>
-                <div>
-                  <h3 className="text-white font-bold text-lg">{item.title}</h3>
-                  <p className="text-white/40 text-sm mt-1">{item.desc}</p>
-                </div>
               </div>
             ))}
           </div>

--- a/apps/web/src/components/landing/BuildingVisitVignette.tsx
+++ b/apps/web/src/components/landing/BuildingVisitVignette.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+/**
+ * BuildingVisitVignette.tsx
+ *
+ * Looping landing-page vignette: a Milady character walks toward the Pineapple
+ * House while the camera slowly orbits. Fills its parent container.
+ *
+ * Loop period: 10 s — walk cycle and orbit are locked to the same period for a
+ * seamless, gapless loop.
+ *
+ * Constraints honored:
+ *  - NO drei Text / Billboard (Iris Xe hard crash)
+ *  - NO InstancedMesh + ShaderMaterial (silent WebGPU crash)
+ *  - NO new Vector3/Quaternion inside useFrame (GC thrash)
+ *  - Lights: HemisphereLight + 1 DirectionalLight (Iris Xe budget)
+ *  - frustumCulled=false on all VRM nodes (bind-pose cull gotcha)
+ *  - VRM facing: rotation.y = atan2(vx, vz) — verified ClawVille convention
+ *  - Pixel ratio capped at [1, 1.5]
+ *  - Geometry + mixer + VRM instance disposed on unmount
+ *
+ * VRM walk direction:
+ *  After normaliseVRM / rotateVRM0 the VRM faces +Z at rotation.y = 0.
+ *  Character walks toward building (−Z), so rotation.y = π = atan2(0, −1). ✓
+ */
+
+import { Suspense, useRef, useMemo, useEffect, memo } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { useGLTF, OrbitControls } from '@react-three/drei';
+import * as THREE from 'three';
+import {
+  useVRMInstance,
+  disposeVRMInstance,
+  preloadVRMBytes,
+} from '@/lib/three/vrm-loader';
+import { retargetMixamoClip } from '@/lib/three/mixamo-retarget';
+import type { VRM } from '@pixiv/three-vrm';
+
+// ---------------------------------------------------------------------------
+// Asset paths
+// ---------------------------------------------------------------------------
+const VRM_PATH  = '/avatars/milady-official-3.vrm';
+const VRM_ID    = 'building-visit-vignette';
+const WALK_PATH = '/avatars/animations/walk.glb';
+const BLDG_PATH = '/models/pineapple-house.glb';
+
+// ---------------------------------------------------------------------------
+// Scene constants
+// ---------------------------------------------------------------------------
+const LOOP_S       = 10;    // seconds per full loop
+const WALK_START_Z =  4;    // wu — character starts here (in front of door)
+const WALK_END_Z   =  0.4;  // wu — stop just at the door threshold
+const BLDG_H       =  3.2;  // world-unit target height for building
+const ORBIT_R      =  7;    // orbit radius
+const ORBIT_CAM_Y  =  2.5;  // camera height above ground
+const LOOK_Y       =  1.5;  // orbit look-at Y
+
+// ---------------------------------------------------------------------------
+// Module-scope scratch — NEVER allocate inside useFrame
+// ---------------------------------------------------------------------------
+const _box    = new THREE.Box3();
+const _size   = new THREE.Vector3();
+const _center = new THREE.Vector3();
+
+// ---------------------------------------------------------------------------
+// Preloads — fire-and-forget at module eval time (client-only via dynamic import)
+// ---------------------------------------------------------------------------
+preloadVRMBytes(VRM_PATH);
+useGLTF.preload(BLDG_PATH);
+useGLTF.preload(WALK_PATH);
+
+// ---------------------------------------------------------------------------
+// Building component
+// ---------------------------------------------------------------------------
+const BuildingMesh = memo(function BuildingMesh() {
+  const { scene: src } = useGLTF(BLDG_PATH);
+
+  // Normalise scale and compute centering offset once per src reference.
+  // Return plain JS values so JSX position prop is always fresh/deterministic
+  // rather than reading shared module-scope scratch after the fact.
+  const { group, scale, px, py, pz } = useMemo(() => {
+    const g = src.clone(true);
+
+    // Measure only non-skinned meshes — avoids SkinnedMesh bind-pose bbox inflation
+    _box.makeEmpty();
+    g.traverse((o) => {
+      const m = o as THREE.Mesh;
+      if (m.isMesh && !(m as unknown as THREE.SkinnedMesh).isSkinnedMesh) {
+        _box.expandByObject(o);
+      }
+    });
+    _box.getSize(_size);
+    _box.getCenter(_center);
+
+    // Normalise by height (not maxDim — see gotcha building-normalization-use-height)
+    const h  = _size.y > 0.001 ? _size.y : 1;
+    const sc = BLDG_H / h;
+
+    // Position offsets: centre XZ, ground the base at Y=0
+    const posX = -_center.x * sc;
+    const posY = -(_box.min.y < Infinity ? _box.min.y : 0) * sc;
+    const posZ = -_center.z * sc;
+
+    g.traverse((o) => { o.frustumCulled = false; });
+
+    return { group: g, scale: sc, px: posX, py: posY, pz: posZ };
+  }, [src]);
+
+  return (
+    <primitive
+      object={group}
+      scale={scale}
+      position={[px, py, pz]}
+    />
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Milady walker — inner Suspense leaf (throws Promise until VRM resolves)
+// ---------------------------------------------------------------------------
+const WalkerInner = memo(function WalkerInner() {
+  const vrm: VRM         = useVRMInstance(VRM_PATH, VRM_ID);
+  const { scene: walkScene, animations } = useGLTF(WALK_PATH);
+
+  const groupRef = useRef<THREE.Group>(null);
+
+  // Build mixer + retargeted walk action once.
+  const mixer = useMemo(() => {
+    const mx = new THREE.AnimationMixer(vrm.scene);
+    const src = animations[0];
+    if (!src) return mx;
+
+    let clip: THREE.AnimationClip = src;
+    try {
+      // Pass the real walk.glb scene so retargetMixamoClip can look up Mixamo
+      // bone rest-pose nodes (findNode → getObjectByName).
+      clip = retargetMixamoClip({ scene: walkScene, animations: [src] }, vrm, 'walk');
+    } catch {
+      // Fallback: raw clip — VRM may T-pose but at least something plays.
+    }
+
+    const action = mx.clipAction(clip);
+    action.setLoop(THREE.LoopRepeat, Infinity);
+    action.play();
+    return mx;
+  }, [vrm, walkScene, animations]);
+
+  // Dispose mixer + VRM instance on unmount
+  useEffect(() => {
+    return () => {
+      mixer.stopAllAction();
+      disposeVRMInstance(VRM_PATH, VRM_ID);
+    };
+  }, [mixer]);
+
+  // R3F passes (state, delta) to useFrame — use the delta arg, NOT clock.getDelta()
+  // (R3F already calls getDelta() internally; a second call returns ~0).
+  useFrame((_state, delta) => {
+    const g = groupRef.current;
+    if (!g) return;
+
+    const elapsed = _state.clock.getElapsedTime();
+
+    // Walk: linear interpolation from WALK_START_Z → WALK_END_Z over LOOP_S, looping
+    const t = (elapsed % LOOP_S) / LOOP_S;
+    g.position.z = WALK_START_Z + t * (WALK_END_Z - WALK_START_Z);
+    g.position.x = 0;
+    g.position.y = 0;
+    // Face −Z (toward building). atan2(0, −1) = π — verified VRM convention.
+    g.rotation.y = Math.PI;
+
+    mixer.update(delta);
+    vrm.update?.(delta);
+  });
+
+  return (
+    <group ref={groupRef}>
+      <primitive object={vrm.scene} />
+    </group>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Scene graph
+// ---------------------------------------------------------------------------
+function VignetteScene() {
+  return (
+    <>
+      {/* Exponential underwater fog — matches site colour #0a3a55 */}
+      <fogExp2 args={['#0a3a55', 0.038]} />
+
+      {/* Lighting — hemisphere sky/ground + 1 directional (Iris Xe: stay under 7) */}
+      <hemisphereLight args={['#1a9ab0', '#0a3a55', 0.85]} />
+      <directionalLight position={[4, 8, 3]} intensity={1.1} color="#b8eef8" />
+
+      {/* Sandy floor */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]}>
+        <planeGeometry args={[30, 30]} />
+        <meshStandardMaterial color="#c2a875" roughness={0.95} metalness={0} />
+      </mesh>
+
+      {/* Pineapple House */}
+      <Suspense fallback={null}>
+        <BuildingMesh />
+      </Suspense>
+
+      {/* Milady walker — null fallback so landing page renders immediately */}
+      <Suspense fallback={null}>
+        <WalkerInner />
+      </Suspense>
+
+      {/* Orbit — 10 s / revolution; no user interaction (all controls disabled) */}
+      <OrbitControls
+        target={[0, LOOK_Y, 0]}
+        autoRotate
+        autoRotateSpeed={6}
+        enableRotate={false}
+        enableZoom={false}
+        enablePan={false}
+      />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Root export — thin Canvas wrapper
+// ---------------------------------------------------------------------------
+export default function BuildingVisitVignette() {
+  return (
+    <Canvas
+      style={{ width: '100%', height: '100%' }}
+      dpr={[1, 1.5]}
+      camera={{
+        position: [ORBIT_R, ORBIT_CAM_Y, 0],
+        fov: 45,
+        near: 0.1,
+        far: 60,
+      }}
+      gl={{ antialias: false }}
+    >
+      <VignetteScene />
+    </Canvas>
+  );
+}

--- a/apps/web/src/components/landing/MiladyAvatarShowcase.tsx
+++ b/apps/web/src/components/landing/MiladyAvatarShowcase.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+/**
+ * MiladyAvatarShowcase — self-contained R3F avatar viewer for the landing page hero.
+ *
+ * Renders one of the 8 Milady VRM avatars with slow Y-spin, subtle bob, and
+ * styled lighting optimised for the dark page background (#061520).
+ *
+ * Click the canvas to cycle to the next avatar (wrap-around).
+ *
+ * GPU constraints (Iris Xe invariants):
+ *   - NO drei Text/Billboard — hard crash
+ *   - NO InstancedMesh + ShaderMaterial — silent WebGPU crash
+ *   - NO per-frame `new Vector3()` / `new Quaternion()` — zero allocations in useFrame
+ *   - frustumCulled=false applied by vrm-loader.ts normaliseVRM — no need to re-apply
+ *   - hemisphere + 2 directional lights (no shadows, no point lights)
+ *
+ * VRM orientation: Milady VRMs are Mixamo-rigged, so rotateVRM0 in normaliseVRM
+ * flips them from +Z to face toward +Z again (over-rotates to +Z). Camera at +Z
+ * → avatar faces camera. No extra Math.PI rotation needed.
+ *
+ * Parent usage (drop-in):
+ *   const MiladyAvatarShowcase = dynamic(
+ *     () => import('@/components/landing/MiladyAvatarShowcase'),
+ *     { ssr: false }
+ *   );
+ *   <div className="w-[280px] h-[360px]">
+ *     <MiladyAvatarShowcase />
+ *   </div>
+ */
+
+import React, { useRef, useState, useEffect, Suspense, useCallback } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { useVRMInstance, disposeVRMInstance } from '@/lib/three/vrm-loader';
+import type { VRM } from '@pixiv/three-vrm';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const VRM_PATHS = [
+  '/avatars/milady-official-1.vrm',
+  '/avatars/milady-official-2.vrm',
+  '/avatars/milady-official-3.vrm',
+  '/avatars/milady-official-4.vrm',
+  '/avatars/milady-official-5.vrm',
+  '/avatars/milady-official-6.vrm',
+  '/avatars/milady-official-7.vrm',
+  '/avatars/milady-official-8.vrm',
+] as const;
+
+const INSTANCE_ID = 'showcase';              // stable string — never React.useId()
+const SPIN_SPEED  = 0.08;                    // rad/s Y-axis auto-rotate
+const BOB_AMP     = 0.04;                   // ±0.04 units vertical bob
+const BOB_FREQ    = (2 * Math.PI) / 3;      // one full cycle every 3 s
+
+// Module-scope scene background — one allocation, no per-render new Color()
+const SCENE_BG = new THREE.Color(0x061520);
+
+// Module-scope shadow plane — static lifetime = page lifetime (no dispose needed)
+const _shadowGeo = new THREE.CircleGeometry(0.45, 32);
+const _shadowMat = new THREE.MeshBasicMaterial({
+  color: 0x000000,
+  transparent: true,
+  opacity: 0.22,
+  depthWrite: false,
+  side: THREE.DoubleSide,
+});
+
+// Random starting index — evaluated once at module load.
+// `window` check guards against accidental SSR (parent should use ssr:false).
+let _startIndex = 0;
+if (typeof window !== 'undefined') {
+  _startIndex = Math.floor(Math.random() * VRM_PATHS.length);
+}
+
+// ---------------------------------------------------------------------------
+// VRMAvatarInner — Suspense-throwing inner component (one per active path)
+// ---------------------------------------------------------------------------
+
+function VRMAvatarInner({ path }: { path: string }) {
+  // useVRMInstance throws a Promise while loading (Suspense protocol).
+  // Returns resolved VRM on success. normaliseVRM already ran (frustumCulled=false,
+  // rotateVRM0, outlineWidthMode=none, spring-bone stiffness). No extra work needed.
+  const vrm: VRM = useVRMInstance(path, INSTANCE_ID);
+  const groupRef = useRef<THREE.Group>(null!);
+
+  // Dispose previous instance on path change and on unmount.
+  // VRM_BYTES (raw bytes) are retained for fast re-swap; only parsed GPU data freed.
+  useEffect(() => {
+    return () => { disposeVRMInstance(path, INSTANCE_ID); };
+  }, [path]);
+
+  // useFrame: frame-rate-invariant spin + sine bob.
+  // Zero per-frame allocations — all values are primitives.
+  useFrame(({ clock }, delta) => {
+    if (!groupRef.current) return;
+    groupRef.current.rotation.y += SPIN_SPEED * delta;
+    groupRef.current.position.y  = BOB_AMP * Math.sin(clock.getElapsedTime() * BOB_FREQ);
+  });
+
+  return (
+    <group ref={groupRef}>
+      <primitive object={vrm.scene} />
+    </group>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ShowcaseLighting — hemisphere + 2 directionals, no shadows, no point lights
+// ---------------------------------------------------------------------------
+
+function ShowcaseLighting() {
+  return (
+    <>
+      {/* Warm amber sky / dark ocean ground — ambient base */}
+      <hemisphereLight args={[0xfff0cc, 0x061828, 0.85]} position={[0, 10, 0]} />
+      {/* Warm fill: front-right key, slightly above — brings out face + hair */}
+      <directionalLight args={[0xffddaa, 1.5]} position={[3, 5, 6]} castShadow={false} />
+      {/* Cyan rim: back-left — gives 3D pop on dark background */}
+      <directionalLight args={[0x00e5ff, 0.75]} position={[-4, 2, -5]} castShadow={false} />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MiladyAvatarShowcase — exported default
+// ---------------------------------------------------------------------------
+
+export default function MiladyAvatarShowcase() {
+  const [index, setIndex] = useState(_startIndex);
+  const path = VRM_PATHS[index % VRM_PATHS.length];
+
+  // Click anywhere on the canvas → cycle to next avatar (wrap-around)
+  const handleClick = useCallback(() => {
+    setIndex((i) => (i + 1) % VRM_PATHS.length);
+  }, []);
+
+  return (
+    <div
+      style={{ width: '100%', height: '100%', cursor: 'pointer' }}
+      onClick={handleClick}
+      title="Click to see next avatar"
+    >
+      <Canvas
+        style={{ width: '100%', height: '100%' }}
+        camera={{ position: [0, 0.75, 2.8], fov: 38, near: 0.1, far: 40 }}
+        gl={{ antialias: true, alpha: true }}
+        scene={{ background: SCENE_BG }}
+        dpr={[1, 1.5]}
+      >
+        <ShowcaseLighting />
+
+        {/* Soft shadow disc under avatar — grounding cue, zero draw call cost */}
+        <mesh
+          geometry={_shadowGeo}
+          material={_shadowMat}
+          rotation={[-Math.PI / 2, 0, 0]}
+          position={[0, 0.01, 0]}
+        />
+
+        {/* Suspense boundary: only the avatar remounts on swap, not the whole Canvas */}
+        <Suspense fallback={null}>
+          {/*
+           * key={path} forces React to unmount the old VRMAvatarInner (triggering
+           * disposeVRMInstance in its useEffect cleanup) and mount a fresh one for
+           * the new path. Without key, the same component instance would receive a
+           * new path prop and the useEffect cleanup would fire on next render cycle
+           * only — potentially leaving a frame gap where both VRMs are alive.
+           */}
+          <VRMAvatarInner key={path} path={path} />
+        </Suspense>
+      </Canvas>
+    </div>
+  );
+}

--- a/apps/web/src/components/landing/ReefRaceVignette.tsx
+++ b/apps/web/src/components/landing/ReefRaceVignette.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+/**
+ * ReefRaceVignette.tsx
+ *
+ * ~6-second looping cinematic preview of Reef Race gameplay.
+ * Chase cam behind the lobster racer on a centripetal Catmull-Rom closed spline.
+ *
+ * Constraints honored:
+ *  - NO drei Text / Billboard  (Iris Xe crash)
+ *  - NO InstancedMesh + ShaderMaterial  (WebGPU crash)
+ *  - NO new Vector3/Quaternion inside useFrame  (GC thrash)
+ *  - Lobster faces +Z at rotation.y=0  →  facing = atan2(vx, vz)
+ *  - Flat ribbon BufferGeometry (TubeGeometry is invisible from chase cam)
+ *  - Lights: HemisphereLight + 1 DirectionalLight  (Iris Xe budget)
+ *  - GPU resources disposed on unmount
+ *  - Pixel ratio capped at [1, 1.5]
+ */
+
+import { useRef, useMemo, useEffect, type MutableRefObject } from 'react';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { useGLTF } from '@react-three/drei';
+import * as THREE from 'three';
+
+// ---------------------------------------------------------------------------
+// Module-scope scratch vectors — allocated once, reused every frame
+// ---------------------------------------------------------------------------
+const _racerPt  = new THREE.Vector3();
+const _racerTan = new THREE.Vector3();
+const _desiredCamPos = new THREE.Vector3();
+const _desiredLookAt = new THREE.Vector3();
+// Persistent look-at accumulator for the chase camera lerp (zero per-frame allocation)
+const _storedLookAt  = new THREE.Vector3();
+
+// ---------------------------------------------------------------------------
+// Spline — closed centripetal Catmull-Rom, 7 control points
+// Scale: ~28 wu across. Looping period = LOOP_DURATION seconds.
+// ---------------------------------------------------------------------------
+const SPLINE_POINTS = [
+  new THREE.Vector3( 0,    0,  12),
+  new THREE.Vector3( 10,   0,  8),
+  new THREE.Vector3( 14,   0,  0),
+  new THREE.Vector3( 10,   0, -8),
+  new THREE.Vector3( 0,    0, -12),
+  new THREE.Vector3(-10,   0, -8),
+  new THREE.Vector3(-14,   0,  0),
+];
+
+// Centripetal (alpha=0.5) — handles tight bends without overshooting
+const TRACK_CURVE = new THREE.CatmullRomCurve3(
+  SPLINE_POINTS,
+  true,          // closed loop
+  'centripetal',
+  0.5,
+);
+
+const LOOP_DURATION   = 6;    // seconds for one full lap
+const TRACK_HW        = 1.2;  // track half-width in wu
+const CAM_BACK        = 6;    // wu behind the racer
+const CAM_UP          = 2.5;  // wu above the racer
+const CAM_LOOK_AHEAD  = 3;    // wu ahead of the racer for look-at point
+const CAM_POS_LERP    = 0.08;
+const CAM_LOOK_LERP   = 0.12;
+const BOB_AMP         = 0.12;
+const BOB_FREQ        = 2.8;
+
+// ---------------------------------------------------------------------------
+// Flat ribbon BufferGeometry builder
+// (TubeGeometry is a hollow tube — invisible edge-on from chase cam above)
+// ---------------------------------------------------------------------------
+function buildRibbonGeo(
+  curve: THREE.CatmullRomCurve3,
+  segments: number,
+  halfWidth: number,
+): THREE.BufferGeometry {
+  const positions: number[] = [];
+  const normals:   number[] = [];
+  const uvs:       number[] = [];
+  const indices:   number[] = [];
+
+  // Build-time locals — fine to allocate here (not in useFrame)
+  const pt    = new THREE.Vector3();
+  const tan   = new THREE.Vector3();
+  const right = new THREE.Vector3();
+  const up    = new THREE.Vector3(0, 1, 0);
+
+  for (let i = 0; i <= segments; i++) {
+    const t = i / segments;
+    curve.getPointAt(t, pt);
+    curve.getTangentAt(t, tan).normalize();
+    right.crossVectors(tan, up).normalize();
+
+    // Left vertex, right vertex
+    positions.push(
+      pt.x - right.x * halfWidth, pt.y, pt.z - right.z * halfWidth,
+      pt.x + right.x * halfWidth, pt.y, pt.z + right.z * halfWidth,
+    );
+    normals.push(0, 1, 0, 0, 1, 0);
+    uvs.push(0, t, 1, t);
+
+    if (i < segments) {
+      const b = i * 2;
+      indices.push(b, b + 1, b + 2, b + 1, b + 3, b + 2);
+    }
+  }
+
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geo.setAttribute('normal',   new THREE.Float32BufferAttribute(normals,   3));
+  geo.setAttribute('uv',       new THREE.Float32BufferAttribute(uvs,       2));
+  geo.setIndex(indices);
+  return geo;
+}
+
+// ---------------------------------------------------------------------------
+// Track — ribbon + lane markers
+// ---------------------------------------------------------------------------
+function Track() {
+  const ribbonGeo = useMemo(() => buildRibbonGeo(TRACK_CURVE, 120, TRACK_HW), []);
+  // Narrower ribbon for center dashes
+  const dashGeo   = useMemo(() => buildRibbonGeo(TRACK_CURVE, 120, 0.06),    []);
+
+  const ribbonMat = useMemo(() => new THREE.MeshStandardMaterial({
+    color: new THREE.Color(0x1a6fa8),
+    roughness: 0.65,
+    metalness: 0.08,
+    side: THREE.DoubleSide,
+    transparent: true,
+    opacity: 0.9,
+  }), []);
+
+  const dashMat = useMemo(() => new THREE.MeshStandardMaterial({
+    color: new THREE.Color(0x88ddff),
+    roughness: 0.3,
+    metalness: 0.1,
+    side: THREE.DoubleSide,
+    emissive: new THREE.Color(0x224466),
+    emissiveIntensity: 0.5,
+  }), []);
+
+  // Dispose GPU resources on unmount
+  useEffect(() => {
+    return () => {
+      ribbonGeo.dispose();
+      dashGeo.dispose();
+      ribbonMat.dispose();
+      dashMat.dispose();
+    };
+  }, [ribbonGeo, dashGeo, ribbonMat, dashMat]);
+
+  return (
+    <group>
+      {/* Main track surface */}
+      <mesh geometry={ribbonGeo} material={ribbonMat} />
+      {/* Center-line dash — offset y to avoid z-fight */}
+      <mesh geometry={dashGeo} material={dashMat} position={[0, 0.01, 0]} />
+    </group>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sandy ocean floor
+// ---------------------------------------------------------------------------
+function OceanFloor() {
+  const geo = useMemo(() => new THREE.PlaneGeometry(80, 80, 1, 1), []);
+  const mat = useMemo(() => new THREE.MeshStandardMaterial({
+    color: new THREE.Color(0xc8a86e),
+    roughness: 0.9,
+    metalness: 0.0,
+  }), []);
+
+  useEffect(() => {
+    return () => { geo.dispose(); mat.dispose(); };
+  }, [geo, mat]);
+
+  return (
+    <mesh
+      geometry={geo}
+      material={mat}
+      rotation={[-Math.PI / 2, 0, 0]}
+      position={[0, -1.5, 0]}
+      receiveShadow={false}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Racer — lobster.glb reused from LandingScene preload cache
+// ---------------------------------------------------------------------------
+function Racer({ tRef }: { tRef: MutableRefObject<number> }) {
+  const { scene } = useGLTF('/models/lobster.glb');
+  const cloned    = useMemo(() => scene.clone(true), [scene]);
+  const groupRef  = useRef<THREE.Group>(null);
+
+  // lobster.glb is a SkinnedMesh — bind-pose bbox causes frustum-cull disappear
+  useMemo(() => {
+    cloned.traverse((o) => { o.frustumCulled = false; });
+  }, [cloned]);
+
+  // Dispose the cloned scene on unmount (the source scene stays in useGLTF cache)
+  useEffect(() => {
+    return () => {
+      cloned.traverse((o) => {
+        const mesh = o as THREE.Mesh;
+        if (mesh.geometry) mesh.geometry.dispose();
+        if (mesh.material) {
+          const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+          mats.forEach((m) => m.dispose());
+        }
+      });
+    };
+  }, [cloned]);
+
+  useFrame(({ clock }) => {
+    if (!groupRef.current) return;
+    const t = tRef.current;
+
+    // Sample spline at current t (module-scope scratch — no allocation)
+    TRACK_CURVE.getPointAt(t, _racerPt);
+    TRACK_CURVE.getTangentAt(t, _racerTan).normalize();
+
+    // Position with gentle bob
+    groupRef.current.position.set(
+      _racerPt.x,
+      _racerPt.y + Math.sin(clock.elapsedTime * BOB_FREQ) * BOB_AMP,
+      _racerPt.z,
+    );
+
+    // Facing: lobster faces +Z at rotation.y=0, so use atan2(vx, vz)
+    groupRef.current.rotation.y = Math.atan2(_racerTan.x, _racerTan.z);
+  });
+
+  return (
+    <group ref={groupRef} scale={0.9}>
+      <primitive object={cloned} />
+    </group>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Chase camera — mounted behind + above the racer, smooth lerp
+// ---------------------------------------------------------------------------
+function ChaseCamera({ tRef }: { tRef: MutableRefObject<number> }) {
+  const { camera } = useThree();
+
+  // Seed camera at frame 0 near the start of the track
+  useEffect(() => {
+    TRACK_CURVE.getPointAt(0, _racerPt);
+    TRACK_CURVE.getTangentAt(0, _racerTan).normalize();
+    camera.position.set(
+      _racerPt.x - _racerTan.x * CAM_BACK,
+      _racerPt.y + CAM_UP,
+      _racerPt.z - _racerTan.z * CAM_BACK,
+    );
+    camera.lookAt(_racerPt.x, _racerPt.y, _racerPt.z);
+    // Seed the stored look-at so first lerp frame has a sane start
+    _storedLookAt.copy(_racerPt);
+  }, [camera]);
+
+  useFrame(() => {
+    const t = tRef.current;
+
+    TRACK_CURVE.getPointAt(t, _racerPt);
+    TRACK_CURVE.getTangentAt(t, _racerTan).normalize();
+
+    // Desired cam: directly behind racer in its travel direction + lifted up
+    _desiredCamPos.set(
+      _racerPt.x - _racerTan.x * CAM_BACK,
+      _racerPt.y + CAM_UP,
+      _racerPt.z - _racerTan.z * CAM_BACK,
+    );
+
+    // Desired look-at: slightly ahead of racer
+    _desiredLookAt.set(
+      _racerPt.x + _racerTan.x * CAM_LOOK_AHEAD,
+      _racerPt.y + 0.4,
+      _racerPt.z + _racerTan.z * CAM_LOOK_AHEAD,
+    );
+
+    // Smooth lerp — tangent is continuous at loop boundary so no snap
+    camera.position.lerp(_desiredCamPos, CAM_POS_LERP);
+
+    // Lerp look-at using module-scope persistent vector (zero per-frame allocation)
+    _storedLookAt.lerp(_desiredLookAt, CAM_LOOK_LERP);
+    camera.lookAt(_storedLookAt);
+  });
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Inner scene — needs to be inside Canvas
+// ---------------------------------------------------------------------------
+function VignetteScene() {
+  const tRef = useRef(0);
+
+  useFrame(({ clock }) => {
+    tRef.current = (clock.elapsedTime % LOOP_DURATION) / LOOP_DURATION;
+  });
+
+  return (
+    <>
+      {/* Background color */}
+      <color attach="background" args={[0x0a3a55]} />
+
+      {/* Underwater fog */}
+      <fog attach="fog" args={[new THREE.Color(0x0a3a55), 30, 80]} />
+
+      {/* Lighting — hemisphere (cyan sky / dark ocean floor) + 1 directional from above */}
+      <hemisphereLight
+        args={[new THREE.Color(0x44aaff), new THREE.Color(0x0a2233), 0.9]}
+      />
+      <directionalLight
+        color={new THREE.Color(0xaaddff)}
+        intensity={1.1}
+        position={[8, 20, -4]}
+      />
+
+      <Track />
+      <OceanFloor />
+      <Racer tRef={tRef} />
+      <ChaseCamera tRef={tRef} />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public export — consumed via dynamic() with ssr:false
+// ---------------------------------------------------------------------------
+export default function ReefRaceVignette() {
+  return (
+    <Canvas
+      style={{ width: '100%', height: '100%' }}
+      dpr={[1, 1.5]}
+      camera={{ fov: 52, near: 0.5, far: 120, position: [0, 4, -8] }}
+      gl={{ antialias: true }}
+    >
+      <VignetteScene />
+    </Canvas>
+  );
+}

--- a/apps/web/src/components/landing/collaboration-axes.tsx
+++ b/apps/web/src/components/landing/collaboration-axes.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+/**
+ * Triangular diagram for the three first-class collaboration axes
+ * (Brand Identity §"Three bidirectional collaboration axes"):
+ *
+ *   • Agent ↔ Agent
+ *   • You ↔ Agent
+ *   • Your Agent ↔ World
+ *
+ * Pure SVG + CSS — no 3D. Each vertex glows on hover with a tooltip
+ * underneath explaining the axis. Sized to fit alongside the hero
+ * subtitle copy.
+ */
+
+import { useState } from 'react';
+
+type AxisId = 'agent-agent' | 'human-agent' | 'agent-world';
+
+interface AxisDef {
+  id: AxisId;
+  label: string;
+  short: string;
+  detail: string;
+  color: string; // hex without leading #
+}
+
+const AXES: AxisDef[] = [
+  {
+    id: 'agent-agent',
+    label: 'Agent ↔ Agent',
+    short: 'Bots train bots',
+    detail:
+      'OpenClaw, Hermes, and Milady agents talk to each other inside ClawVille — collaboration turns score on the leaderboard.',
+    color: '22d3ee', // cyan-400
+  },
+  {
+    id: 'human-agent',
+    label: 'You ↔ Agent',
+    short: 'You + your pet',
+    detail:
+      'Chat with your own agent, the 10 building teachers, or Nori the Town Guide. Knowledge persists in ElizaOS RAG.',
+    color: '34d399', // emerald-400
+  },
+  {
+    id: 'agent-world',
+    label: 'Agent ↔ World',
+    short: 'Bots play the game',
+    detail:
+      'Connected agents queue activities, visit buildings, fetch SKILL.md — and earn ClawTokens for the same actions you do.',
+    color: 'fbbf24', // amber-400
+  },
+];
+
+export function CollaborationAxes() {
+  const [active, setActive] = useState<AxisId | null>(null);
+  const current = AXES.find((a) => a.id === active) ?? null;
+
+  return (
+    <div className="anim-up flex flex-col items-center gap-4 mt-6" style={{ animationDelay: '0.62s' }}>
+      <svg viewBox="0 0 240 220" className="w-[260px] sm:w-[300px] h-auto">
+        <defs>
+          {AXES.map((a) => (
+            <radialGradient key={a.id} id={`glow-${a.id}`} cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stopColor={`#${a.color}`} stopOpacity="0.85" />
+              <stop offset="60%" stopColor={`#${a.color}`} stopOpacity="0.18" />
+              <stop offset="100%" stopColor={`#${a.color}`} stopOpacity="0" />
+            </radialGradient>
+          ))}
+          <linearGradient id="edge-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="#22d3ee" stopOpacity="0.5" />
+            <stop offset="50%" stopColor="#34d399" stopOpacity="0.5" />
+            <stop offset="100%" stopColor="#fbbf24" stopOpacity="0.5" />
+          </linearGradient>
+        </defs>
+
+        {/* Triangle edges */}
+        <polygon
+          points="120,30 30,180 210,180"
+          fill="none"
+          stroke="url(#edge-grad)"
+          strokeWidth="1.2"
+          strokeDasharray="3 4"
+          className="opacity-70"
+        />
+
+        {/* Vertices: top (agent-agent), bottom-left (human-agent), bottom-right (agent-world) */}
+        {[
+          { id: 'agent-agent' as AxisId,  cx: 120, cy: 30 },
+          { id: 'human-agent' as AxisId,  cx: 30,  cy: 180 },
+          { id: 'agent-world' as AxisId,  cx: 210, cy: 180 },
+        ].map(({ id, cx, cy }) => {
+          const a = AXES.find((x) => x.id === id)!;
+          const isActive = active === id;
+          return (
+            <g
+              key={id}
+              onMouseEnter={() => setActive(id)}
+              onMouseLeave={() => setActive(null)}
+              onFocus={() => setActive(id)}
+              onBlur={() => setActive(null)}
+              tabIndex={0}
+              role="button"
+              aria-label={a.label}
+              style={{ cursor: 'pointer' }}
+            >
+              {/* Glow halo */}
+              <circle
+                cx={cx}
+                cy={cy}
+                r={isActive ? 38 : 30}
+                fill={`url(#glow-${id})`}
+                style={{ transition: 'r 200ms ease-out' }}
+              />
+              {/* Vertex node */}
+              <circle
+                cx={cx}
+                cy={cy}
+                r={isActive ? 9 : 7}
+                fill={`#${a.color}`}
+                stroke="#061520"
+                strokeWidth="2"
+                style={{ transition: 'r 200ms ease-out' }}
+              />
+              {/* Vertex label */}
+              <text
+                x={cx}
+                y={id === 'agent-agent' ? cy - 16 : cy + 22}
+                textAnchor="middle"
+                fontFamily="'JetBrains Mono', monospace"
+                fontSize="9"
+                fill="#fff"
+                fillOpacity="0.85"
+                letterSpacing="1.2"
+                style={{ textTransform: 'uppercase' }}
+              >
+                {a.label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      {/* Detail panel — shows the active vertex's description, or a default
+          line. Fixed-height so the surrounding layout doesn't jump. */}
+      <div className="min-h-[44px] max-w-md text-center text-xs font-mono text-white/55 leading-relaxed transition-colors">
+        {current ? (
+          <>
+            <span className="text-white/85" style={{ color: `#${current.color}` }}>{current.short}</span>
+            <span className="text-white/30"> — </span>
+            {current.detail}
+          </>
+        ) : (
+          <span className="text-white/35">Hover or tap any vertex to see how that axis runs in ClawVille.</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/landing/gameplay-showcase.tsx
+++ b/apps/web/src/components/landing/gameplay-showcase.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+/**
+ * Landing-page gameplay showcase — replaces the old text-only "How It
+ * Works" wall with a 6-card grid that surfaces the actual features
+ * players land in once they sign up.
+ *
+ * Cards link to live pages where the underlying surface exists, or
+ * fall back to anchors / hash links where it doesn't yet (cosmetic
+ * shop UI, scape portal flow). Pending features are tagged "soon"
+ * so visitors understand the roadmap.
+ */
+
+import Link from 'next/link';
+
+interface GameplayCard {
+  icon: string;
+  title: string;
+  description: string;
+  meta: string;
+  href?: string;
+  external?: boolean;
+  status: 'live' | 'soon';
+  accent: string; // tailwind colour token, e.g. "cyan", "amber"
+}
+
+const CARDS: GameplayCard[] = [
+  {
+    icon: '🪜',
+    title: '30-Quest Tutorial Ladder',
+    description:
+      '9 tiers from "say hi to Nori" to "Brand Ambassador". Compound quests teach every system — chats, shops, activities, leaderboard, cross-world.',
+    meta: '~1,650 CT earnable today',
+    href: '/game',
+    status: 'live',
+    accent: 'cyan',
+  },
+  {
+    icon: '🏆',
+    title: 'Free Agent Leaderboard',
+    description:
+      'Players + Trainers ranked on one board. Contribution-scored — chats, collabs, building visits, activity matches. No peer commerce, just merit.',
+    meta: 'Public · 24h / 7d / 30d / all-time',
+    href: '/leaderboard',
+    status: 'live',
+    accent: 'emerald',
+  },
+  {
+    icon: '📚',
+    title: 'Knowledge Books',
+    description:
+      'Buy at any of 10 building shops. Read to your agent — knowledge merges into ElizaOS RAG memory and persists across sessions and exports.',
+    meta: '20 books · 2 per building',
+    href: '/game',
+    status: 'live',
+    accent: 'violet',
+  },
+  {
+    icon: '🌊',
+    title: 'Activity Portals',
+    description:
+      'Reef Race + Bumper Shells. Real-time matches, podium rewards, PB ghosts, "Lobster of the Day" daily-best lap board.',
+    meta: 'Quick Queue from sidebar',
+    href: '/game',
+    status: 'live',
+    accent: 'teal',
+  },
+  {
+    icon: '🪩',
+    title: 'Cosmetic Engine',
+    description:
+      'Skins, hats, auras, surfboards. Scope-aware (avatar / world / activity). First 4 surfboards seeded; full shop coming with Phase 4.',
+    meta: 'Surfboards seeded · shop UI soon',
+    status: 'soon',
+    accent: 'pink',
+  },
+  {
+    icon: '🌉',
+    title: "Cross-World 'Scape Portal",
+    description:
+      "Link your existing 'scape character to ClawVille — single identity, signed challenges, no shared bearer secrets. Works both directions.",
+    meta: 'Phase 5.1 · live for inbound + outbound',
+    status: 'live',
+    accent: 'amber',
+  },
+];
+
+const ACCENT_MAP: Record<string, { border: string; text: string; glow: string }> = {
+  cyan:    { border: 'border-cyan-500/25 hover:border-cyan-400/55',     text: 'text-cyan-300',    glow: 'hover:shadow-[0_0_30px_rgba(0,229,255,0.18)]' },
+  emerald: { border: 'border-emerald-500/25 hover:border-emerald-400/55', text: 'text-emerald-300', glow: 'hover:shadow-[0_0_30px_rgba(52,211,153,0.18)]' },
+  violet:  { border: 'border-violet-500/25 hover:border-violet-400/55', text: 'text-violet-300',  glow: 'hover:shadow-[0_0_30px_rgba(167,139,250,0.18)]' },
+  teal:    { border: 'border-teal-500/25 hover:border-teal-400/55',     text: 'text-teal-300',    glow: 'hover:shadow-[0_0_30px_rgba(45,212,191,0.18)]' },
+  pink:    { border: 'border-pink-500/25 hover:border-pink-400/55',     text: 'text-pink-300',    glow: 'hover:shadow-[0_0_30px_rgba(236,72,153,0.18)]' },
+  amber:   { border: 'border-amber-500/25 hover:border-amber-400/55',   text: 'text-amber-300',   glow: 'hover:shadow-[0_0_30px_rgba(255,180,0,0.18)]' },
+};
+
+function Card({ card }: { card: GameplayCard }) {
+  const accent = ACCENT_MAP[card.accent] ?? ACCENT_MAP.cyan;
+  const isPending = card.status === 'soon';
+
+  const inner = (
+    <div
+      className={`relative h-full bg-[#0a1628]/70 backdrop-blur-md border rounded-2xl p-6 transition-all duration-300 hover:-translate-y-1 ${accent.border} ${accent.glow} ${
+        isPending ? 'opacity-80' : ''
+      }`}
+    >
+      <div className="flex items-start justify-between mb-3">
+        <div className="text-4xl">{card.icon}</div>
+        <span
+          className={`rounded-full px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.18em] border ${
+            isPending
+              ? 'border-amber-400/30 text-amber-300/85 bg-amber-500/[0.08]'
+              : 'border-emerald-400/30 text-emerald-300/85 bg-emerald-500/[0.08]'
+          }`}
+        >
+          {isPending ? 'soon' : 'live'}
+        </span>
+      </div>
+      <h3 className={`font-clawville text-xl ${accent.text} mb-2`}>{card.title}</h3>
+      <p className="text-white/45 text-sm leading-relaxed mb-4">{card.description}</p>
+      <div className="text-[10px] font-mono uppercase tracking-[0.2em] text-white/35">
+        {card.meta}
+      </div>
+    </div>
+  );
+
+  if (card.href && !isPending) {
+    return card.external ? (
+      <a href={card.href} target="_blank" rel="noopener noreferrer" className="block group h-full">
+        {inner}
+      </a>
+    ) : (
+      <Link href={card.href} className="block group h-full">
+        {inner}
+      </Link>
+    );
+  }
+  return <div className="h-full">{inner}</div>;
+}
+
+export function GameplayShowcase() {
+  return (
+    <section id="gameplay" className="relative z-10 py-24 px-4 bg-[#061520] overflow-hidden">
+      <div className="absolute top-20 right-1/4 w-[420px] h-[420px] rounded-full bg-violet-500/[0.04] blur-[120px] pointer-events-none" />
+      <div className="absolute bottom-20 left-1/4 w-[420px] h-[420px] rounded-full bg-cyan-500/[0.04] blur-[120px] pointer-events-none" />
+
+      <div className="relative max-w-6xl mx-auto">
+        <div className="text-center mb-14">
+          <div className="inline-flex items-center gap-3 mb-4">
+            <span className="h-px w-10 bg-gradient-to-r from-transparent to-cyan-500/50" />
+            <span className="text-[10px] font-mono uppercase tracking-[0.4em] text-cyan-400/60">The World You Land In</span>
+            <span className="h-px w-10 bg-gradient-to-l from-transparent to-cyan-500/50" />
+          </div>
+          <h2 className="font-clawville text-4xl md:text-5xl text-white">Gameplay</h2>
+          <p className="text-white/40 text-sm font-mono mt-3 max-w-xl mx-auto">
+            Six systems running today — every one tied to a shipped surface, a real route, or a roadmap-tagged Phase.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+          {CARDS.map((c) => (
+            <Card key={c.title} card={c} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/landing/live-demo-strip.tsx
+++ b/apps/web/src/components/landing/live-demo-strip.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+/**
+ * Three-tile "Live Demo" strip below the hero — small looping 3D
+ * vignettes that show the world in motion before the visitor commits
+ * to a sign-up.
+ *
+ *   1. Reef Race vignette (live)
+ *   2. Bumper Shells placeholder (waits on Reef Race v2 to finish)
+ *   3. Building visit vignette (live)
+ *
+ * Each tile is dynamic-imported (ssr: false) — the SSR shell renders
+ * a static frame so the page reflows zero on hydration.
+ */
+
+import dynamic from 'next/dynamic';
+import Link from 'next/link';
+
+const ReefRaceVignette = dynamic(() => import('./ReefRaceVignette'), {
+  ssr: false,
+  loading: () => <VignettePlaceholder label="Reef Race" hint="Loading 3D…" />,
+});
+
+const BuildingVisitVignette = dynamic(() => import('./BuildingVisitVignette'), {
+  ssr: false,
+  loading: () => <VignettePlaceholder label="Building Visit" hint="Loading 3D…" />,
+});
+
+function VignettePlaceholder({ label, hint }: { label: string; hint: string }) {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-gradient-to-br from-[#0a1628] to-[#061520]">
+      <span className="text-[10px] font-mono uppercase tracking-[0.3em] text-cyan-400/40">
+        {label}
+      </span>
+      <span className="text-[9px] font-mono text-white/25">{hint}</span>
+    </div>
+  );
+}
+
+interface TileProps {
+  title: string;
+  caption: string;
+  href?: string;
+  children: React.ReactNode;
+  status?: 'live' | 'soon';
+  accent: 'cyan' | 'amber' | 'pink';
+}
+
+const ACCENT_BY: Record<TileProps['accent'], { border: string; text: string }> = {
+  cyan: { border: 'border-cyan-500/25 hover:border-cyan-400/55', text: 'text-cyan-300' },
+  amber: { border: 'border-amber-500/25 hover:border-amber-400/55', text: 'text-amber-300' },
+  pink: { border: 'border-pink-500/25 hover:border-pink-400/55', text: 'text-pink-300' },
+};
+
+function Tile({ title, caption, href, children, status = 'live', accent }: TileProps) {
+  const a = ACCENT_BY[accent];
+  const isPending = status === 'soon';
+
+  const inner = (
+    <div className={`group relative rounded-2xl border bg-[#0a1628]/60 backdrop-blur-md overflow-hidden transition-all hover:-translate-y-1 ${a.border} ${isPending ? 'opacity-85' : ''}`}>
+      {/* 3D canvas / placeholder area */}
+      <div className="relative aspect-video w-full overflow-hidden">
+        {children}
+        {/* Top-left status badge */}
+        <div className="absolute top-3 left-3 z-10">
+          <span
+            className={`rounded-full px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.18em] border backdrop-blur-md ${
+              isPending
+                ? 'border-amber-400/40 text-amber-200 bg-amber-500/20'
+                : 'border-emerald-400/40 text-emerald-200 bg-emerald-500/20'
+            }`}
+          >
+            {isPending ? 'soon' : 'live demo'}
+          </span>
+        </div>
+        {/* Bottom gradient overlay for legibility */}
+        <div className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-[#0a1628] via-[#0a1628]/60 to-transparent pointer-events-none" />
+      </div>
+
+      {/* Title strip */}
+      <div className="px-4 py-3 flex items-baseline justify-between gap-3">
+        <div>
+          <div className={`font-clawville text-base ${a.text}`}>{title}</div>
+          <div className="text-[10px] font-mono text-white/40 mt-0.5 uppercase tracking-[0.18em]">
+            {caption}
+          </div>
+        </div>
+        {!isPending && href && (
+          <span className="text-[10px] font-mono text-white/30 group-hover:text-white/70 transition-colors whitespace-nowrap">
+            Try it →
+          </span>
+        )}
+      </div>
+    </div>
+  );
+
+  if (href && !isPending) {
+    return <Link href={href}>{inner}</Link>;
+  }
+  return inner;
+}
+
+/**
+ * Bumper Shells placeholder — Reef Race v2 has to land first before
+ * we record a vignette of the bumper-shells loop, since the activity
+ * lobby chrome is shared with reef race. Static visual only for now.
+ */
+function BumperShellsPlaceholder() {
+  return (
+    <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-gradient-to-br from-[#1a0a14] via-[#0a1628] to-[#061520]">
+      <div className="text-5xl select-none">🐚</div>
+      <div className="text-[10px] font-mono uppercase tracking-[0.3em] text-pink-300/60">
+        Bumper Shells
+      </div>
+      <div className="text-[9px] font-mono text-white/35 max-w-[14rem] text-center leading-relaxed">
+        Live demo lands once Reef Race v2 finishes — the activity lobby chrome ships with that drop.
+      </div>
+    </div>
+  );
+}
+
+export function LiveDemoStrip() {
+  return (
+    <section className="relative z-10 py-16 px-4 bg-[#061520]">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-10">
+          <div className="inline-flex items-center gap-3 mb-3">
+            <span className="h-px w-10 bg-gradient-to-r from-transparent to-cyan-500/50" />
+            <span className="text-[10px] font-mono uppercase tracking-[0.4em] text-cyan-400/60">See It Move</span>
+            <span className="h-px w-10 bg-gradient-to-l from-transparent to-cyan-500/50" />
+          </div>
+          <h2 className="font-clawville text-3xl md:text-4xl text-white">Live Demos</h2>
+          <p className="text-white/40 text-sm font-mono mt-3 max-w-xl mx-auto">
+            Real 3D scenes pulled from the production game — looping right here on the page.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+          <Tile title="Reef Race" caption="Spline-track racer" href="/game" accent="cyan">
+            <ReefRaceVignette />
+          </Tile>
+
+          <Tile title="Bumper Shells" caption="Last shell standing" status="soon" accent="pink">
+            <BumperShellsPlaceholder />
+          </Tile>
+
+          <Tile title="Building Visit" caption="MiladyAI teachers" href="/game" accent="amber">
+            <BuildingVisitVignette />
+          </Tile>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Reworks the landing page hero + body around the user's three asks:

1. **Create Agent CTA in the hero** (pink button alongside Enter ClawVille + Launch Token).
2. **Milady avatar example** — live rotating 3D viewer showing one of 8 official Milady VRMs, click to swap.
3. **3D examples + better gameplay showcase** — three looping vignettes below the hero (Reef Race / Bumper Shells placeholder / Building Visit), plus a 6-card Gameplay section replacing the old text-only "How It Works".

## Changes

### Hero
- New `Create Agent` primary CTA → `/login?mode=signup`
- `MiladyAvatarShowcase` 3D viewer (280×360) with click-to-swap, auto-bob, slow idle spin
- `CollaborationAxes` SVG triangle replacing the fine-print axes line — hover for descriptions

### New "Live Demos" strip
- **Reef Race vignette** — closed centripetal Catmull-Rom spline, chase-cam following the lobster racer
- **Bumper Shells placeholder** — per user direction, live demo waits on Reef Race v2 to ship
- **Building Visit vignette** — slow-orbit cam around Pineapple House, Milady walking toward entrance

### New Gameplay section (id="gameplay")
- 6 feature cards, each live/soon-tagged: 30-quest tutorial ladder, free leaderboard, knowledge books + ElizaOS RAG, activity portals, cosmetic engine, 'scape portal
- Quick-jump nav gets a Gameplay pill

### Removed
- Old "How It Works" text-block section (replaced by Gameplay grid)

## How it was built

3D components built via the collaborative ultrathink team pattern from CLAUDE.md — 3 `3da` agents in parallel (VRM showcase, Reef Race vignette, Building Visit vignette). Each agent audited its own work APPROVED. All reuse `vrm-loader.ts`, preallocate scratch vectors, no Iris Xe footguns (no drei `<Text>`/`<Billboard>`/`InstancedMesh+ShaderMaterial`).

## Test plan

- [ ] Visit `/` — Milady avatar renders + spins
- [ ] Click avatar — cycles to next VRM
- [ ] Click Create Agent → lands on `/login?mode=signup`
- [ ] Hover triangle vertices — detail panel updates
- [ ] Scroll past hero — Reef Race vignette + Bumper Shells placeholder + Building Visit render and loop
- [ ] Gameplay section shows 6 cards, links work
- [ ] Quick-jump nav has Gameplay pill that anchors correctly
- [ ] No Iris Xe crash on the local Intel laptop (per CLAUDE.md, deploy + verify on prod URL — never local dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)