### PR TITLE
perf(reef-race): drop shadow-map pipeline — match Bumper Shells precedent

### DIFF
--- a/apps/web/src/lib/three/activities/reef-race/ReefRaceScene.tsx
+++ b/apps/web/src/lib/three/activities/reef-race/ReefRaceScene.tsx
@@ -478,10 +478,15 @@ export default function ReefRaceScene({ roomId, selfAvatarId = null }: ReefRaceS
     <Canvas
       key={roomId}
       camera={{ near: CAMERA_NEAR, far: CAMERA_FAR, fov: 60 }}
-      shadows
-      gl={{ antialias: false }} // Disable MSAA for Iris Xe perf budget
+      // shadows REMOVED 2026-05-09 — full shadow-map pipeline was running per
+      // frame for the track + guardrails + ramps + checkpoints + pickups +
+      // hazards. Mirrors Bumper Shells which dropped shadows for the same
+      // perf budget. Lighting is still directional via the scene's
+      // directional+ambient lights; the cost was the second render pass for
+      // shadow map generation, not the lights themselves.
+      gl={{ antialias: false }}
       style={{ width: '100%', height: '100%' }}
-      dpr={[1, 1.5]} // Clamp pixel ratio for Iris Xe
+      dpr={[1, 1.5]}
     >
       <SceneContents
         entities={entities ?? new Map()}


### PR DESCRIPTION
## Summary

#7 of the FPS plan — Reef Race had `shadows` enabled on its Canvas. That ran a full second render pass every frame to generate shadow maps for the track + guardrails + ramps + checkpoints + pickups + hazards. Disabled.

## Why it's safe

- **Bumper Shells already did this** with shipped visual results. Same precedent.
- **No Canvas-level shadow pipeline** = `castShadow`/`receiveShadow` on individual meshes become no-ops automatically. Left them in place for cheap re-enable.
- Lighting is still directional via the scene's directional+ambient lights — what's gone is the shadow render pass, not the lights.

## Hardware-agnostic

Every device pays the shadow render cost. Mobile + low-end laptops feel it most, but desktops also save.

## Files

One file, one prop removed (`shadows`):
- `apps/web/src/lib/three/activities/reef-race/ReefRaceScene.tsx`

## Test plan

- [ ] Coolify auto-deploys
- [ ] Reef Race scene still loads and renders
- [ ] Track / pickups / ramps still visible — lighting flatter but readable
- [ ] FPS during Reef Race higher than before (especially on mid-range hardware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)