### PR TITLE
feat(game): redesigned building entry — big floating glow prompt

### DIFF
--- a/apps/web/src/components/game/location-hud.tsx
+++ b/apps/web/src/components/game/location-hud.tsx
@@ -1,14 +1,37 @@
 'use client';
 
 import { useGameStore, type GameState } from '@/stores/game';
+import { useIsMobile } from '@/hooks/use-is-mobile';
 import { MAP_LOCATIONS, BUILDING_OPENCLAW_THEMES } from '@clawville/shared';
 
+/**
+ * Building-entry prompt — replaces the prior tiny top-center hint
+ * with a prominent bottom-center action pill that's hard to miss on
+ * any device.
+ *
+ * Design:
+ *   - Bottom-center, anchored above the mobile joystick zone (safe-area
+ *     respected so it never hides under iOS Safari chrome).
+ *   - Large tap target (≥64px tall, 320px wide on phone, capped on desktop).
+ *   - Pulses a soft cyan glow so the player notices it the moment they
+ *     wander into range.
+ *   - Single tap / click / press-E enters. Keyboard E binding is owned
+ *     by the canvas controller upstream — this component is the visual
+ *     + tap surface only.
+ *   - Shows the character name when one is in front of the player, the
+ *     building name otherwise.
+ */
 export default function LocationHUD() {
   const nearLocation = useGameStore((s: GameState) => s.nearLocation);
   const nearCharacter = useGameStore((s: GameState) => s.nearCharacter);
   const agentConnected = useGameStore((s: GameState) => s.agentConnected);
+  const controlMode = useGameStore((s: GameState) => s.controlMode);
   const enterBuilding = useGameStore((s: GameState) => s.enterBuilding);
+  const isMobile = useIsMobile();
 
+  // Spectator/explore mode has no character to walk in — suppress the
+  // prompt so it doesn't dangle from the free-cam.
+  if (controlMode === 'explore') return null;
   if (!nearLocation) return null;
 
   const location = MAP_LOCATIONS.find((l) => l.id === nearLocation);
@@ -16,41 +39,110 @@ export default function LocationHUD() {
 
   const theme = BUILDING_OPENCLAW_THEMES[nearLocation];
   const characterName = nearCharacter;
+  const subjectLabel = characterName ?? theme?.label ?? location.name;
+  const ctaLine = characterName
+    ? `Talk to ${characterName}`
+    : theme?.label
+      ? `Enter ${theme.label}`
+      : `Enter ${location.name}`;
 
   const handleTap = () => enterBuilding(nearLocation, characterName ?? undefined);
 
+  // Lift above joystick zones (joysticks anchor at
+  // max(env(safe-area-inset-bottom,0)+60px, 80px)); add another ~150px
+  // so the pill sits above the nipples on every phone/tablet.
+  const bottomOffset = isMobile
+    ? 'max(calc(env(safe-area-inset-bottom, 0px) + 220px), 240px)'
+    : 'calc(env(safe-area-inset-bottom, 0px) + 36px)';
+
   return (
-    <div
-      className="claw-panel fixed top-28 left-1/2 -translate-x-1/2 z-40 text-center max-w-xs cursor-pointer md:cursor-default"
+    <button
+      type="button"
       onClick={handleTap}
+      aria-label={ctaLine}
+      style={{
+        position: 'fixed',
+        bottom: bottomOffset,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 45,
+        minWidth: 280,
+        maxWidth: 'min(420px, calc(100vw - 32px))',
+        padding: '14px 28px',
+        borderRadius: 999,
+        background:
+          'linear-gradient(135deg, rgba(8,28,52,0.96) 0%, rgba(14,52,96,0.96) 100%)',
+        border: '1.5px solid rgba(56,189,248,0.65)',
+        boxShadow:
+          '0 0 0 1px rgba(56,189,248,0.25), 0 18px 44px -10px rgba(56,189,248,0.45), 0 0 38px rgba(56,189,248,0.35)',
+        color: '#e0f2fe',
+        cursor: 'pointer',
+        textAlign: 'center',
+        touchAction: 'manipulation',
+        userSelect: 'none',
+        WebkitUserSelect: 'none',
+        animation: 'cv-enter-pulse 2.4s ease-in-out infinite',
+        backdropFilter: 'blur(8px)',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 4,
+      }}
     >
-      {characterName ? (
-        <p className="text-white font-bold text-lg">
-          💬 {characterName}
-        </p>
-      ) : theme ? (
-        <p className="text-white font-bold text-lg">
-          {location.icon} {theme.label}
-        </p>
-      ) : null}
-      <p className="text-white/60 text-xs mt-0.5">
-        {location.icon} {location.name}
-      </p>
-      <p className="text-white/70 text-sm mt-1">
-        <span className="hidden md:inline">
-          Press <kbd className="font-mono bg-white/10 px-1.5 py-0.5 rounded text-xs">E</kbd>
-          {characterName ? ` to talk to ${characterName}` : ' to talk'}
+      <style jsx>{`
+        @keyframes cv-enter-pulse {
+          0%, 100% {
+            box-shadow:
+              0 0 0 1px rgba(56, 189, 248, 0.25),
+              0 18px 44px -10px rgba(56, 189, 248, 0.45),
+              0 0 38px rgba(56, 189, 248, 0.35);
+          }
+          50% {
+            box-shadow:
+              0 0 0 1px rgba(56, 189, 248, 0.45),
+              0 22px 52px -10px rgba(56, 189, 248, 0.6),
+              0 0 58px rgba(56, 189, 248, 0.55);
+          }
+        }
+      `}</style>
+      <span
+        style={{
+          fontSize: 13,
+          fontWeight: 700,
+          letterSpacing: '0.18em',
+          color: 'rgba(186, 230, 253, 0.85)',
+          textTransform: 'uppercase',
+        }}
+      >
+        {isMobile ? 'Tap' : 'Press E'} · {subjectLabel}
+      </span>
+      <span
+        style={{
+          fontSize: 18,
+          fontWeight: 800,
+          color: '#fff',
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 8,
+        }}
+      >
+        <span aria-hidden style={{ fontSize: 22 }}>
+          {characterName ? '💬' : location.icon}
         </span>
-        <span className="md:hidden">
-          {characterName ? `Tap to talk to ${characterName}` : 'Tap to talk'}
-        </span>
-      </p>
+        {ctaLine}
+      </span>
       {theme && (
-        <p className="text-white/50 text-xs mt-1">
+        <span
+          style={{
+            fontSize: 11,
+            color: 'rgba(186,230,253,0.75)',
+            fontWeight: 500,
+          }}
+        >
           {agentConnected ? '🔌 Your bot will learn: ' : 'Learn about '}
           {theme.focus.split(',')[0]}
-        </p>
+        </span>
       )}
-    </div>
+    </button>
   );
 }

--- a/apps/web/src/components/game/mobile-controls.tsx
+++ b/apps/web/src/components/game/mobile-controls.tsx
@@ -174,32 +174,8 @@ export default function MobileControls() {
         }}
       />
 
