### PR TITLE
perf(landing): pause offscreen canvases + tighter avatar fit + label fit

### DIFF
--- a/apps/web/src/components/landing/BuildingVisitVignette.tsx
+++ b/apps/web/src/components/landing/BuildingVisitVignette.tsx
@@ -28,6 +28,7 @@ import { Suspense, useRef, useMemo, useEffect, memo } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { useGLTF, OrbitControls } from '@react-three/drei';
 import * as THREE from 'three';
+import { useVisibleFrameloop } from '@/lib/use-visible-frameloop';
 import {
   useVRMInstance,
   disposeVRMInstance,
@@ -226,19 +227,24 @@ function VignetteScene() {
 // Root export — thin Canvas wrapper
 // ---------------------------------------------------------------------------
 export default function BuildingVisitVignette() {
+  // Pause the canvas frameloop when offscreen — significant perf win.
+  const { ref, frameloop } = useVisibleFrameloop();
   return (
-    <Canvas
-      style={{ width: '100%', height: '100%' }}
-      dpr={[1, 1.5]}
-      camera={{
-        position: [ORBIT_R, ORBIT_CAM_Y, 0],
-        fov: 45,
-        near: 0.1,
-        far: 60,
-      }}
-      gl={{ antialias: false }}
-    >
-      <VignetteScene />
-    </Canvas>
+    <div ref={ref} style={{ width: '100%', height: '100%' }}>
+      <Canvas
+        style={{ width: '100%', height: '100%' }}
+        dpr={[1, 1.25]}
+        camera={{
+          position: [ORBIT_R, ORBIT_CAM_Y, 0],
+          fov: 45,
+          near: 0.1,
+          far: 60,
+        }}
+        gl={{ antialias: false, powerPreference: 'high-performance' }}
+        frameloop={frameloop}
+      >
+        <VignetteScene />
+      </Canvas>
+    </div>
   );
 }

--- a/apps/web/src/components/landing/MiladyAvatarShowcase.tsx
+++ b/apps/web/src/components/landing/MiladyAvatarShowcase.tsx
@@ -33,6 +33,7 @@ import React, { useRef, useState, useEffect, Suspense, useCallback } from 'react
 import { Canvas, useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { useVRMInstance, disposeVRMInstance } from '@/lib/three/vrm-loader';
+import { useVisibleFrameloop } from '@/lib/use-visible-frameloop';
 import type { VRM } from '@pixiv/three-vrm';
 
 // ---------------------------------------------------------------------------
@@ -55,8 +56,8 @@ const SPIN_SPEED  = 0.08;                    // rad/s Y-axis auto-rotate
 const BOB_AMP     = 0.04;                   // ±0.04 units vertical bob
 const BOB_FREQ    = (2 * Math.PI) / 3;      // one full cycle every 3 s
 // Framing offset — keep the bob centered on this Y instead of Y=0 so
-// the avatar (1.7u tall × 0.65 scale ≈ 1.1u) sits centered on origin.
-const AVATAR_BASE_Y = -0.55;
+// the avatar (1.7u tall × 0.5 scale ≈ 0.85u) sits centered on origin.
+const AVATAR_BASE_Y = -0.42;
 
 // Module-scope scene background — one allocation, no per-render new Color()
 const SCENE_BG = new THREE.Color(0x061520);
@@ -107,11 +108,10 @@ function VRMAvatarInner({ path }: { path: string }) {
   });
 
   // Avatar framing: VRMs export ~1.7u tall with feet at Y=0. Scale to
-  // 0.65 (≈1.1u tall) and offset down so center lands at origin —
-  // robust headroom on every VRM regardless of pose / clothing height.
-  // Verified visually 2026-04-29 after two earlier framings cropped.
+  // 0.5 (≈0.85u tall — slightly more breathing room than 0.65) and
+  // offset down so center lands at origin. Robust on every VRM.
   return (
-    <group ref={groupRef} position={[0, -0.55, 0]} scale={0.65}>
+    <group ref={groupRef} position={[0, AVATAR_BASE_Y, 0]} scale={0.5}>
       <primitive object={vrm.scene} />
     </group>
   );
@@ -142,13 +142,17 @@ export default function MiladyAvatarShowcase() {
   const [index, setIndex] = useState(_startIndex);
   const path = VRM_PATHS[index % VRM_PATHS.length];
 
-  // Click anywhere on the canvas → cycle to next avatar (wrap-around)
+  // Pause the canvas frameloop when the showcase scrolls offscreen —
+  // big perf win, the GPU goes idle when you're past the hero.
+  const { ref, frameloop } = useVisibleFrameloop();
+
   const handleClick = useCallback(() => {
     setIndex((i) => (i + 1) % VRM_PATHS.length);
   }, []);
 
   return (
     <div
+      ref={ref}
       style={{ width: '100%', height: '100%', cursor: 'pointer' }}
       onClick={handleClick}
       title="Click to see next avatar"
@@ -156,20 +160,20 @@ export default function MiladyAvatarShowcase() {
       <Canvas
         style={{ width: '100%', height: '100%' }}
         camera={{ position: [0, 0, 2.4], fov: 38, near: 0.1, far: 40 }}
-        gl={{ antialias: true, alpha: true }}
+        gl={{ antialias: true, alpha: true, powerPreference: 'high-performance' }}
         scene={{ background: SCENE_BG }}
-        dpr={[1, 1.5]}
+        dpr={[1, 1.25]}
+        frameloop={frameloop}
       >
         <ShowcaseLighting />
 
-        {/* Soft shadow disc under avatar at the new foot level
-            (offset -0.55, scaled 0.65 → feet at Y ≈ -0.55). */}
+        {/* Soft shadow disc at avatar foot level (matches AVATAR_BASE_Y). */}
         <mesh
           geometry={_shadowGeo}
           material={_shadowMat}
           rotation={[-Math.PI / 2, 0, 0]}
-          position={[0, -0.55, 0]}
-          scale={0.7}
+          position={[0, AVATAR_BASE_Y, 0]}
+          scale={0.55}
         />
 
         {/* Suspense boundary: only the avatar remounts on swap, not the whole Canvas */}

--- a/apps/web/src/components/landing/ReefRaceVignette.tsx
+++ b/apps/web/src/components/landing/ReefRaceVignette.tsx
@@ -21,6 +21,7 @@ import { useRef, useMemo, useEffect, type MutableRefObject } from 'react';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import { useGLTF } from '@react-three/drei';
 import * as THREE from 'three';
+import { useVisibleFrameloop } from '@/lib/use-visible-frameloop';
 
 // ---------------------------------------------------------------------------
 // Module-scope scratch vectors — allocated once, reused every frame
@@ -330,14 +331,19 @@ function VignetteScene() {
 // Public export — consumed via dynamic() with ssr:false
 // ---------------------------------------------------------------------------
 export default function ReefRaceVignette() {
+  // Pause the canvas frameloop when the tile scrolls offscreen.
+  const { ref, frameloop } = useVisibleFrameloop();
   return (
-    <Canvas
-      style={{ width: '100%', height: '100%' }}
-      dpr={[1, 1.5]}
-      camera={{ fov: 52, near: 0.5, far: 120, position: [0, 4, -8] }}
-      gl={{ antialias: true }}
-    >
-      <VignetteScene />
-    </Canvas>
+    <div ref={ref} style={{ width: '100%', height: '100%' }}>
+      <Canvas
+        style={{ width: '100%', height: '100%' }}
+        dpr={[1, 1.25]}
+        camera={{ fov: 52, near: 0.5, far: 120, position: [0, 4, -8] }}
+        gl={{ antialias: true, powerPreference: 'high-performance' }}
+        frameloop={frameloop}
+      >
+        <VignetteScene />
+      </Canvas>
+    </div>
   );
 }

--- a/apps/web/src/components/landing/collaboration-axes.tsx
+++ b/apps/web/src/components/landing/collaboration-axes.tsx
@@ -58,7 +58,10 @@ export function CollaborationAxes() {
 
   return (
     <div className="anim-up flex flex-col items-center gap-4 mt-6" style={{ animationDelay: '0.62s' }}>
-      <svg viewBox="0 0 240 220" className="w-[260px] sm:w-[300px] h-auto">
+      {/* viewBox extended -50→290 in X to give the bottom-corner labels
+          ("YOU ↔ AGENT" / "AGENT ↔ WORLD") room to render past the
+          vertex coordinates without clipping at the SVG edge. */}
+      <svg viewBox="-50 0 340 220" className="w-[280px] sm:w-[320px] h-auto">
         <defs>
           {AXES.map((a) => (
             <radialGradient key={a.id} id={`glow-${a.id}`} cx="50%" cy="50%" r="50%">

--- a/apps/web/src/components/three/LandingScene.tsx
+++ b/apps/web/src/components/three/LandingScene.tsx
@@ -4,6 +4,7 @@ import { useRef, useMemo, useState, useEffect } from 'react';
 import { Canvas, useFrame, extend } from '@react-three/fiber';
 import { useGLTF } from '@react-three/drei';
 import * as THREE from 'three';
+import { useVisibleFrameloop } from '@/lib/use-visible-frameloop';
 
 extend(THREE as any);
 
@@ -287,6 +288,7 @@ function SceneContents() {
 // ---------------------------------------------------------------------------
 export default function LandingScene() {
   const [ready, setReady] = useState(false);
+  const { ref, frameloop } = useVisibleFrameloop();
 
   useEffect(() => {
     setReady(true);
@@ -295,10 +297,12 @@ export default function LandingScene() {
   if (!ready) return null;
 
   return (
-    <div className="absolute inset-0 z-0">
+    <div ref={ref} className="absolute inset-0 z-0">
       <Canvas
         shadows
-        gl={{ antialias: true }}
+        gl={{ antialias: true, powerPreference: 'high-performance' }}
+        dpr={[1, 1.5]}
+        frameloop={frameloop}
         camera={{
           fov: 50,
           near: 1,

--- a/apps/web/src/lib/use-visible-frameloop.ts
+++ b/apps/web/src/lib/use-visible-frameloop.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * IntersectionObserver-driven frameloop toggle for landing-page R3F
+ * canvases. When the wrapping div scrolls fully out of view, returns
+ * `'never'` so the Canvas stops rendering frames and the GPU goes idle.
+ * When the div re-enters the viewport (with a 200px rootMargin so the
+ * scene is warm before it's actually visible), returns `'always'`.
+ *
+ * Big perf win on the landing page where 4 separate canvases would
+ * otherwise compete for the GPU even when scrolled completely past.
+ *
+ * Usage:
+ *
+ *   const { ref, frameloop } = useVisibleFrameloop();
+ *   return (
+ *     <div ref={ref} style={{ width: '100%', height: '100%' }}>
+ *       <Canvas frameloop={frameloop}>…</Canvas>
+ *     </div>
+ *   );
+ */
+export function useVisibleFrameloop() {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [frameloop, setFrameloop] = useState<'always' | 'never'>('always');
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === 'undefined') return;
+    const obs = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.some((e) => e.isIntersecting);
+        setFrameloop(visible ? 'always' : 'never');
+      },
+      { rootMargin: '200px 0px 200px 0px', threshold: 0 },
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  return { ref, frameloop };
+}


### PR DESCRIPTION
Three browser-playtest fixes:

1. **Avatar size** — scale 0.65 → 0.5 + proportional offset
2. **Triangle labels** — viewBox widened so YOU↔AGENT / AGENT↔WORLD don't clip
3. **Perf** — new useVisibleFrameloop hook pauses each of the 4 R3F canvases (LandingScene + Milady + Reef Race + Building Visit) when they scroll out of view. GPU goes idle when past the visible canvases. Plus DPR cap 1.5→1.25 and powerPreference: 'high-performance' on each canvas.

Expected impact: page should feel native-snappy past the hero.