### PR TITLE
ci: register deploy workflows on master + promote staging (world/loader fixes, mobile rule)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,18 @@ Emergency SSH: PROD `ssh root@$PROD_VPS_IP` (key in ssh-agent), STAGING `ssh -i 
 
 (1) Wait for Coolify (~3–5 min) or `curl -sS --ssl-no-revoke https://api.clawville.world/health`. (2) Open `https://clawville.world/game` via Chrome MCP. (3) Check buildings visible + not clipped, camera zoom, player spawn center, FPS > 50, no console errors. (4) If Chrome disconnected, tell user "I cannot verify — please screenshot". (5) NEVER claim a visual fix done without seeing it.
 
+### Mobile + iPad verification — MANDATORY for EVERY UI/UX feature (set 2026-05-28 after iPad joysticks shipped covered 3× in a row)
+
+Any change that adds/moves on-screen UI (HUD, button, panel, modal, joystick, prompt, toast, banner) is NOT done until verified at mobile AND iPad viewports — desktop-only checking is the #1 source of repeat regressions here. Run BEFORE claiming done:
+
+1. **Viewport sweep** via `chrome-devtools` `emulate` `<w>x<h>x2,mobile,touch` at minimum: phone 390×844, iPad mini 744×1133, iPad Air 820×1180, iPad Pro 13 1024×1366 — **portrait AND landscape** (swap w/h + add `,landscape`).
+2. **Per size, confirm:** (a) both joystick zones visible + NOT covered by any panel/sidebar/HUD; (b) no two fixed/absolute elements overlapping (gear vs Nori, prompt vs joystick, status-bar vs joystick); (c) the feature's own tap target is reachable (≥44px, not under Safari chrome); (d) any modal it opens fits the viewport and is dismissable.
+3. **Touch-aware gating:** mobile/desktop visibility MUST use the canonical `useIsMobile()` hook (`maxTouchPoints > 1` + coarse-pointer), NEVER a bare Tailwind `md:` / `max-width` media query — those miss iPad Air/Pro/landscape (the exact bug that shipped covered joysticks). [[feedback_ipad_detection_maxtouchpoints]]
+4. **Safe-area caveat:** devtools has NO `env(safe-area-inset-*)`, so any bottom-anchored element using safe-area math (joysticks, bottom prompts) CANNOT be fully proven in emulation — it needs a real-iPad screenshot from the user. State this explicitly; do not claim the safe-area lift verified from devtools alone.
+5. **Interaction, not just layout:** force the feature's live state (walk to a building / open the modal / trigger the toast) — a component that returns `null` until `nearLocation` is set proves nothing rendered. Use click-to-move on the minimap or inject store state.
+
+Skipping this = the change is not done, regardless of green build or desktop screenshot.
+
 ### Local + Windows gotchas
 
 NEVER run `bun run dev` locally — Iris Xe crashes the Three.js/WebGPU scene → PC restart. Push → staging → prod.

--- a/apps/web/src/components/three/World3DCanvas.tsx
+++ b/apps/web/src/components/three/World3DCanvas.tsx
@@ -446,6 +446,54 @@ function markWorldReadyIfUploadsDone(): void {
   }
 }
 
+/**
+ * Async-WebGPU first-paint kick (2026-05-31).
+ *
+ * Symptom: the world rendered nothing (uniform SKY_COLOR blue) on initial
+ * load and only painted once the user RESIZED the window. Measured live:
+ * frameloop='always', RAF firing, 328 visible meshes, 1 render/frame,
+ * canvas full-screen opacity 1 — yet no visible output until a real resize.
+ *
+ * Cause: the WebGPU swapchain context is configured inside the async
+ * `glFactory` (during `await renderer.init()` + the factory's `setSize`)
+ * BEFORE R3F finishes wiring its render pipeline. The first frames render
+ * into a swapchain that never presents until something re-runs
+ * `gl.setSize()` → `backend.updateSize()` → context reconfigure. A manual
+ * window resize does exactly that (R3F's ResizeObserver → setSize), which
+ * is why resizing "fixed" it.
+ *
+ * Fix: replicate that resize ONCE after layout settles by re-issuing
+ * `gl.setSize()` with the real container dimensions. `setSize` is NOT
+ * deduped — three r170 always calls `backend.updateSize()` — so this
+ * reliably forces the reconfigure. Re-issued across a few frames to cover
+ * the init-resolve race.
+ *
+ * This is a one-shot SIZE re-issue, NOT a render loop. Do NOT turn this
+ * into a recurring `gl.render` call — a second render per frame is exactly
+ * what the removed OpaqueCanvasClearGuard did, and on WebGPU that
+ * double-render presented only the clear color (the blue screen).
+ */
+function forceWebGpuFirstPaint(state: any): void {
+  const gl = state?.gl;
+  if (!gl || typeof gl.setSize !== 'function') return;
+  let attempts = 0;
+  const reissue = () => {
+    const canvas: HTMLCanvasElement | undefined = gl.domElement;
+    const host = canvas?.parentElement;
+    const w = Math.round(host?.clientWidth || canvas?.clientWidth || window.innerWidth);
+    const h = Math.round(host?.clientHeight || canvas?.clientHeight || window.innerHeight);
+    if (w > 0 && h > 0) {
+      // updateStyle=false — R3F owns the canvas CSS box; we only re-issue the
+      // backing-store size so backend.updateSize() reconfigures the swapchain.
+      gl.setSize(w, h, false);
+      if (typeof state.invalidate === 'function') state.invalidate();
+    }
+    attempts += 1;
+    if (attempts < 3) requestAnimationFrame(reissue);
+  };
+  requestAnimationFrame(reissue);
+}
+
 function kickRenderLoop(state: any): void {
   if (typeof state.invalidate === 'function') {
     state.invalidate();
@@ -465,6 +513,9 @@ function kickRenderLoop(state: any): void {
       // hidden and RAF is throttled to 0 Hz.
       (window as any).__W3D_step = () =>
         state.advance(performance.now() / 1000, true);
+      // Force the WebGPU swapchain to reconfigure so the world paints on
+      // first load instead of staying blue until a manual resize.
+      forceWebGpuFirstPaint(state);
     });
   }
 }


### PR DESCRIPTION
## Primary purpose: fix the push-to-deploy pipeline
The deploy workflows were silently gitignored (`.gitignore` blanket `*.yml`) so they were **never committed** — GitHub registered 0 workflows and ran 0 Actions ever; every deploy was manual tinker. This PR commits `.github/workflows/{deploy,deploy-staging}.yml` (+ the `!.github/workflows/*.yml` negation) onto `master` so GitHub finally registers them. Repo secrets are now set: `PROD_VPS_IP`, `STAGING_VPS_IP`, `STAGING_SSH_KEY` (existing passphrase-free deploy key), `COOLIFY_SSH_KEY` (fresh no-passphrase prod CI deploy key, authorized on the prod box + verified).

## Also promotes (already staging-tested)
- World/loader session: paint-on-load (WebGPU swapchain re-present), blue-flash kill, SceneTransition unmount-after-ready, loader waits for textured frame, 3s loader cap.
- `docs(claude)`: mandatory mobile/iPad verification rule.

## Note
Merging this is itself the first prod CI test — `deploy.yml` should run on the merge. The blackjack engine work is uncommitted (Workflow in progress) and is intentionally NOT in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)