### PR TITLE
fix(mobile): iPad joystick visibility — lift above Safari toolbar + stack gear under Nori

### DIFF
--- a/apps/web/src/components/cove/CoveMobileControls.tsx
+++ b/apps/web/src/components/cove/CoveMobileControls.tsx
@@ -146,7 +146,7 @@ export default function CoveMobileControls() {
         style={{
           position: 'fixed',
           left: 0,
-          bottom: 'max(env(safe-area-inset-bottom, 0px), 24px)',
+          bottom: 'max(env(safe-area-inset-bottom, 0px), 32px)',
           width: '50vw',
           height: '240px',
           zIndex: 50,
@@ -160,7 +160,7 @@ export default function CoveMobileControls() {
         style={{
           position: 'fixed',
           right: 0,
-          bottom: 'max(env(safe-area-inset-bottom, 0px), 24px)',
+          bottom: 'max(env(safe-area-inset-bottom, 0px), 32px)',
           width: '50vw',
           height: '240px',
           zIndex: 50,

--- a/apps/web/src/components/cove/CoveMobileControls.tsx
+++ b/apps/web/src/components/cove/CoveMobileControls.tsx
@@ -136,13 +136,17 @@ export default function CoveMobileControls() {
 
   return (
     <>
-      {/* Left joystick zone — movement */}
+      {/* Left joystick zone — movement.
+          `bottom: max(env(safe-area-inset-bottom), 24px)` lifts the nipple
+          above iOS Safari's bottom toolbar + home-indicator safe area on
+          real iPads (without this the nipple sits IN the viewport but
+          UNDER Safari's chrome — invisible/untappable). */}
       <div
         ref={leftRef}
         style={{
           position: 'fixed',
           left: 0,
-          bottom: 0,
+          bottom: 'max(env(safe-area-inset-bottom, 0px), 24px)',
           width: '50vw',
           height: '240px',
           zIndex: 50,
@@ -156,7 +160,7 @@ export default function CoveMobileControls() {
         style={{
           position: 'fixed',
           right: 0,
-          bottom: 0,
+          bottom: 'max(env(safe-area-inset-bottom, 0px), 24px)',
           width: '50vw',
           height: '240px',
           zIndex: 50,

--- a/apps/web/src/components/cove/CoveMobileControls.tsx
+++ b/apps/web/src/components/cove/CoveMobileControls.tsx
@@ -146,7 +146,7 @@ export default function CoveMobileControls() {
         style={{
           position: 'fixed',
           left: 0,
-          bottom: 'max(env(safe-area-inset-bottom, 0px), 32px)',
+          bottom: 'max(calc(env(safe-area-inset-bottom, 0px) + 60px), 80px)',
           width: '50vw',
           height: '240px',
           zIndex: 50,
@@ -160,7 +160,7 @@ export default function CoveMobileControls() {
         style={{
           position: 'fixed',
           right: 0,
-          bottom: 'max(env(safe-area-inset-bottom, 0px), 32px)',
+          bottom: 'max(calc(env(safe-area-inset-bottom, 0px) + 60px), 80px)',
           width: '50vw',
           height: '240px',
           zIndex: 50,

--- a/apps/web/src/components/game/mobile-controls.tsx
+++ b/apps/web/src/components/game/mobile-controls.tsx
@@ -141,7 +141,7 @@ export default function MobileControls() {
         // Without this the nipples render INSIDE the viewport but UNDER
         // Safari's chrome on a real iPad — invisible/untappable.
         // Min 32px so it stays clear even without safe-area (devtools/etc).
-        bottom: 'max(env(safe-area-inset-bottom, 0px), 32px)',
+        bottom: 'max(calc(env(safe-area-inset-bottom, 0px) + 60px), 80px)',
         width: '100vw',
         height: '220px',
       }}

--- a/apps/web/src/components/game/mobile-controls.tsx
+++ b/apps/web/src/components/game/mobile-controls.tsx
@@ -140,10 +140,10 @@ export default function MobileControls() {
         // Lift above iOS Safari bottom toolbar + home-indicator safe area.
         // Without this the nipples render INSIDE the viewport but UNDER
         // Safari's chrome on a real iPad — invisible/untappable.
-        bottom: 'max(env(safe-area-inset-bottom, 0px), 0px)',
-        paddingBottom: '24px',
+        // Min 32px so it stays clear even without safe-area (devtools/etc).
+        bottom: 'max(env(safe-area-inset-bottom, 0px), 32px)',
         width: '100vw',
-        height: '244px',
+        height: '220px',
       }}
     >
       {/* Left joystick zone — movement / explore-mode camera pan */}

--- a/apps/web/src/components/game/mobile-controls.tsx
+++ b/apps/web/src/components/game/mobile-controls.tsx
@@ -135,8 +135,16 @@ export default function MobileControls() {
 
   return (
     <div
-      className="fixed bottom-0 left-0 z-40 pointer-events-none"
-      style={{ width: '100vw', height: '220px' }}
+      className="fixed left-0 z-40 pointer-events-none"
+      style={{
+        // Lift above iOS Safari bottom toolbar + home-indicator safe area.
+        // Without this the nipples render INSIDE the viewport but UNDER
+        // Safari's chrome on a real iPad — invisible/untappable.
+        bottom: 'max(env(safe-area-inset-bottom, 0px), 0px)',
+        paddingBottom: '24px',
+        width: '100vw',
+        height: '244px',
+      }}
     >
       {/* Left joystick zone — movement / explore-mode camera pan */}
       {!movementFrozen && (

--- a/apps/web/src/components/game/sidebar-menu.tsx
+++ b/apps/web/src/components/game/sidebar-menu.tsx
@@ -947,11 +947,13 @@ export default function SidebarMenu() {
   if (isMobile) {
     return (
       <>
-        {/* Gear FAB */}
+        {/* Gear FAB — stacked BELOW the Nori button (which sits at
+            top:16 right:16). Nori is ~44px tall, so top:72 keeps a 12px
+            gap. Without this offset the gear sat on top of Nori on iPad. */}
         <div
           style={{
             position: 'fixed',
-            top: 12,
+            top: 72,
             right: 12,
             zIndex: 45,
           }}


### PR DESCRIPTION
## Summary
- **Joystick lift**: outer mobile-controls containers (both /game and /cove) now anchor at `bottom: max(calc(env(safe-area-inset-bottom, 0px) + 60px), 80px)`. Previously joystick nipples sat 50px from the viewport bottom — INSIDE the viewport but UNDER iOS Safari's bottom toolbar + home-indicator safe area on real iPads. Now 130px from bottom (devtools) or higher with safe-area on actual devices.
- **Gear-Nori stack**: mobile sidebar gear FAB moved from `top:12` to `top:72` so it stops overlapping the Nori "ASK NORI" button (which sits at `top-4 right-4`, ~44px tall).
- Earlier in branch: useIsMobile fix so iPad Air/Pro hide sidebar+status overlays. Without that the joysticks rendered but were covered by full-width sidebar/statusbar panels.

## Verified on staging (devtools iPad mini 744×1133)
- Outer style: `bottom: max(calc(env(safe-area-inset-bottom, 0px) + 60px), 80px)`
- Outer container bottom edge: 80px from viewport bottom (no safe-area in devtools)
- Nipple distance from bottom: 130px (was 50px)
- Gear FAB top: 72px (was 12px, overlapping Nori at top 16px)

## Test plan
- [ ] Hard refresh on a real iPad — both joysticks visible above Safari toolbar
- [ ] Tap gear FAB without hitting Nori button
- [ ] Test /cove too (same lift applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)