### PR TITLE
feat(hud): proximity-aware Talk to Nori pill

### DIFF
--- a/apps/web/src/components/game/nori-button.tsx
+++ b/apps/web/src/components/game/nori-button.tsx
@@ -3,22 +3,19 @@
 /**
  * NoriButton — always-visible HUD shortcut for opening the Town Guide chat.
  *
- * Background: Nori (the system-agent at slug `town-guide`) was reachable
- * only by clicking her 3D model in the world. New players couldn't find
- * her, and players who scrolled past her didn't have a way to summon
- * the chat without backtracking. This button mirrors the click-Nori
- * 3D handler — calls `openGuideChat()` from the game store, which the
- * existing `<ChatPanel>` already renders into a `<GuideChatBody>`.
+ * Two visual states:
  *
- * Mounted unconditionally on /game (not gated on agent connection) —
- * Nori is the orientation NPC for everyone, including unconnected
- * Players.
+ *   - **Far** (default): subtle pink pill, label "Ask Nori"
+ *   - **Near** (player within NORI_TALK_RADIUS): stronger glow + pulse
+ *     + label "Talk to Nori" — mirrors the proximity affordance the 10
+ *     building characters get when you walk up to them.
+ *
+ * Click → openGuideChat() (same path the 3D click handler uses).
  *
  * Hidden when:
- *   - Guide chat already open (would be a no-op)
- *   - Location chat open (mutually exclusive — Nori never coexists
- *     with a building character chat)
- *   - Inside an activity room (gameplay surface owns the screen)
+ *   - guide chat already open (no-op)
+ *   - location chat open (mutually exclusive)
+ *   - inside an activity room (gameplay surface owns the screen)
  */
 
 import { useGameStore } from '@/stores/game';
