### PR TITLE
fix(landing): horizontal camera = full Milady avatar visible

### DIFF
--- a/apps/web/src/components/landing/MiladyAvatarShowcase.tsx
+++ b/apps/web/src/components/landing/MiladyAvatarShowcase.tsx
@@ -149,7 +149,7 @@ export default function MiladyAvatarShowcase() {
     >
       <Canvas
         style={{ width: '100%', height: '100%' }}
-        camera={{ position: [0, 0.75, 2.8], fov: 38, near: 0.1, far: 40 }}
+        camera={{ position: [0, 0, 3.0], fov: 38, near: 0.1, far: 40 }}
         gl={{ antialias: true, alpha: true }}
         scene={{ background: SCENE_BG }}
         dpr={[1, 1.5]}


### PR DESCRIPTION
Follow-up to PR #70: prior offset moved the avatar down but the tilted camera at [0, 0.75, 2.8] still cropped the head. Switch to horizontal camera at [0, 0, 3.0] looking at body center — avatar fits with padding above/below.

Browser playtest already confirmed: prior fix showed waist-down + skirt; this fix should show full avatar.