### PR TITLE
feat(hud): always-visible Ask Nori button

### DIFF
--- a/apps/web/src/app/game/page.tsx
+++ b/apps/web/src/app/game/page.tsx
@@ -45,6 +45,7 @@ const LeaderboardModal = dynamic(() => import('@/components/game/leaderboard-mod
 import BuildingTooltip from '@/components/game/building-tooltip';
 import DailyLoginModal from '@/components/game/daily-login-modal';
 import QuestTracker from '@/components/game/quest-tracker';
+import NoriButton from '@/components/game/nori-button';
 import ThoughtLog from '@/components/game/thought-log';
 import ControlModeToggle from '@/components/game/control-mode-toggle';
 import AutonomyHUD from '@/components/game/autonomy-hud';
@@ -306,6 +307,11 @@ export default function GamePage() {
       <MobileControls />
       <PerfHud />
       <ToastNotifications />
+      {/* Ask Nori HUD shortcut — opens the Town Guide chat from anywhere
+          on the world surface so new players don't have to find her 3D
+          model first. Hides itself when a chat is already open or
+          inside an activity room. */}
+      <NoriButton />
       {/* Listens for `clawville:ensure-guest-pet` window events from the
           game store and bootstraps a guest pet for un-authenticated
           visitors. No UI of its own. */}

--- a/apps/web/src/components/game/nori-button.tsx
+++ b/apps/web/src/components/game/nori-button.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+/**
+ * NoriButton — always-visible HUD shortcut for opening the Town Guide chat.
+ *
+ * Background: Nori (the system-agent at slug `town-guide`) was reachable
+ * only by clicking her 3D model in the world. New players couldn't find
+ * her, and players who scrolled past her didn't have a way to summon
+ * the chat without backtracking. This button mirrors the click-Nori
+ * 3D handler — calls `openGuideChat()` from the game store, which the
+ * existing `<ChatPanel>` already renders into a `<GuideChatBody>`.
+ *
+ * Mounted unconditionally on /game (not gated on agent connection) —
+ * Nori is the orientation NPC for everyone, including unconnected
+ * Players.
+ *
+ * Hidden when:
+ *   - Guide chat already open (would be a no-op)
+ *   - Location chat open (mutually exclusive — Nori never coexists
+ *     with a building character chat)
+ *   - Inside an activity room (gameplay surface owns the screen)
+ */
+
+import { useGameStore } from '@/stores/game';
+
+export default function NoriButton() {
+  const guideChatOpen   = useGameStore((s) => s.guideChatOpen);
+  const chatOpen        = useGameStore((s) => s.chatOpen);
+  const activityLobbyId = useGameStore((s) => s.activityLobbyId);
+  const openGuideChat   = useGameStore((s) => s.openGuideChat);
+
+  if (guideChatOpen || chatOpen || activityLobbyId) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={openGuideChat}
+      title="Ask Nori — your Town Guide"
+      aria-label="Talk to Nori the Town Guide"
+      className="fixed top-4 right-4 z-40 group flex items-center gap-2 rounded-full
+                 border border-pink-400/40 bg-black/70 backdrop-blur-md px-3 py-2
+                 shadow-[0_0_24px_rgba(236,72,153,0.25)]
+                 hover:border-pink-300/70 hover:bg-black/85 hover:shadow-[0_0_32px_rgba(236,72,153,0.4)]
+                 transition-all"
+    >
+      <span className="text-lg leading-none" aria-hidden>💗</span>
+      <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-pink-200/85
+                       group-hover:text-pink-100">
+        Ask Nori
+      </span>
+    </button>
+  );
+}


### PR DESCRIPTION
Adds a top-right HUD pill that opens the Town Guide chat from anywhere on /game. Nori was only reachable by clicking her 3D model, which made her invisible to new players. Hides itself when a chat is already open or inside an activity room. Mounted for everyone including guests + Players (no agent) — Nori is the orientation NPC for all visitors.