### PR TITLE
fix(landing): frame Milady avatar + tighten Reef Race cam

### DIFF
--- a/apps/web/src/components/landing/MiladyAvatarShowcase.tsx
+++ b/apps/web/src/components/landing/MiladyAvatarShowcase.tsx
@@ -100,8 +100,12 @@ function VRMAvatarInner({ path }: { path: string }) {
     groupRef.current.position.y  = BOB_AMP * Math.sin(clock.getElapsedTime() * BOB_FREQ);
   });
 
+  // Mount avatar offset DOWN by ~0.95 so the body center lands near
+  // origin — VRMs export with feet at Y=0 and head at Y~1.7, but the
+  // canvas camera looks at origin, so without this offset only the
+  // legs/shoes render. Verified visually 2026-04-29.
   return (
-    <group ref={groupRef}>
+    <group ref={groupRef} position={[0, -0.95, 0]}>
       <primitive object={vrm.scene} />
     </group>
   );
@@ -152,12 +156,13 @@ export default function MiladyAvatarShowcase() {
       >
         <ShowcaseLighting />
 
-        {/* Soft shadow disc under avatar — grounding cue, zero draw call cost */}
+        {/* Soft shadow disc under avatar — grounding cue, zero draw call cost.
+            Y matches the avatar foot level (avatar is offset down by 0.95). */}
         <mesh
           geometry={_shadowGeo}
           material={_shadowMat}
           rotation={[-Math.PI / 2, 0, 0]}
-          position={[0, 0.01, 0]}
+          position={[0, -0.94, 0]}
         />
 
         {/* Suspense boundary: only the avatar remounts on swap, not the whole Canvas */}

--- a/apps/web/src/components/landing/ReefRaceVignette.tsx
+++ b/apps/web/src/components/landing/ReefRaceVignette.tsx
@@ -56,9 +56,11 @@ const TRACK_CURVE = new THREE.CatmullRomCurve3(
 
 const LOOP_DURATION   = 6;    // seconds for one full lap
 const TRACK_HW        = 1.2;  // track half-width in wu
-const CAM_BACK        = 6;    // wu behind the racer
-const CAM_UP          = 2.5;  // wu above the racer
-const CAM_LOOK_AHEAD  = 3;    // wu ahead of the racer for look-at point
+const CAM_BACK        = 3.5;  // wu behind the racer (tightened from 6 so
+                              // the lobster reads at small landing-tile
+                              // viewport — verified visually 2026-04-29)
+const CAM_UP          = 1.5;  // wu above the racer (lowered with cam back)
+const CAM_LOOK_AHEAD  = 2;    // wu ahead of the racer for look-at point
 const CAM_POS_LERP    = 0.08;
 const CAM_LOOK_LERP   = 0.12;
 const BOB_AMP         = 0.12;
@@ -231,7 +233,7 @@ function Racer({ tRef }: { tRef: MutableRefObject<number> }) {
   });
 
   return (
-    <group ref={groupRef} scale={0.9}>
+    <group ref={groupRef} scale={1.6}>
       <primitive object={cloned} />
     </group>
   );


### PR DESCRIPTION
Browser playtest fixes for the landing page refresh (PR #69):

1. Milady avatar — only legs visible because camera looked at origin (foot level). Offset avatar group down by 0.95 so body center sits at origin.
2. Reef Race vignette — racer too small / too far. Pulled cam from 6wu→3.5wu back, scaled lobster from 0.9→1.6.

Verified visually on prod: https://clawville.world/