### PR TITLE
Mobile/iPad fixes: cove joysticks, chat-gating, building-entry prompt + bundled world/loader fixes

### DIFF
--- a/apps/web/src/components/cove/CoveMobileControls.tsx
+++ b/apps/web/src/components/cove/CoveMobileControls.tsx
@@ -136,38 +136,53 @@ export default function CoveMobileControls() {
 
   return (
     <>
-      {/* Left joystick zone — movement.
-          `bottom: max(env(safe-area-inset-bottom), 24px)` lifts the nipple
-          above iOS Safari's bottom toolbar + home-indicator safe area on
-          real iPads (without this the nipple sits IN the viewport but
-          UNDER Safari's chrome — invisible/untappable). */}
+      {/* Joystick container — mirrors the working /game MobileControls
+          structure EXACTLY: a `position:fixed` lifted OUTER container with
+          `position:absolute` inner zones at bottom:0. nipplejs places its
+          handle relative to the zone; with per-zone `position:fixed` the
+          handle landed 80px lower than /game (cove joysticks at 50px vs
+          game's 130px from bottom — under the iPad Safari toolbar). The
+          outer-container pattern is the one that positions the nipple
+          correctly. Lift via safe-area so it clears Safari chrome on real
+          iPads. (Fixed 2026-05-28.) */}
       <div
-        ref={leftRef}
         style={{
           position: 'fixed',
           left: 0,
           bottom: 'max(calc(env(safe-area-inset-bottom, 0px) + 60px), 80px)',
-          width: '50vw',
-          height: '240px',
+          width: '100vw',
+          height: '220px',
           zIndex: 50,
-          pointerEvents: 'auto',
-          touchAction: 'none',
+          pointerEvents: 'none',
         }}
-      />
-      {/* Right joystick zone — camera */}
-      <div
-        ref={rightRef}
-        style={{
-          position: 'fixed',
-          right: 0,
-          bottom: 'max(calc(env(safe-area-inset-bottom, 0px) + 60px), 80px)',
-          width: '50vw',
-          height: '240px',
-          zIndex: 50,
-          pointerEvents: 'auto',
-          touchAction: 'none',
-        }}
-      />
+      >
+        {/* Left zone — movement */}
+        <div
+          ref={leftRef}
+          style={{
+            position: 'absolute',
+            left: 0,
+            bottom: 0,
+            width: '50vw',
+            height: '220px',
+            pointerEvents: 'auto',
+            touchAction: 'none',
+          }}
+        />
+        {/* Right zone — camera */}
+        <div
+          ref={rightRef}
+          style={{
+            position: 'absolute',
+            right: 0,
+            bottom: 0,
+            width: '50vw',
+            height: '220px',
+            pointerEvents: 'auto',
+            touchAction: 'none',
+          }}
+        />
+      </div>
       {/* INTERACT button — E-key proxy. Tap-and-hold for E. */}
       <button
         type="button"
@@ -178,7 +193,9 @@ export default function CoveMobileControls() {
         style={{
           position: 'fixed',
           right: 30,
-          bottom: 260,
+          // Sit above the lifted joystick zone (zone top ≈ 300px from bottom
+          // on a device with safe-area); keep it clear of Safari chrome.
+          bottom: 'max(calc(env(safe-area-inset-bottom, 0px) + 240px), 260px)',
           width: 72,
           height: 72,
           borderRadius: '50%',

--- a/apps/web/src/components/game/location-hud.tsx
+++ b/apps/web/src/components/game/location-hud.tsx
@@ -27,11 +27,15 @@ export default function LocationHUD() {
   const agentConnected = useGameStore((s: GameState) => s.agentConnected);
   const controlMode = useGameStore((s: GameState) => s.controlMode);
   const enterBuilding = useGameStore((s: GameState) => s.enterBuilding);
+  const activeChatLocation = useGameStore((s: GameState) => s.activeChatLocation);
+  const activeSystemAgent = useGameStore((s: GameState) => s.activeSystemAgent);
   const isMobile = useIsMobile();
 
   // Spectator/explore mode has no character to walk in — suppress the
   // prompt so it doesn't dangle from the free-cam.
   if (controlMode === 'explore') return null;
+  // A chat panel is open — the prompt would float over the chat UI.
+  if (activeChatLocation !== null || activeSystemAgent !== null) return null;
   if (!nearLocation) return null;
 
   const location = MAP_LOCATIONS.find((l) => l.id === nearLocation);

--- a/apps/web/src/components/game/location-hud.tsx
+++ b/apps/web/src/components/game/location-hud.tsx
@@ -28,7 +28,7 @@ export default function LocationHUD() {
   const controlMode = useGameStore((s: GameState) => s.controlMode);
   const enterBuilding = useGameStore((s: GameState) => s.enterBuilding);
   const buildingChatOpen = useGameStore((s: GameState) => s.chatOpen);
-  const systemAgentChatOpen = useGameStore((s: GameState) => s.systemAgentChatOpen);
+  const systemAgentChatOpen = useGameStore((s: GameState) => s.guideChatOpen);
   const isMobile = useIsMobile();
 
   // Spectator/explore mode has no character to walk in — suppress the

--- a/apps/web/src/components/game/location-hud.tsx
+++ b/apps/web/src/components/game/location-hud.tsx
@@ -27,15 +27,15 @@ export default function LocationHUD() {
   const agentConnected = useGameStore((s: GameState) => s.agentConnected);
   const controlMode = useGameStore((s: GameState) => s.controlMode);
   const enterBuilding = useGameStore((s: GameState) => s.enterBuilding);
-  const activeChatLocation = useGameStore((s: GameState) => s.activeChatLocation);
-  const activeSystemAgent = useGameStore((s: GameState) => s.activeSystemAgent);
+  const buildingChatOpen = useGameStore((s: GameState) => s.chatOpen);
+  const systemAgentChatOpen = useGameStore((s: GameState) => s.systemAgentChatOpen);
   const isMobile = useIsMobile();
 
   // Spectator/explore mode has no character to walk in — suppress the
   // prompt so it doesn't dangle from the free-cam.
   if (controlMode === 'explore') return null;
   // A chat panel is open — the prompt would float over the chat UI.
-  if (activeChatLocation !== null || activeSystemAgent !== null) return null;
+  if (buildingChatOpen || systemAgentChatOpen) return null;
   if (!nearLocation) return null;
 
   const location = MAP_LOCATIONS.find((l) => l.id === nearLocation);

--- a/apps/web/src/components/game/mobile-controls.tsx
+++ b/apps/web/src/components/game/mobile-controls.tsx
@@ -15,14 +15,24 @@ export default function MobileControls() {
   const movementFrozen = useGameStore((s) => s.movementFrozen);
   const nearLocation = useGameStore((s) => s.nearLocation);
   const controlMode = useGameStore((s) => s.controlMode);
+  // When a chat panel is open (building chat or the Nori system-agent
+  // overlay) the chat input sits at the bottom of the screen. With the
+  // joystick lift (2026-05-28) the nipples now occupy the same band and
+  // float over the text input. Suppress BOTH joysticks while any chat is
+  // open — you're talking, not walking.
+  const activeChatLocation = useGameStore((s) => s.activeChatLocation);
+  const activeSystemAgent = useGameStore((s) => s.activeSystemAgent);
+  const chatOpen = activeChatLocation !== null || activeSystemAgent !== null;
 
   // Explore mode = pure spectator with no character — no movement joystick, no building entry
   const isExplore = controlMode === 'explore';
+  // Joysticks hidden entirely while a chat panel is open.
+  const hideControls = chatOpen;
 
   // Left joystick — movement/pan. In explore mode it drives the free-roam spectator
   // camera via WASDCameraController (World3DCanvas.tsx) reading joystickVelocity.
   useEffect(() => {
-    if (!isMobile || movementFrozen || !leftContainerRef.current) {
+    if (!isMobile || movementFrozen || hideControls || !leftContainerRef.current) {
       if (leftJoystickRef.current) {
         leftJoystickRef.current.destroy();
         leftJoystickRef.current = null;
@@ -70,7 +80,7 @@ export default function MobileControls() {
         useGameStore.getState().setJoystickVelocity(0, 0);
       }
     };
-  }, [isMobile, movementFrozen]);
+  }, [isMobile, movementFrozen, hideControls]);
 
   // Right joystick — camera orbit (arrow key equivalent)
   useEffect(() => {
@@ -122,9 +132,12 @@ export default function MobileControls() {
         useGameStore.getState().setCameraJoystickVelocity(0, 0);
       }
     };
-  }, [isMobile]);
+  }, [isMobile, hideControls]);
 
   if (!isMobile) return null;
+  // Chat open → suppress the whole control layer (joysticks would float over
+  // the chat input at the bottom of the screen).
+  if (hideControls) return null;
 
   const handleEnterBuilding = () => {
     const store = useGameStore.getState();

--- a/apps/web/src/components/game/mobile-controls.tsx
+++ b/apps/web/src/components/game/mobile-controls.tsx
@@ -20,14 +20,14 @@ export default function MobileControls() {
   // joystick lift (2026-05-28) the nipples now occupy the same band and
   // float over the text input. Suppress BOTH joysticks while any chat is
   // open — you're talking, not walking.
-  const activeChatLocation = useGameStore((s) => s.activeChatLocation);
-  const activeSystemAgent = useGameStore((s) => s.activeSystemAgent);
-  const chatOpen = activeChatLocation !== null || activeSystemAgent !== null;
+  const buildingChatOpen = useGameStore((s) => s.chatOpen);
+  const systemAgentChatOpen = useGameStore((s) => s.systemAgentChatOpen);
+  const chatActive = buildingChatOpen || systemAgentChatOpen;
 
   // Explore mode = pure spectator with no character — no movement joystick, no building entry
   const isExplore = controlMode === 'explore';
   // Joysticks hidden entirely while a chat panel is open.
-  const hideControls = chatOpen;
+  const hideControls = chatActive;
 
   // Left joystick — movement/pan. In explore mode it drives the free-roam spectator
   // camera via WASDCameraController (World3DCanvas.tsx) reading joystickVelocity.

--- a/apps/web/src/components/game/mobile-controls.tsx
+++ b/apps/web/src/components/game/mobile-controls.tsx
@@ -21,7 +21,7 @@ export default function MobileControls() {
   // float over the text input. Suppress BOTH joysticks while any chat is
   // open — you're talking, not walking.
   const buildingChatOpen = useGameStore((s) => s.chatOpen);
-  const systemAgentChatOpen = useGameStore((s) => s.systemAgentChatOpen);
+  const systemAgentChatOpen = useGameStore((s) => s.guideChatOpen);
   const chatActive = buildingChatOpen || systemAgentChatOpen;
 
   // Explore mode = pure spectator with no character — no movement joystick, no building entry

--- a/apps/web/src/components/game/sea-loading-screen.tsx
+++ b/apps/web/src/components/game/sea-loading-screen.tsx
@@ -66,12 +66,30 @@ export default function SeaLoadingScreen({ forceReady }: Props) {
   const [fading, setFading]         = useState(false);
   const [slow, setSlow]             = useState(false);
   /**
-   * Progress in [0, 1]. Driven directly from `window.__W3D_PROGRESS`
-   * (THREE.DefaultLoadingManager: loaded/total). Capped at 0.99 until the
-   * ready signal fires so the bar never hits 100% with a black world still
-   * compiling. Ratcheted forward so it never moves backward.
+   * Progress in [0, 1]. Composite signal so the bar tracks the user's
+   * actual wait, not just network downloads. Rewritten 2026-05-31 after
+   * the previous bar (driven only by `__W3D_PROGRESS`) reached 99% the
+   * moment asset downloads finished and then stalled for the entire
+   * GPU texture-upload window — typically 2-3× the download time on
+   * Iris Xe. Phases:
+   *   0    – 0.60   `__W3D_PROGRESS` (network download via
+   *                  THREE.DefaultLoadingManager — fast, often cached)
+   *   0.60 – 0.92   `__W3D_TEXTURE_UPLOAD_DONE / __W3D_TEXTURE_UPLOAD_TOTAL`
+   *                  (GPU texture upload via StaggeredTextureUpload —
+   *                   slow on Iris Xe)
+   *   0.92 – 0.99   `__W3D_CANVAS_READY` (first frame compile + paint;
+   *                  pipeline compile hitch lives here)
+   *   1.00          `__W3D_READY` (canvas + textures both done — bar
+   *                  snaps + fade)
+   * Ratcheted forward so the bar never moves backward.
    */
   const [progress, setProgress]     = useState(0);
+  /**
+   * Current phase shown under the bar. Communicates WHY the user is
+   * waiting at each step — "Downloading assets…" vs "Uploading to GPU…"
+   * — instead of a single misleading percentage.
+   */
+  const [phase, setPhase] = useState<'downloading' | 'uploading' | 'compiling' | 'ready'>('downloading');
   const rafRef     = useRef<number | null>(null);
   const mountedRef = useRef(true);
   const startedAtRef = useRef<number>(0);
@@ -102,11 +120,15 @@ export default function SeaLoadingScreen({ forceReady }: Props) {
         __W3D_PROGRESS?: number;
         __W3D_READY?: boolean;
         __W3D_TEXTURES_READY?: boolean;
+        __W3D_TEXTURE_UPLOAD_TOTAL?: number;
+        __W3D_TEXTURE_UPLOAD_DONE?: number;
       };
       bridge.__W3D_CANVAS_READY = false;
       bridge.__W3D_PROGRESS = 0;
       bridge.__W3D_READY = false;
       bridge.__W3D_TEXTURES_READY = false;
+      bridge.__W3D_TEXTURE_UPLOAD_TOTAL = 0;
+      bridge.__W3D_TEXTURE_UPLOAD_DONE = 0;
     }
 
     // Show "taking longer" hint after 15s
@@ -126,20 +148,25 @@ export default function SeaLoadingScreen({ forceReady }: Props) {
       }
     }, TIMEOUT_MS);
 
-    // Bar = real progress, full stop. window.__W3D_PROGRESS comes from
-    // THREE.DefaultLoadingManager (wired in World3DCanvas at module load),
-    // updates with every GLB/VRM/texture load. Bar tracks it 1:1 and snaps
-    // to 100% when the world ready signal fires.
+    // Composite bar formula (2026-05-31). Three phases stitched into
+    // [0, 1] so the bar's velocity reflects the user's actual wait, not
+    // just network downloads. Old bar: pure `__W3D_PROGRESS` capped at
+    // 0.99 — hit 99% the moment THREE.DefaultLoadingManager drained and
+    // then sat there for the full StaggeredTextureUpload window. New
+    // bar: maps each phase to a band and shows a phase label so the
+    // user can SEE which step is running.
+    const DOWNLOAD_BAND_END = 0.60;
+    const UPLOAD_BAND_END = 0.92;
+    const COMPILE_BAND_END = 0.99;
     let highWaterMark = 0;
     function tick() {
       if (!mountedRef.current) return;
-      // 2026-05-26: dismiss on __W3D_READY (canvas first-frame AND
-      // StaggeredTextureUpload complete), NOT __W3D (canvas first-frame only).
-      // The first-frame-only signal dismissed the overlay before WebGPU
-      // texture uploads finished, exposing a blue/blank world under the UI.
+      // Dismiss only when both canvas AND textures are ready (keeps the
+      // blue-flash fix from 2026-05-26).
       const ready = forceReady || !!(window as any).__W3D_READY;
       if (ready) {
         readyRef.current = true;
+        setPhase('ready');
         setProgress(1);
         setFading(true);
         setTimeout(() => {
@@ -147,14 +174,56 @@ export default function SeaLoadingScreen({ forceReady }: Props) {
         }, 420);
         return;
       }
-      const real = (window as unknown as { __W3D_PROGRESS?: number }).__W3D_PROGRESS;
-      // Ratchet — bar never moves backward (e.g. if a new loader registers
-      // mid-stream and total spikes faster than loaded).
-      highWaterMark = Math.max(highWaterMark, typeof real === 'number' ? real : 0);
-      // Cap at 0.99 so the bar never hits 100% before the ready signal —
-      // otherwise the bar fills, the % shows 100, and the user stares at a
-      // "complete" bar while the world is still mounting.
-      setProgress(Math.min(0.99, highWaterMark));
+
+      const bridge = window as unknown as {
+        __W3D_PROGRESS?: number;
+        __W3D_TEXTURE_UPLOAD_TOTAL?: number;
+        __W3D_TEXTURE_UPLOAD_DONE?: number;
+        __W3D_CANVAS_READY?: boolean;
+        __W3D_TEXTURES_READY?: boolean;
+      };
+
+      // Phase 1 — asset download (THREE.DefaultLoadingManager loaded/total).
+      const downloadFrac = Math.max(0, Math.min(1, bridge.__W3D_PROGRESS ?? 0));
+
+      // Phase 2 — GPU texture upload (StaggeredTextureUpload counter).
+      // Only counts once asset downloads are essentially complete AND
+      // upload has actually started (TOTAL > 0). Stays at 0 until then.
+      const uploadTotal = bridge.__W3D_TEXTURE_UPLOAD_TOTAL ?? 0;
+      const uploadDone = bridge.__W3D_TEXTURE_UPLOAD_DONE ?? 0;
+      const uploadFrac = uploadTotal > 0
+        ? Math.max(0, Math.min(1, uploadDone / uploadTotal))
+        : 0;
+
+      // Phase 3 — first-canvas-frame paint + pipeline compile.
+      const canvasReady = !!bridge.__W3D_CANVAS_READY;
+      const texturesReady = !!bridge.__W3D_TEXTURES_READY;
+
+      // Determine the current phase + composite value. Each phase fills
+      // its allocated band; the next phase carries over from there.
+      let composite = downloadFrac * DOWNLOAD_BAND_END;
+      let currentPhase: typeof phase = 'downloading';
+
+      if (downloadFrac >= 0.999 || uploadTotal > 0) {
+        // Downloads done — credit the full band and start tracking upload.
+        composite = DOWNLOAD_BAND_END + uploadFrac * (UPLOAD_BAND_END - DOWNLOAD_BAND_END);
+        currentPhase = 'uploading';
+      }
+
+      if (texturesReady) {
+        // GPU uploads done — credit the full upload band. The bar now
+        // sits at COMPILE_BAND_END waiting for the canvas-first-frame
+        // signal (pipeline compile + paint).
+        composite = canvasReady ? COMPILE_BAND_END : UPLOAD_BAND_END;
+        currentPhase = canvasReady ? 'compiling' : 'compiling';
+      }
+
+      // Ratchet — never move backward (asset retries / late re-registers
+      // could otherwise rewind the bar).
+      highWaterMark = Math.max(highWaterMark, composite);
+      setProgress(Math.min(COMPILE_BAND_END, highWaterMark));
+      setPhase(currentPhase);
+
       rafRef.current = requestAnimationFrame(tick);
     }
 
@@ -494,8 +563,10 @@ export default function SeaLoadingScreen({ forceReady }: Props) {
             Dropping in...
           </p>
 
-          {/* Progress bar — width = real % loaded (THREE.DefaultLoadingManager),
-              capped at 99% until window.__W3D fires, then snaps to 100%. */}
+          {/* Progress bar — composite signal stitching three phases
+              (asset download → texture upload → pipeline compile).
+              See the `tick()` doc-block at the top of the component for
+              the band split. */}
           <div
             role="progressbar"
             aria-valuemin={0}
@@ -527,12 +598,20 @@ export default function SeaLoadingScreen({ forceReady }: Props) {
             style={{
               fontFamily: 'var(--font-oxanium), sans-serif',
               fontSize: '10px',
-              color: 'rgba(125,211,252,0.45)',
+              color: 'rgba(125,211,252,0.55)',
               letterSpacing: '0.18em',
+              textAlign: 'center',
+              lineHeight: 1.45,
             }}
             aria-hidden="true"
           >
             {Math.round(progress * 100)}%
+            <div style={{ fontSize: '9px', opacity: 0.7, marginTop: 2 }}>
+              {phase === 'downloading' && 'Downloading assets…'}
+              {phase === 'uploading' && 'Uploading to GPU…'}
+              {phase === 'compiling' && 'Compiling shaders…'}
+              {phase === 'ready' && 'Ready'}
+            </div>
           </div>
 
           {/* Three pulsing dots */}

--- a/apps/web/src/components/three/World3DCanvas.tsx
+++ b/apps/web/src/components/three/World3DCanvas.tsx
@@ -646,6 +646,8 @@ function StaggeredTextureUpload() {
     // Verify initTexture is available (guard for unusual renderer builds)
     if (typeof (gl as any).initTexture !== 'function') {
       console.warn('[World3D] StaggeredTextureUpload: renderer.initTexture() not available, skipping');
+      (window as any).__W3D_TEXTURE_UPLOAD_TOTAL = 0;
+      (window as any).__W3D_TEXTURE_UPLOAD_DONE = 0;
       markTextureUploadReady();
       return;
     }
@@ -680,12 +682,25 @@ function StaggeredTextureUpload() {
 
         const unique = Array.from(seen);
         if (unique.length === 0) {
+          // No-textures path — still publish the counters so the loader bar
+          // doesn't get stuck waiting for an update that never arrives.
+          (window as any).__W3D_TEXTURE_UPLOAD_TOTAL = 0;
+          (window as any).__W3D_TEXTURE_UPLOAD_DONE = 0;
           markTextureUploadReady();
           return;
         }
 
         const hasIdle = typeof (window as any).requestIdleCallback === 'function';
         console.log(`[World3D] StaggeredTextureUpload: uploading ${unique.length} textures via ${hasIdle ? 'rIC' : 'rAF'} budget`);
+
+        // 2026-05-31: publish upload progress so the SeaLoadingScreen bar can
+        // track the GPU-upload phase honestly. Without this the bar hit 99%
+        // once asset downloads finished and then stalled for the entire
+        // texture-upload window — the user's "loads another 2-3× the wait"
+        // complaint. Window flags are cheap (no React state, no allocs in
+        // the slice loop).
+        (window as any).__W3D_TEXTURE_UPLOAD_TOTAL = unique.length;
+        (window as any).__W3D_TEXTURE_UPLOAD_DONE = 0;
 
         let i = 0;
 
@@ -702,6 +717,7 @@ function StaggeredTextureUpload() {
             }
             i++;
           }
+          (window as any).__W3D_TEXTURE_UPLOAD_DONE = i;
           if (i < unique.length) {
             idleHandle = (window as any).requestIdleCallback(uploadIdle, { timeout: 200 });
           } else {
@@ -721,6 +737,7 @@ function StaggeredTextureUpload() {
               console.warn('[World3D] initTexture error (non-fatal):', err);
             }
           }
+          (window as any).__W3D_TEXTURE_UPLOAD_DONE = i;
           const elapsed = performance.now() - t0;
           if (elapsed > 20) {
             console.warn(`[World3D] StaggeredTextureUpload: batch took ${elapsed.toFixed(1)}ms`);

--- a/apps/web/src/components/three/World3DCanvas.tsx
+++ b/apps/web/src/components/three/World3DCanvas.tsx
@@ -576,26 +576,18 @@ function PerfCameraPreset({
   return null;
 }
 
-function OpaqueCanvasClearGuard() {
-  const { camera, gl, scene } = useThree();
-  useEffect(() => {
-    let raf = 0;
-    let disposed = false;
-    const present = () => {
-      if (disposed) return;
-      gl.setClearColor(SKY_COLOR, 1);
-      gl.setClearAlpha?.(1);
-      gl.render(scene, camera);
-      raf = requestAnimationFrame(present);
-    };
-    raf = requestAnimationFrame(present);
-    return () => {
-      disposed = true;
-      cancelAnimationFrame(raf);
-    };
-  }, [camera, gl, scene]);
-  return null;
-}
+// REMOVED 2026-05-31 — OpaqueCanvasClearGuard caused the permanent blue screen.
+// It ran an INDEPENDENT requestAnimationFrame loop calling gl.render(scene, camera)
+// on top of R3F's own frameloop='always' render loop — measured live at exactly
+// 2.00 gl.render() calls per frame. On WebGPU the swapchain texture can only be
+// acquired once per frame (context.getCurrentTexture()); the guard's second
+// render presented only the SKY_COLOR clear and clobbered R3F's real frame, so
+// the whole world showed as uniform blue. Opaque presentation is already
+// guaranteed by: alpha:false on the renderer + renderer.setClearColor(SKY_COLOR,1)
+// in createWebGPURenderer/onCreated + scene.background=SKY_COLOR. R3F's
+// frameloop='always' renders the populated scene every frame on its own — the
+// guard added nothing but the fatal double-render. Introduced in commit 11034881
+// ("stabilize world canvas presentation"); that "stabilization" was the regression.
 
 // ---------------------------------------------------------------------------
 // StaggeredTextureUpload — spread GPU texture uploads across idle time
@@ -810,8 +802,6 @@ const SceneContents = memo(function SceneContents({
 
   return (
     <>
-      <OpaqueCanvasClearGuard />
-
       {/* Pre-compile WebGPU render pipelines once after the first frame commit.
           Eliminates the 274ms post-mount main-thread hitch. No-ops on WebGL. */}
       <PreCompilePipelines />


### PR DESCRIPTION
## Mobile / iPad (this session)
- **Cove joysticks 80px too low** → mirrored the working /game outer-container structure so nipplejs places the handle correctly (was under the iPad Safari toolbar).
- **Joystick lift collided with chat input** → joysticks + building-entry prompt now hide whenever a chat panel is open (chatOpen || guideChatOpen). Verified on staging: joysticks 2 → 0 → 2 opening/closing Nori chat.
- **Gear FAB stacked below Nori** (top:72) — no more top-right overlap.
- **Mandatory mobile/iPad verification rule** added to CLAUDE.md (every UI feature must be checked at phone + iPad portrait/landscape before "done").

Verified on staging via chrome-devtools at iPad mini 744 / Air 820 / Pro 1024 portrait+landscape: joysticks visible + clear, no overlaps, prompt clears joysticks, chat hides joysticks. **Safe-area lift needs a real-iPad confirm** (devtools has no safe-area inset).

## Bundled from the perf session (already on staging)
- `fix(world): remove OpaqueCanvasClearGuard` — blue-screen root cause.
- `fix(loader): honest progress bar` — tracks GPU upload + compile.

## Test plan (prod)
- [ ] Real iPad: both joysticks visible above Safari toolbar on /game and /cove
- [ ] Walk near a building → glowing prompt appears, clears joysticks
- [ ] Open a chat → joysticks vanish; close → return
- [ ] Gear + Nori both tappable, no overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)