@@ -27,6 +24,7 @@ export default function NoriButton() {
   const guideChatOpen   = useGameStore((s) => s.guideChatOpen);
   const chatOpen        = useGameStore((s) => s.chatOpen);
   const activityLobbyId = useGameStore((s) => s.activityLobbyId);
+  const nearGuide       = useGameStore((s) => s.nearGuide);
   const openGuideChat   = useGameStore((s) => s.openGuideChat);
 
   if (guideChatOpen || chatOpen || activityLobbyId) return null;
@@ -36,17 +34,21 @@ export default function NoriButton() {
       type="button"
       onClick={openGuideChat}
       title="Ask Nori — your Town Guide"
-      aria-label="Talk to Nori the Town Guide"
-      className="fixed top-4 right-4 z-40 group flex items-center gap-2 rounded-full
-                 border border-pink-400/40 bg-black/70 backdrop-blur-md px-3 py-2
-                 shadow-[0_0_24px_rgba(236,72,153,0.25)]
-                 hover:border-pink-300/70 hover:bg-black/85 hover:shadow-[0_0_32px_rgba(236,72,153,0.4)]
-                 transition-all"
+      aria-label={nearGuide ? 'Talk to Nori the Town Guide' : 'Ask Nori the Town Guide'}
+      className={`fixed top-4 right-4 z-40 group flex items-center gap-2 rounded-full
+                  border bg-black/70 backdrop-blur-md px-3 py-2 transition-all
+                  ${nearGuide
+                    ? 'border-pink-300/80 shadow-[0_0_36px_rgba(236,72,153,0.55)] scale-105 animate-pulse'
+                    : 'border-pink-400/40 shadow-[0_0_24px_rgba(236,72,153,0.25)] hover:border-pink-300/70 hover:bg-black/85 hover:shadow-[0_0_32px_rgba(236,72,153,0.4)]'}
+      `}
     >
       <span className="text-lg leading-none" aria-hidden>💗</span>
-      <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-pink-200/85
-                       group-hover:text-pink-100">
-        Ask Nori
+      <span
+        className={`font-mono text-[10px] uppercase tracking-[0.2em] transition-colors ${
+          nearGuide ? 'text-pink-100' : 'text-pink-200/85 group-hover:text-pink-100'
+        }`}
+      >
+        {nearGuide ? 'Talk to Nori' : 'Ask Nori'}
       </span>
     </button>
   );

--- a/apps/web/src/lib/three/npc-controller.tsx
+++ b/apps/web/src/lib/three/npc-controller.tsx
@@ -19,6 +19,7 @@ import { useNpcStore } from '@/stores/npc';
 import type { NpcSpriteState } from '@/stores/npc';
 import { MAP_WIDTH, MAP_HEIGHT } from '@/lib/pixi/tilemap-data';
 import { findNearestCharacter } from '@/lib/three/character-positions';
+import { NORI_WORLD_X, NORI_WORLD_Z, NORI_TALK_RADIUS_SQ } from '@/lib/three/town-guide';
 import { isEditable, jumpState } from '@/lib/three/jump-state';
 
 const SPEED = 550; // pixels/sec — pass 2 2026-04-16: bumped 320→550 (user tested pass 1 at 320,
@@ -147,6 +148,12 @@ export default function NpcController() {
       const nearName = nearest ? nearest.characterName : null;
       if (nearId !== store.nearLocation) store.setNearLocation(nearId);
       if (nearName !== store.nearCharacter) store.setNearCharacter(nearName);
+
+      // Town Guide proximity (singleton — Nori isn't in CHARACTER_POSITIONS).
+      const ndx = wx - NORI_WORLD_X;
+      const ndz = wz - NORI_WORLD_Z;
+      const noriNear = (ndx * ndx + ndz * ndz) < NORI_TALK_RADIUS_SQ;
+      if (noriNear !== store.nearGuide) store.setNearGuide(noriNear);
     }
 
     // ---- Unified input: joystick + WASD → camera-relative ----

--- a/apps/web/src/lib/three/player-pet.tsx
+++ b/apps/web/src/lib/three/player-pet.tsx
@@ -10,6 +10,7 @@ import {
   MAP_HEIGHT,
 } from '@/lib/pixi/tilemap-data';
 import { findNearestCharacter } from '@/lib/three/character-positions';
+import { NORI_WORLD_X, NORI_WORLD_Z, NORI_TALK_RADIUS_SQ } from '@/lib/three/town-guide';
 import { applyWalkAnimation, applyIdleAnimation } from '@/lib/three/procedural-animation';
 import { LobsterAnimator } from '@/lib/three/lobster-animations';
 import { discoverLobsterParts } from '@/lib/three/lobster-parts';
@@ -408,6 +409,14 @@ function PlayerPetVRMInner({ reg }: { reg: ModelRegistryEntry }) {
       const nearName = nearest ? nearest.characterName : null;
       if (nearId !== store.nearLocation) store.setNearLocation(nearId);
       if (nearName !== store.nearCharacter) store.setNearCharacter(nearName);
+
+      // Town Guide proximity — same shape as findNearestCharacter, but
+      // Nori isn't in the building map so we test her singleton position
+      // inline. Squared distance avoids sqrt in the hot path.
+      const ndx = wx - NORI_WORLD_X;
+      const ndz = wz - NORI_WORLD_Z;
+      const noriNear = (ndx * ndx + ndz * ndz) < NORI_TALK_RADIUS_SQ;
+      if (noriNear !== store.nearGuide) store.setNearGuide(noriNear);
     }
 
     const group = groupRef.current;
@@ -700,6 +709,14 @@ function PlayerPetGLBInner() {
       const nearName = nearest ? nearest.characterName : null;
       if (nearId !== store.nearLocation) store.setNearLocation(nearId);
       if (nearName !== store.nearCharacter) store.setNearCharacter(nearName);
+
+      // Town Guide proximity — same shape as findNearestCharacter, but
+      // Nori isn't in the building map so we test her singleton position
+      // inline. Squared distance avoids sqrt in the hot path.
+      const ndx = wx - NORI_WORLD_X;
+      const ndz = wz - NORI_WORLD_Z;
+      const noriNear = (ndx * ndx + ndz * ndz) < NORI_TALK_RADIUS_SQ;
+      if (noriNear !== store.nearGuide) store.setNearGuide(noriNear);
     }
 
     const group = groupRef.current;

--- a/apps/web/src/lib/three/town-guide.tsx
+++ b/apps/web/src/lib/three/town-guide.tsx
@@ -54,6 +54,16 @@ const GROUND_Y    = -2;
 const GUIDE_Z     = 240;
 const GUIDE_SCALE = 200;
 
+// Exported so player-pet / npc-controller can run the same proximity
+// check building characters get against the CHARACTER_POSITIONS map.
+// X is 0 (town center on X-axis); Z matches the placement above.
+export const NORI_WORLD_X = 0;
+export const NORI_WORLD_Z = GUIDE_Z;
+// Squared talk-radius — 320 wu gives Nori a slightly larger pull-in
+// circle than the 260 wu building characters use, since she stands in
+// the open town center where proximity is the only chat affordance.
+export const NORI_TALK_RADIUS_SQ = 320 * 320;
+
 const CLIP_WAVE = 'wave';
 
 // Ordered playlist. pose-laying excluded (looks broken at standing height —

--- a/apps/web/src/stores/game.ts
+++ b/apps/web/src/stores/game.ts
@@ -84,6 +84,13 @@ export interface GameState {
   nearCharacter: string | null;
   setNearCharacter: (name: string | null) => void;
 
+  // Near Town Guide (Nori) — true when player is within TALK_RADIUS_WORLD of
+  // the town-guide anchor (0, _, 240). Drives the in-HUD "Talk to Nori" pill
+  // glow + label swap so Nori gets the same proximity affordance the 10
+  // building characters do. Written by the same 3D proximity pass.
+  nearGuide: boolean;
+  setNearGuide: (near: boolean) => void;
+
   // Current location the player is chatting at (still keyed by buildingId for
   // downstream routing — API chat endpoint, shop, knowledge context — but the
   // UX is framed as "talking to the character in front of this building",
@@ -448,6 +455,9 @@ export const useGameStore = create<GameState>((set, get) => ({
 
   nearCharacter: null,
   setNearCharacter: (name) => set({ nearCharacter: name }),
+
+  nearGuide: false,
+  setNearGuide: (near) => set({ nearGuide: near }),
 
   currentLocation: null,
   currentCharacter: null,


### PR DESCRIPTION
Same proximity affordance building chars get. NoriButton glows + pulses + swaps label to "Talk to Nori" when player is within 320wu of her town-center spot.