-      {/* Enter building button — centered between joysticks (hidden in explore mode) */}
-      {!movementFrozen && !isExplore && nearLocation && (
-        <button
-          onClick={handleEnterBuilding}
-          className="pointer-events-auto absolute"
-          style={{
-            left: '50%',
-            bottom: '70px',
-            transform: 'translateX(-50%)',
-            width: '56px',
-            height: '56px',
-            borderRadius: '50%',
-            background: 'rgba(255,255,255,0.3)',
-            backdropFilter: 'blur(4px)',
-            border: '2px solid rgba(255,255,255,0.5)',
-            color: 'white',
-            fontWeight: 'bold',
-            fontSize: '18px',
-            touchAction: 'manipulation',
-            boxShadow: '0 2px 12px rgba(0,0,0,0.3)',
-          }}
-          aria-label="Enter building"
-        >
-          E
-        </button>
-      )}
+      {/* Building enter is now owned by the bottom-center floating prompt
+          in `location-hud.tsx` (single source of truth, bigger tap target). */}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Replaces the tiny top-center "Press E near a building" hint + the small 56px white E pill between joysticks with **one** big bottom-center floating action pill.

- 280–420px wide, ~80px tall — large tap target
- Cyan-glow border with `cv-enter-pulse` 2.4s keyframe — hard to miss
- Anchored above mobile joysticks via safe-area-inset math (220px above safe-area)
- Shows building icon + name OR character name + 💬 if one is in front of the player
- Includes the agent-learning hint when an agent is connected
- Keyboard E binding unchanged (npc-controller.tsx)
- Old top-center hint removed (`oldTopCenterHint_exists: false` verified on staging)

## Test plan
- [ ] Walk avatar near a building → big glowing pill appears at bottom-center, fades in
- [ ] Walk near a character at a building → shows 💬 + "Talk to {name}"
- [ ] Press E (desktop) or tap pill (mobile/iPad) → enters building
- [ ] Walk away → pill disappears
- [ ] In explore mode → pill never shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)