### PR TITLE
perf(3d): WorldLabelsOverlay — replace 30+ drei <Html> portals with single overlay

### DIFF
--- a/apps/web/src/components/three/World3DCanvas.tsx
+++ b/apps/web/src/components/three/World3DCanvas.tsx
@@ -35,6 +35,7 @@ import NpcSpeechBubbles from '@/lib/three/npc-speech-bubbles';
 import ClickToMove from '@/lib/three/click-to-move';
 import { KTX2LoaderSetup } from '@/lib/three/ktx2-loader-setup';
 import { MeshoptLoaderSetup } from '@/lib/three/meshopt-loader-setup';
+import { WorldLabelsOverlayMount } from '@/lib/three/world-labels-overlay';
 import JumpTicker from '@/lib/three/jump-ticker';
 import { jumpState } from '@/lib/three/jump-state';
 import { useGameStore, avatarPositionRef } from '@/stores/game';
@@ -664,6 +665,12 @@ const SceneContents = memo(function SceneContents({ mode }: { mode: WorldMode })
           R3F runs useFrame hooks in mount order; hoisting here ensures every
           consumer reads current-frame heightOffset, not the prior frame's stale value. */}
       <JumpTicker />
+
+      {/* Single DOM overlay for all world-space labels (NPC names, building labels,
+          speech bubbles). Replaces 30+ per-instance drei <Html> portals.
+          Mount early so consumers (ArenaNpcs, ArenaBuildings, etc.) see the overlay
+          node ready on their first render. */}
+      <WorldLabelsOverlayMount />
 
       {/* Camera controls.
           Target at z=-50 centres on the middle building row (z ≈ -64) so the

--- a/apps/web/src/lib/three/arena-buildings.tsx
+++ b/apps/web/src/lib/three/arena-buildings.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useRef, useState, useEffect, useCallback, Suspense } from 'react';
 import * as THREE from 'three';
 import { useGLTF, Html } from '@react-three/drei';
+import { useWorldLabel, WorldLabel } from '@/lib/three/world-labels-overlay';
 import { useFrame, useThree } from '@react-three/fiber';
 import { BUILDING_OPENCLAW_THEMES } from '@clawville/shared';
 import {
@@ -32,7 +33,6 @@ function zoneCenter(zone: BuildingZone): [number, number, number] {
 }
 
 import { TERRAIN_LAYER } from '@/lib/three/arena-terrain';
-import { anchorInFrontOfCamera } from '@/lib/three/utils/camera-cull';
 import { makeObject3DWebGPUSafe } from '@/lib/three/webgpu-geometry';
 
 // Shared raycaster -- only hits layer 1 (terrain)
@@ -45,9 +45,6 @@ const _buildRayDir = new THREE.Vector3(0, -1, 0);
 // 800 gives buildings proper visual weight on the 160x160 (5120 world-unit) map —
 // previously 480 made buildings feel like tiny props relative to the vast sand floor.
 const BUILDING_TARGET_HEIGHT = 800;
-
-// Module-scope scratch for getWorldPosition in the building label behind-camera cull.
-const _buildAnchorWorldPos = new THREE.Vector3();
 
 // Map each building ID to a GLB model + display config.
 // rotY: each building faces the village center at tile (80, 80) = world (0, 0).
@@ -313,10 +310,15 @@ function GLBBuilding({ zone }: { zone: BuildingZone }) {
   const [cx, , cz] = zoneCenter(zone);
   const { scene } = useGLTF(config.model);
   const groupRef = useRef<THREE.Group>(null);
-  // Ref for the label div — needed for behind-camera imperative cull (see useFrame below).
-  // drei <Html> is a DOM portal; Three.js visibility flags do NOT propagate to DOM.
-  const labelDivRef = useRef<HTMLDivElement>(null);
-  const { camera } = useThree();
+
+  // WorldLabelsOverlay label — always visible (buildings are never distance-culled).
+  // pointerEvents='auto' preserves click-target behavior from the original <Html>.
+  const { divRef: labelDivRef } = useWorldLabel({
+    id: `building-label-${zone.id}`,
+    anchorRef: groupRef,
+    offset: [0, BUILDING_TARGET_HEIGHT + 20, 0],
+    initialVisible: true,
+  });
 
   const { cloned, buildingScale, pivotOffsetX, pivotOffsetY, pivotOffsetZ } = useMemo(() => {
     const c = scene.clone(true);
@@ -386,10 +388,10 @@ function GLBBuilding({ zone }: { zone: BuildingZone }) {
       <group position={[-pivotOffsetX, -pivotOffsetY, -pivotOffsetZ]}>
         <primitive object={cloned} scale={buildingScale} />
       </group>
-      {/* Floating building label.
-          PERF: removed distanceFactor (was 1500) — see arena-npcs.tsx PERF note */}
+      {/* Floating building label — WorldLabelsOverlay projects offset [0, BUILDING_TARGET_HEIGHT+20, 0].
+          pointerEvents='auto' preserves click-target behavior. */}
       {theme && (
-        <Html position={[0, BUILDING_TARGET_HEIGHT + 20, 0]} center style={{ pointerEvents: 'auto' }}>
+        <WorldLabel divRef={labelDivRef} pointerEvents="auto">
           <div
             style={{
               background: 'rgba(10, 22, 40, 0.85)',
@@ -406,7 +408,7 @@ function GLBBuilding({ zone }: { zone: BuildingZone }) {
             <div style={{ color: '#7dd3fc', fontWeight: 'bold', fontSize: 13 }}>{theme.label}</div>
             <div style={{ color: 'rgba(148,163,184,0.7)', fontSize: 10, marginTop: 2 }}>{theme.category}</div>
           </div>
-        </Html>
+        </WorldLabel>
       )}
     </group>
   );

--- a/apps/web/src/lib/three/arena-location-npcs.tsx
+++ b/apps/web/src/lib/three/arena-location-npcs.tsx
@@ -2,7 +2,8 @@
 
 import { useRef, useMemo, memo, Suspense, useEffect, type ReactElement } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
-import { useGLTF, Html } from '@react-three/drei';
+import { useGLTF } from '@react-three/drei';
+import { useWorldLabel, WorldLabel } from '@/lib/three/world-labels-overlay';
 import * as THREE from 'three';
 import * as SkeletonUtils from 'three/addons/utils/SkeletonUtils.js';
 import {
@@ -393,6 +394,17 @@ const NpcMesh = memo(function NpcMesh({
   // Null for un-rigged GLBs (most of the canonical SpongeBob cast + Flying Dutchman).
   const mixerRef = useRef<THREE.AnimationMixer | null>(null);
   const { scene: threeScene } = useThree();
+
+  // WorldLabelsOverlay label — always visible for primary NPCs (showLabel=true),
+  // invisible/skipped for companions (showLabel=false). No distance cull needed —
+  // location NPCs are stationary and the user must approach them to interact.
+  // id encodes model path + position so companion instances don't collide with primary.
+  const { divRef: locationLabelRef } = useWorldLabel({
+    id: `location-npc-label-${modelCfg.model}-${worldX}-${worldZ}`,
+    anchorRef: groupRef,
+    offset: [0, 150, 0],
+    initialVisible: showLabel,
+  });
   const { scene, animations } = useGLTF(modelCfg.model);
   const terrainY = useRef(-2);
   const placed = useRef(false);
@@ -589,18 +601,13 @@ const NpcMesh = memo(function NpcMesh({
           <primitive object={cloned} />
         </group>
       </group>
-      {/* Name label — OUTSIDE scaled group so position is in world units.
-          Only shown for primary NPCs; companions are passive (no label). */}
+      {/* Name label — WorldLabelsOverlay projects offset [0,150,0].
+          Only primary NPCs get a label (showLabel=true via initialVisible). */}
       {showLabel && (
-        // PERF: removed distanceFactor — see arena-npcs.tsx PERF note
-        <Html
-          position={[0, 150, 0]}
-          center
-          style={{ pointerEvents: 'none' }}
-          zIndexRange={[10, 100]}
-        >
+        <WorldLabel divRef={locationLabelRef}>
           <div
             style={{
+              display: 'flex',
               background: 'rgba(8, 20, 38, 0.78)',
               border: '1px solid rgba(100, 200, 255, 0.25)',
               borderRadius: 6,
@@ -615,7 +622,7 @@ const NpcMesh = memo(function NpcMesh({
           >
             {modelCfg.name}
           </div>
-        </Html>
+        </WorldLabel>
       )}
     </group>
   );

--- a/apps/web/src/lib/three/arena-npcs.tsx
+++ b/apps/web/src/lib/three/arena-npcs.tsx
@@ -2,8 +2,9 @@
 
 import { useRef, useMemo, useEffect, useLayoutEffect, memo, Suspense } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
-import { useGLTF, Html } from '@react-three/drei';
+import { useGLTF } from '@react-three/drei';
 import * as THREE from 'three';
+import { useWorldLabel, WorldLabel } from '@/lib/three/world-labels-overlay';
 import * as SkeletonUtils from 'three/addons/utils/SkeletonUtils.js';
 import { useNpcStore, type NpcSpriteState } from '@/stores/npc';
 import { applyWalkAnimation, applyIdleAnimation, idToSeed } from '@/lib/three/procedural-animation';
@@ -454,10 +455,6 @@ const GLBNpcMesh = memo(function GLBNpcMesh({ npc }: { npc: NpcSpriteState }) {
   // Layer 2 safety net: one-shot rendered-height hard cap applied after first render.
   // Catches any NPC that slips through computeNpcScale with a wrong pivot offset.
   const rescaleAppliedRef = useRef(false);
-  // drei <Html> uses a React DOM portal outside the Three.js scene graph — setting
-  // group.visible=false does NOT propagate to the DOM div. We imperatively sync
-  // label display in useFrame so the label disappears with the mesh.
-  const labelRef = useRef<HTMLDivElement>(null);
   // Occlusion latch — flipped at ~10Hz by checkLabelOcclusion, read every frame
   // to decide label visibility without burning raycast budget.
   const occludedRef = useRef(false);
@@ -479,6 +476,15 @@ const GLBNpcMesh = memo(function GLBNpcMesh({ npc }: { npc: NpcSpriteState }) {
   // idToSeed returns a float (0..10). Convert to integer so (frame + seed) % N
   // uses integer arithmetic — float modulo with strict === 0 never fires.
   const seed = useMemo(() => Math.round(idToSeed(npc.id)), [npc.id]);
+
+  // WorldLabelsOverlay label — replaces drei <Html> for this NPC's name tag.
+  // starts hidden (initialVisible:false); useFrame calls setVisible when NPC enters range.
+  const { divRef: labelRef, setVisible: setLabelVisible } = useWorldLabel({
+    id: `glb-npc-label-${npc.id}`,
+    anchorRef: groupRef,
+    offset: [0, 100, 0],
+    initialVisible: false,
+  });
 
   const targetPos = useRef(new THREE.Vector3(...mapToWorld(npc.x, npc.y)));
   const currentPos = useRef(new THREE.Vector3(...mapToWorld(npc.x, npc.y)));
@@ -630,39 +636,28 @@ const GLBNpcMesh = memo(function GLBNpcMesh({ npc }: { npc: NpcSpriteState }) {
       // already false, so the label stayed visible at distance indefinitely.
       // Always writing the style (cheap when value doesn't change) prevents the leak.
       group.visible = false;
-      // drei <Html> DOM portal is outside the scene graph — visibility flag does NOT
-      // propagate to the DOM div. Imperatively hide the label so it doesn't float
-      // over empty world space while the 3D mesh is culled.
-      const label = labelRef.current;
-      if (label && label.style.display !== 'none') label.style.display = 'none';
+      // WorldLabelsOverlay manages the DOM label — hide it imperatively so it
+      // doesn't float over empty world space while the 3D mesh is culled.
+      setLabelVisible(false);
       return;
     }
     group.visible = true;
     const frame = Math.floor(clock.elapsedTime * 60);
     {
       // Behind-camera cull + line-of-sight occlusion gate.
-      // Behind-camera: drei <Html> projects to screen XY even when the anchor
-      // is behind the camera, producing a ghost label.
-      // Occlusion: anchor in front but blocked by a building/closer NPC →
-      // label would draw over foreground geometry. Re-locked 2026-04-26 after
-      // PR #65 stripped this — that's the bug where Driftwood/Riptide labels
-      // float over Nori's chest.
+      // Behind-camera: overlay projects even when anchor is behind camera → hide.
+      // Occlusion: anchor in front but blocked by building/closer NPC → hide.
+      // Re-locked 2026-04-26 after PR #65 stripped this.
       group.getWorldPosition(_npcAnchorWorldPos);
       const inFront = anchorInFrontOfCamera(_npcAnchorWorldPos, camera);
-      // 10Hz occlusion test, staggered per NPC. Only runs when the label is
+      // 10Hz occlusion test, staggered per NPC. Only runs when label is
       // already in front (so behind-camera labels don't burn raycast budget).
       if (inFront && (frame + seed) % 6 === 0) {
         occludedRef.current = checkLabelOcclusion(
           camera.position, _npcAnchorWorldPos, npc.id, threeScene,
         );
       }
-      const label = labelRef.current;
-      const shouldShow = inFront && !occludedRef.current;
-      if (!shouldShow) {
-        if (label && label.style.display !== 'none') label.style.display = 'none';
-      } else {
-        if (label && label.style.display !== 'flex') label.style.display = 'flex';
-      }
+      setLabelVisible(inFront && !occludedRef.current);
     }
 
     // Raycast to find terrain surface Y (every 3rd frame to save perf).
@@ -800,30 +795,12 @@ const GLBNpcMesh = memo(function GLBNpcMesh({ npc }: { npc: NpcSpriteState }) {
           <primitive object={cloned} />
         </group>
       </group>
-      {/* Name label — OUTSIDE scaled group so position is in world units.
-          100 = clearance above TARGET_NPC_HEIGHT=45 for the tallest species. */}
-      {/* PERF: removed `distanceFactor={300}` — drei recomputes camera-distance
-          scale + writes a new CSS transform every frame for each Html, which
-          forces a full Layout pass per label per frame (~14% of frame budget
-          across 18 NPC labels per the DevTools profile). Labels now display
-          at constant CSS size; positioning still tracks the 3D point. */}
-      <Html
-        position={[0, 100, 0]}
-        center
-        style={{ pointerEvents: 'none' }}
-        zIndexRange={[10, 100]}
-      >
-        {/* ref attached so useFrame can imperatively sync display with group.visible.
-            drei <Html> is a DOM portal — Three.js visibility flag does NOT propagate.
-            Default display:'none' so labels start hidden; useFrame opens them when
-            the NPC enters range. This prevents ghost labels on the very first frames
-            before useFrame has had a chance to evaluate distance — and also ensures
-            that memo re-renders (which re-apply the JSX inline style) default to
-            hidden rather than overwriting a cull-frame 'none' with 'flex'. */}
+      {/* Name label — WorldLabelsOverlay manages projection + DOM writes.
+          offset [0,100,0]: 100wu clearance above TARGET_NPC_HEIGHT=45. */}
+      <WorldLabel divRef={labelRef}>
         <div
-          ref={labelRef}
           style={{
-            display: 'none',
+            display: 'flex',
             alignItems: 'center',
             gap: 4,
             background: 'rgba(8, 20, 38, 0.78)',
@@ -860,7 +837,7 @@ const GLBNpcMesh = memo(function GLBNpcMesh({ npc }: { npc: NpcSpriteState }) {
             </span>
           )}
         </div>
-      </Html>
+      </WorldLabel>
     </group>
   );
 });
@@ -874,9 +851,6 @@ const GLBNpcMesh = memo(function GLBNpcMesh({ npc }: { npc: NpcSpriteState }) {
 // The 2 demo Milady NPCs intentionally use different paths (official_7 / official_8).
 const VRMNpcMesh = memo(function VRMNpcMesh({ npc }: { npc: NpcSpriteState }) {
   const groupRef = useRef<THREE.Group>(null!);
-  // Same DOM-portal caveat as GLBNpcMesh — drei <Html> is outside the scene graph.
-  // Imperatively sync label display with group.visible in the cull block.
-  const labelRef = useRef<HTMLDivElement>(null);
   // Occlusion latch — same pattern as GLBNpcMesh.
   const occludedRef = useRef(false);
   const { scene: threeScene } = useThree();
@@ -896,6 +870,15 @@ const VRMNpcMesh = memo(function VRMNpcMesh({ npc }: { npc: NpcSpriteState }) {
 
   // idToSeed returns float — round to int so (frame + seed) % 3 uses integer arithmetic.
   const seed = useMemo(() => Math.round(idToSeed(npc.id)), [npc.id]);
+
+  // WorldLabelsOverlay label — replaces drei <Html> for this NPC's name tag.
+  // Starts hidden; useFrame calls setVisible when NPC enters cull radius.
+  const { divRef: labelRef, setVisible: setLabelVisible } = useWorldLabel({
+    id: `vrm-npc-label-${npc.id}`,
+    anchorRef: groupRef,
+    offset: [0, 100, 0],
+    initialVisible: false,
+  });
 
   const targetPos = useRef(new THREE.Vector3(...mapToWorld(npc.x, npc.y)));
   const currentPos = useRef(new THREE.Vector3(...mapToWorld(npc.x, npc.y)));
@@ -1002,9 +985,8 @@ const VRMNpcMesh = memo(function VRMNpcMesh({ npc }: { npc: NpcSpriteState }) {
       // Always write — not transition-only. See GLBNpcMesh cull block for full rationale:
       // memo re-renders restore JSX inline style; always-write prevents the leak.
       group.visible = false;
-      // drei <Html> DOM portal — Three.js visibility flag does NOT propagate.
-      const label = labelRef.current;
-      if (label && label.style.display !== 'none') label.style.display = 'none';
+      // WorldLabelsOverlay manages the DOM label — hide imperatively.
+      setLabelVisible(false);
       return;
     }
     group.visible = true;
@@ -1017,13 +999,7 @@ const VRMNpcMesh = memo(function VRMNpcMesh({ npc }: { npc: NpcSpriteState }) {
           camera.position, _npcAnchorWorldPos, npc.id, threeScene,
         );
       }
-      const label = labelRef.current;
-      const shouldShow = inFront && !occludedRef.current;
-      if (!shouldShow) {
-        if (label && label.style.display !== 'none') label.style.display = 'none';
-      } else {
-        if (label && label.style.display !== 'flex') label.style.display = 'flex';
-      }
+      setLabelVisible(inFront && !occludedRef.current);
     }
 
     // Raycast terrain every 3rd frame (staggered by seed to avoid per-frame spikes)
@@ -1115,27 +1091,12 @@ const VRMNpcMesh = memo(function VRMNpcMesh({ npc }: { npc: NpcSpriteState }) {
         object={vrm.scene}
         scale={[VRM_NPC_SCALE, VRM_NPC_SCALE, VRM_NPC_SCALE]}
       />
-      {/* Name label — OUTSIDE scale so it's in world units. y=100 matches GLBNpcMesh. */}
-      {/* PERF: removed `distanceFactor={300}` — drei recomputes camera-distance
-          scale + writes a new CSS transform every frame for each Html, which
-          forces a full Layout pass per label per frame (~14% of frame budget
-          across 18 NPC labels per the DevTools profile). Labels now display
-          at constant CSS size; positioning still tracks the 3D point. */}
-      <Html
-        position={[0, 100, 0]}
-        center
-        style={{ pointerEvents: 'none' }}
-        zIndexRange={[10, 100]}
-      >
-        {/* ref attached so useFrame can imperatively sync display with group.visible.
-            drei <Html> is a DOM portal — Three.js visibility flag does NOT propagate.
-            Default display:'none' — same rationale as GLBNpcMesh: prevents ghost labels
-            on first frames and prevents memo re-renders from restoring 'flex' on culled
-            NPCs. useFrame opens the label when the NPC enters the cull radius. */}
+      {/* Name label — WorldLabelsOverlay manages projection + DOM writes.
+          offset [0,100,0]: 100wu clearance, matches GLBNpcMesh. */}
+      <WorldLabel divRef={labelRef}>
         <div
-          ref={labelRef}
           style={{
-            display: 'none',
+            display: 'flex',
             alignItems: 'center',
             gap: 4,
             background: 'rgba(8, 20, 38, 0.78)',
@@ -1172,7 +1133,7 @@ const VRMNpcMesh = memo(function VRMNpcMesh({ npc }: { npc: NpcSpriteState }) {
             </span>
           )}
         </div>
-      </Html>
+      </WorldLabel>
     </group>
   );
 });

--- a/apps/web/src/lib/three/npc-speech-bubbles.tsx
+++ b/apps/web/src/lib/three/npc-speech-bubbles.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { memo, useMemo, useState, useEffect, useRef } from 'react';
-import { Html } from '@react-three/drei';
-import { useFrame, useThree } from '@react-three/fiber';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { useWorldLabel, WorldLabel } from '@/lib/three/world-labels-overlay';
 import { useNpcStore, type NpcChatBubble, type NpcSpriteState } from '@/stores/npc';
 import { useShallow } from 'zustand/react/shallow';
 import { MAP_WIDTH, MAP_HEIGHT } from '@/lib/pixi/tilemap-data';
@@ -41,68 +42,50 @@ const SpeechBubble = memo(function SpeechBubble({ npc, bubble }: SpeechBubblePro
     ? bubble.text.slice(0, MAX_CHARS) + '…'
     : bubble.text;
 
-  // bubbleDivRef: imperative behind-camera cull — drei <Html> does not hide its
-  // DOM portal when the 3D anchor is behind the camera (NDC z > 1 still produces
-  // a screen XY), so ghost bubbles float over empty world space. Starts hidden
-  // (display:'none'); useFrame below opens it only when the NPC is in front.
-  // Zero-allocation: camera.matrixWorldInverse viewZ test (no Vector3 alloc).
-  const bubbleDivRef = useRef<HTMLDivElement>(null);
-  const { camera } = useThree();
+  // groupRef serves as the 3D anchor for WorldLabelsOverlay.
+  // The overlay handles behind-camera detection via NDC z > 1 — no manual
+  // camera.matrixWorldInverse viewZ calculation needed.
+  const groupRef = useRef<THREE.Group>(null);
 
   // Keep world coords in refs so useFrame reads fresh values without closure capture.
+  // Still needed to update the group position each frame (NPC moves with server ticks).
   const worldXRef = useRef(worldX);
   const worldZRef = useRef(worldZ);
   worldXRef.current = worldX;
   worldZRef.current = worldZ;
 
+  const { divRef: bubbleDivRef } = useWorldLabel({
+    id: `speech-bubble-${npc.id}-${bubble.expiresAt}`,
+    anchorRef: groupRef,
+    // offset [0,0,0]: group is already positioned at [worldX, BUBBLE_Y, worldZ].
+    offset: [0, 0, 0],
+    initialVisible: true,
+  });
+
+  // Update group world position each frame to track NPC movement.
+  // Also keeps visibility in sync — the overlay's NDC z > 1 check replaces the
+  // manual viewZ calculation from the previous drei <Html> implementation.
   useFrame(() => {
-    const div = bubbleDivRef.current;
-    if (!div) return;
-    // camera.matrixWorldInverse transforms world→view; viewZ < 0 = in front of camera.
-    // Anchor world position: (worldX, BUBBLE_Y, worldZ) — no group.matrixWorld needed.
-    const m = camera.matrixWorldInverse.elements;
-    const wx = worldXRef.current;
-    const wy = BUBBLE_Y;
-    const wz = worldZRef.current;
-    const viewZ = m[2] * wx + m[6] * wy + m[10] * wz + m[14];
-    const inFront = viewZ < 0;
-    if (!inFront) {
-      if (div.style.display !== 'none') div.style.display = 'none';
-    } else {
-      if (div.style.display !== 'block') div.style.display = 'block';
-    }
+    const g = groupRef.current;
+    if (!g) return;
+    g.position.x = worldXRef.current;
+    g.position.z = worldZRef.current;
   });
 
   return (
-    <group position={[worldX, BUBBLE_Y, worldZ]}>
-      {/* NO distanceFactor. Earlier version set distanceFactor={300} claiming
-          it was required to preserve maxWidth — in practice the opposite was
-          true. drei computes `scale = distanceFactor / cameraDistance`. At
-          the default spectate camera ~1217wu from town center, scale ≈ 0.25,
-          which shrunk the inner `maxWidth: 180` to ~45px visual — narrow
-          enough to force 1-char-per-line wrapping (the tall skinny column
-          the user reported 2026-04-24). Constant CSS size (no
-          distanceFactor) matches the NPC name-label pattern and keeps the
-          bubble readable at all camera distances. */}
-      <Html
-        center
-        style={{ pointerEvents: 'none' }}
-        zIndexRange={[10, 100]}
-      >
+    <group ref={groupRef} position={[worldX, BUBBLE_Y, worldZ]}>
+      {/* WorldLabelsOverlay projects this bubble to screen space.
+          width:180 preserves the original layout — see prior comment about
+          drei <Html center> collapsing to min-content width. */}
+      <WorldLabel divRef={bubbleDivRef}>
         <div
-          ref={bubbleDivRef}
           style={{
-            display: 'none',
+            display: 'flex',
+            flexDirection: 'column',
             background: 'rgba(8, 20, 38, 0.88)',
             border: '1px solid rgba(100, 200, 255, 0.3)',
             borderRadius: 8,
             padding: '5px 9px',
-            // width (not maxWidth!): drei's <Html center> wrapper collapses
-            // to min-content around this div. With only `maxWidth: 180`,
-            // the actual computed width becomes 1 character (min-content of
-            // `word-break: break-word` broken text) and text renders as a
-            // vertical column of letters. Setting `width: 180` forces the
-            // div to be exactly that wide, and text wraps normally inside.
             width: 180,
             boxSizing: 'border-box',
             backdropFilter: 'blur(4px)',
@@ -151,7 +134,7 @@ const SpeechBubble = memo(function SpeechBubble({ npc, bubble }: SpeechBubblePro
             }}
           />
         </div>
-      </Html>
+      </WorldLabel>
     </group>
   );
 });

--- a/apps/web/src/lib/three/world-labels-overlay.tsx
+++ b/apps/web/src/lib/three/world-labels-overlay.tsx
@@ -1,0 +1,348 @@
+'use client';
+
+/**
+ * WorldLabelsOverlay
+ *
+ * Single DOM overlay component mounted once at the Canvas root.
+ * Replaces 30+ per-NPC/per-building drei <Html> portals with one rAF
+ * projection pass and one batched DOM write per label per frame.
+ *
+ * Architecture:
+ *   - One <div> overlay (absolute, pointer-events: none, inset: 0, overflow: hidden).
+ *   - Module-scope registry: Map<string, LabelEntry> tracks every registered label.
+ *   - Single useFrame: projects each anchor's world position to screen, updates
+ *     each label's transform in one pass with zero per-frame allocations.
+ *   - Consumers call useWorldLabel() hook to register an entry, render content
+ *     via <WorldLabel>, and get back a divRef + setVisible.
+ *
+ * Perf rules (non-negotiable):
+ *   - ZERO per-frame allocations: all scratch Vector3 at module scope.
+ *   - Canvas DOMRect read once per frame (not per label).
+ *   - transform only written when NDC moved ≥ 0.5 px.
+ *   - display only written when it changes.
+ */
+
+import {
+  useRef,
+  useEffect,
+  useState,
+  useMemo,
+  type RefObject,
+  type ReactNode,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { useFrame, useThree } from '@react-three/fiber';
+import * as THREE from 'three';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface LabelEntry {
+  id: string;
+  anchorRef: RefObject<THREE.Object3D | null>;
+  offset: [number, number, number];
+  visible: boolean;
+  divRef: RefObject<HTMLDivElement | null>;
+  /** Previous state — avoid redundant DOM writes. */
+  _prevDisplay: string;
+  _prevX: number;
+  _prevY: number;
+}
+
+// ---------------------------------------------------------------------------
+// Module-scope registry — mutated in place, never replaced
+// ---------------------------------------------------------------------------
+const _registry = new Map<string, LabelEntry>();
+
+// Module-scope scratch — ZERO allocations per frame.
+const _scratchPos = new THREE.Vector3();
+const _scratchOffset = new THREE.Vector3();
+
+// ---------------------------------------------------------------------------
+// Module-scope overlay node reference.
+// Set by WorldLabelsOverlayMount on mount, cleared on unmount.
+// WorldLabel reads this synchronously — safe because:
+//   1. WorldLabelsOverlayMount mounts early in SceneContents (before consumers).
+//   2. Consumer components mount in the same commit cycle or later.
+//   3. React commit order is parent → child, SceneContents renders children after itself.
+// On the first frame consumers may see null and render nothing; the next render
+// (triggered by the overlay-ready state below) shows labels.
+// ---------------------------------------------------------------------------
+let _overlayNode: HTMLDivElement | null = null;
+const _overlayReadyListeners = new Set<() => void>();
+
+function setOverlayNode(node: HTMLDivElement | null) {
+  _overlayNode = node;
+  if (node) {
+    _overlayReadyListeners.forEach((fn) => fn());
+    _overlayReadyListeners.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// WorldLabelsOverlayMount — mount once inside Canvas (SceneContents)
+// ---------------------------------------------------------------------------
+
+/**
+ * Mount exactly once inside `<Canvas>`.
+ * Creates the DOM overlay container and runs the single projection pass each frame.
+ * Add `<WorldLabelsOverlayMount />` to SceneContents in World3DCanvas.tsx.
+ */
+export function WorldLabelsOverlayMount() {
+  const { gl, camera } = useThree();
+
+  useEffect(() => {
+    const canvas = gl.domElement;
+    // Append to canvas parent so it sits in the same stacking context as the canvas.
+    const container = canvas.parentElement ?? document.body;
+
+    const overlay = document.createElement('div');
+    overlay.setAttribute('data-world-labels', '1');
+    overlay.style.cssText =
+      'position:absolute;inset:0;overflow:hidden;pointer-events:none;z-index:10';
+    container.appendChild(overlay);
+    setOverlayNode(overlay);
+
+    return () => {
+      overlay.remove();
+      setOverlayNode(null);
+    };
+  // gl is stable after init — intentional omission
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Single projection pass — one read of canvas rect, one write per label.
+  useFrame(() => {
+    if (!_overlayNode) return;
+
+    const rect = gl.domElement.getBoundingClientRect();
+    const W = rect.width;
+    const H = rect.height;
+    if (W <= 0 || H <= 0) return;
+
+    _registry.forEach((entry) => {
+      const div = entry.divRef.current;
+      if (!div) return;
+
+      if (!entry.visible) {
+        if (entry._prevDisplay !== 'none') {
+          div.style.display = 'none';
+          entry._prevDisplay = 'none';
+        }
+        return;
+      }
+
+      const anchor = entry.anchorRef.current;
+      if (!anchor) {
+        if (entry._prevDisplay !== 'none') {
+          div.style.display = 'none';
+          entry._prevDisplay = 'none';
+        }
+        return;
+      }
+
+      // World position = anchor.worldPos + offset
+      anchor.getWorldPosition(_scratchPos);
+      _scratchOffset.set(entry.offset[0], entry.offset[1], entry.offset[2]);
+      _scratchPos.add(_scratchOffset);
+
+      // Project to NDC [-1, 1]
+      _scratchPos.project(camera);
+
+      // NDC z > 1 = behind camera clipping plane → hide
+      if (_scratchPos.z > 1) {
+        if (entry._prevDisplay !== 'none') {
+          div.style.display = 'none';
+          entry._prevDisplay = 'none';
+        }
+        return;
+      }
+
+      // NDC → CSS pixel (center-anchored; WorldLabel applies translate(-50%,-50%))
+      const cssX = (_scratchPos.x * 0.5 + 0.5) * W;
+      const cssY = (1 - (_scratchPos.y * 0.5 + 0.5)) * H;
+
+      // Only write display when it changes
+      if (entry._prevDisplay !== 'block') {
+        div.style.display = 'block';
+        entry._prevDisplay = 'block';
+      }
+
+      // Only write transform when moved ≥ 0.5 px (avoids constant layout invalidation)
+      if (
+        Math.abs(cssX - entry._prevX) >= 0.5 ||
+        Math.abs(cssY - entry._prevY) >= 0.5
+      ) {
+        div.style.transform = `translate3d(${cssX}px,${cssY}px,0) translate(-50%,-50%)`;
+        entry._prevX = cssX;
+        entry._prevY = cssY;
+      }
+    });
+  });
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// useWorldLabel — consumer hook
+// ---------------------------------------------------------------------------
+
+export interface UseWorldLabelOpts {
+  id: string;
+  anchorRef: RefObject<THREE.Object3D | null>;
+  offset?: [number, number, number];
+  zIndex?: number;
+  /**
+   * Initial visibility state. Defaults to true.
+   * Set false for labels that use imperative setVisible() to control display
+   * (wandering NPC labels, speech bubbles). Set true for labels that are always
+   * visible (location NPC names, building labels).
+   */
+  initialVisible?: boolean;
+}
+
+export interface UseWorldLabelReturn {
+  divRef: RefObject<HTMLDivElement | null>;
+  setVisible: (visible: boolean) => void;
+}
+
+/**
+ * Register a label in the overlay registry.
+ * Returns a stable divRef (attach to the label root div) and setVisible.
+ *
+ * Mount: registers entry. Unmount: deregisters and removes DOM node.
+ */
+export function useWorldLabel({
+  id,
+  anchorRef,
+  offset = [0, 0, 0],
+  initialVisible = true,
+}: UseWorldLabelOpts): UseWorldLabelReturn {
+  const divRef = useRef<HTMLDivElement | null>(null);
+
+  // Stable setVisible — reads/writes registry entry directly.
+  const setVisible = useMemo(
+    () => (visible: boolean) => {
+      const entry = _registry.get(id);
+      if (entry) entry.visible = visible;
+    },
+    [id],
+  );
+
+  // Register on mount, deregister on unmount.
+  useEffect(() => {
+    const entry: LabelEntry = {
+      id,
+      anchorRef,
+      offset: [offset[0], offset[1], offset[2]],
+      visible: initialVisible,
+      divRef,
+      _prevDisplay: '',
+      _prevX: -9999,
+      _prevY: -9999,
+    };
+    _registry.set(id, entry);
+
+    return () => {
+      _registry.delete(id);
+      // Detach DOM node from overlay if it was portaled there.
+      const div = divRef.current;
+      if (div && div.parentElement) {
+        div.parentElement.removeChild(div);
+      }
+    };
+  // id is the stable key; anchorRef and initialVisible intentionally not in deps
+  // (they don't change after mount and including them causes spurious re-registers).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  // Sync offset when it changes (rare — only if parent component changes offset prop)
+  useEffect(() => {
+    const entry = _registry.get(id);
+    if (entry) {
+      entry.offset[0] = offset[0];
+      entry.offset[1] = offset[1];
+      entry.offset[2] = offset[2];
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, offset[0], offset[1], offset[2]]);
+
+  return { divRef, setVisible };
+}
+
+// ---------------------------------------------------------------------------
+// WorldLabel — portals label content into the overlay container
+// ---------------------------------------------------------------------------
+
+export interface WorldLabelProps {
+  divRef: RefObject<HTMLDivElement | null>;
+  className?: string;
+  children: ReactNode;
+  /**
+   * Pointer events on the label container div.
+   * Default 'none' — overlay is transparent to mouse events.
+   * Set 'auto' for interactive labels (building click targets).
+   */
+  pointerEvents?: 'none' | 'auto';
+}
+
+/**
+ * Portals label content into the overlay DOM container.
+ *
+ * If the overlay isn't mounted yet, renders nothing — safe on first frame.
+ * The parent component will re-render once the overlay is ready (via the
+ * overlay-ready listener pattern in useOverlayReady).
+ */
+export function WorldLabel({
+  divRef,
+  className,
+  children,
+  pointerEvents = 'none',
+}: WorldLabelProps) {
+  // Subscribe to overlay-ready so this component re-renders when the overlay mounts.
+  const overlayReady = useOverlayReady();
+
+  if (!overlayReady || !_overlayNode) return null;
+
+  return createPortal(
+    <div
+      ref={divRef}
+      className={className}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        display: 'none',
+        pointerEvents,
+      }}
+    >
+      {children}
+    </div>,
+    _overlayNode,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// useOverlayReady — triggers a re-render when the overlay DOM node is ready.
+// ---------------------------------------------------------------------------
+
+/** Returns true once the overlay DOM node has been created. */
+function useOverlayReady(): boolean {
+  const [ready, setReady] = useState(() => _overlayNode !== null);
+
+  useEffect(() => {
+    if (_overlayNode !== null) {
+      setReady(true);
+      return;
+    }
+    // Not ready yet — subscribe to the ready event.
+    const handler = () => setReady(true);
+    _overlayReadyListeners.add(handler);
+    return () => {
+      _overlayReadyListeners.delete(handler);
+    };
+  }, []);
+
+  return ready;
+}


### PR DESCRIPTION
## Summary

#1 of the FPS plan. Drei `<Html>` creates one DOM portal + writes one CSS transform per frame per instance. We had 30+ instances scattered across 4 files. This PR replaces them with a **single overlay + one rAF projection pass**.

**Hardware-agnostic win** — every device pays browser layout/composite cost per portal. Mobile + low-end laptops feel it most.

## Architecture

New: `apps/web/src/lib/three/world-labels-overlay.tsx` (348 lines)

- **One** absolute-positioned `<div>` overlay over the canvas, mounted via `<WorldLabelsOverlayMount />` in `World3DCanvas`
- **Module-scope `Map<id, LabelEntry>` registry** — labels register/unregister via the `useWorldLabel` hook
- **One useFrame** projects all anchor positions to NDC, computes screen XY, writes `transform: translate3d(...)` to each child div
- **Skip writes** when NDC moves <0.5 px or display state unchanged
- **Behind-camera culling** via `NDC.z > 1` check (replaces per-site `viewZ` math)
- **ZERO per-frame allocations** — all scratch Vector3/Matrix4 at module scope

## Files migrated

| File | Sites migrated | Notes |
|---|---|---|
| `arena-npcs.tsx` | GLBNpcMesh + VRMNpcMesh name labels | Cull logic ported from `style.display` to `setLabelVisible(bool)` |
| `arena-buildings.tsx` | GLBBuilding name labels | EditableBuilding/EditMode keep drei `<Html>` (edit-mode only, gated by `?edit=1`) |
| `arena-location-npcs.tsx` | NpcMesh + companion labels | Companions use `initialVisible: showLabel` |
| `npc-speech-bubbles.tsx` | SpeechBubble | Manual `viewZ < 0` check removed — overlay's NDC z > 1 handles it |

Plus `World3DCanvas.tsx` — one line to mount `<WorldLabelsOverlayMount />`.

**Bumper Shells / Reef Race scenes deliberately untouched** — different scene cohorts.

## Stats

- 6 files changed, +459/−151
- Zero per-frame allocations preserved

## Test plan

- [ ] Coolify auto-deploys
- [ ] NPC name labels render at correct positions
- [ ] Building labels render correctly
- [ ] Speech bubbles appear over the right NPCs
- [ ] Labels hide when behind camera + at distance per existing thresholds
- [ ] Visual styling identical
- [ ] Edit mode (`?edit=1`) still works
- [ ] PerfHud FPS up vs prior baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)