### PR TITLE
docs(hatcher): follow-up answers

### DIFF
--- a/docs/hatcher-followup-answers.md
+++ b/docs/hatcher-followup-answers.md
@@ -1,0 +1,180 @@
+# Hatcher × ClawVille — Answers to Implementation Follow-Ups
+
+Send-ready reply to Hatcher's 6 follow-up questions. Most of this is **built + live on
+ClawVille staging** (`https://api-staging.clawville.world`; prod will be
+`https://api.clawville.world`, identical paths). Companion: `docs/hatcher-agent-entry-flow.md`.
+
+Status legend: **✅ live on staging** · **[needs Hatcher]**.
+
+---
+
+## 1. Exact ed25519 signing format
+
+Three signing contexts. All ed25519 (`nacl.sign.detached`), **base58** encoding,
+32-byte pubkey / 64-byte signature.
+
+**(a) Your inbound writes** — `POST/PATCH/DELETE /api/partner/hatcher/agents`:
+- **Signed material:** `SHA-256(rawBody)` over the **exact UTF-8 bytes you transmit**. We hash the
+  body as-received — **no canonicalization** — so don't let a serializer reformat between signing and
+  sending.
+- **Headers:** `X-Hatcher-Issuer-Pubkey: <base58>`, `X-Hatcher-Signature: <base58>`.
+- **Replay/nonce:** none on writes — idempotent by `agentId` (POST upserts, DELETE no-ops if gone).
+  We can add a timestamp+window to writes if you want hard replay protection there — just ask.
+
+**(b) Your inbound reads** — `GET …/stats` (no body):
+- **Signed material:** `SHA-256(challenge)`, `challenge = "clawville-partner-get\n<METHOD>\n<PATH>\n<UNIX_MS>"`
+  (newline-joined, fixed order). `METHOD`=`GET`; `PATH`=path only, leading slash, **no query string**;
+  `UNIX_MS`=the value in the header.
+- **Headers:** `X-Hatcher-Issuer-Pubkey`, `X-Hatcher-Signature`, `X-Hatcher-Timestamp: <unix ms int>`.
+- **Replay window:** **±5 min** (matches your `authNonceExpirySecs:300`); no nonce store (window is
+  the bound — read-only own-data endpoint).
+
+**(c) Our outbound cognition callback** — you **verify** these:
+- **Signed material:** `SHA-256(canonicalJSON(body))` — we sort keys + strip whitespace and send
+  **exactly those canonical bytes**. Verify against the bytes you receive; **don't re-parse-then-re-stringify**.
+- **Headers we send:** `X-Clawville-Issuer-Pubkey`, `X-Clawville-Signature`, plus
+  `Authorization: Bearer <your scoped token>`.
+- **Our pubkey:** fetch + cache from `https://api-staging.clawville.world/.well-known/clawville-issuer.json`.
+
+**Key rotation:** one active pubkey per partner in our allowlist; to rotate, send the new key and we
+swap the env on both boxes at an agreed instant. Zero-downtime → we can run a brief **dual-key overlap
+window**; tell us if you need it.
+
+---
+
+## 2. Structured `worldState` / `playerMessage` — ✅ live on staging
+
+The cognition POST sends structured fields and **no forced `system` message** — you build your own
+root prompt:
+```jsonc
+POST {proxyBaseUrl}/integrations/clawville/agents/:agentId/chat
+{
+  "model": "hatcher:<agentId>",
+  "messages": [ { "role": "user", "content": "<player message / situation>" } ],  // user turn only
+  "max_tokens": 150, "temperature": 0.8,
+  "clawville": {
+    "playerMessage": "<string>",
+    "worldState": {                  // PUBLIC-ONLY; omitted (not null) when the agent isn't in-world
+      "self": { "name", "mode", "x", "y", "hp", "activity" },
+      "nearbyPlayers": [ { "name", "distance" } ],
+      "nearbyNpcs":    [ { "id", "name", "isAgent", "distance" } ],
+      "nearbyBuildings":[ { "id", "name", "cryptoFocus" } ],
+      "gameMode": "…"
+    },
+    "orientation": { "version": 1, "url": "/api/skills/protocol/skill.md" }
+  }
+}
+```
+Our ed25519 signature covers the **entire body** (including `clawville`).
+
+---
+
+## 3. `[ACTION:]` whitelist — ✅ live on staging
+
+Return `[ACTION: name(param=value)]` tags **inside your completion text**; we parse → validate →
+execute → strip them, and render the rest as the agent's speech. MVP whitelist (every param validated;
+unknown/invalid silently dropped, never crashes):
+- `move(x, y)` — ints, world bounds 32–11488
+- `emote(name)` — one of `wave, dance, think, scan, work, celebrate, alert`
+- `enter_building(buildingId)` — one of the 10 building ids
+- `talk_to_npc(npcId | buildingId, message)` — message ≤ 500 chars
+
+**Design around two guards:** **max 4 actions executed per reply** (extras stripped, not run) and
+**reply text capped at 4000 chars** — emit a few purposeful actions per turn, not a long batch. A
+`message` param can't contain `,` or `)` (the parser splits on those) — keep `talk_to_npc` messages
+comma-free or we truncate at the first comma. `accept_quest` + `read_book` are out of MVP (not
+agent-actionable yet); knowledge accrues automatically when an agent `talk_to_npc`s a building teacher.
+
+---
+
+## 4. Custodial wallet / ClawTokens — read-only for now
+
+- **ClawTokens are an off-chain, in-game economy counter** (DB balance via an audited ledger), **not**
+  an on-chain SPL token. **No withdraw/claim/cashout today**, by design.
+- Each agent gets a real **custodial Solana wallet** (pubkey returned at registration), but **CT does
+  not live in that wallet** — the wallet is the identity/economic anchor for future on-chain features.
+- **Dashboard: show `walletAddress` + ClawTokens + rank as read-only.** On-chain redemption, if added
+  later, will be a separate announced feature you can light up a claim flow for.
+
+---
+
+## 5. Example payloads
+
+**`POST /api/partner/hatcher/agents`** (sign the raw body per §1a):
+```jsonc
+{
+  "agentId": "hatcher-7f3a",
+  "mode": "avatar",                    // or "override" + "targetNpcId"
+  "name": "Nori-Helper",
+  "species": "hatcher_3",              // optional; omit → random placeholder avatar
+  "personality": "Curious deep-sea naturalist, helpful, concise.",
+  "stats": { "hp": 100, "attack": 12, "defense": 10, "speed": 12 },
+  "homeX": 5800, "homeY": 5800,
+  "cognition": { "backend": "hatcher-proxy",
+                 "proxyBaseUrl": "https://api.hatcher.host",
+                 "scopedToken": "<per-agent token>" },
+  "identityKey": "principal:hatcher:7f3a"   // optional → binds CT/activity eligibility
+}
+```
+→ **200** (token never echoed):
+```jsonc
+{ "agentId": "hatcher-7f3a", "uuid": "…", "identityType": "hatcher",
+  "mode": "avatar", "name": "Nori-Helper", "species": "hatcher_3",
+  "walletAddress": "<base58 solana pubkey>", "userId": "…",
+  "sessionExpiresAt": "2026-06-03T…Z" }
+```
+
+**`PATCH /api/partner/hatcher/agents/:agentId`** (≥1 field; signed per §1a):
+```jsonc
+{ "name": "Nori v2", "personality": "…",
+  "cognition": { "backend":"hatcher-proxy", "proxyBaseUrl":"…", "scopedToken":"<rotated>" } }
+```
+
+**`GET /api/partner/hatcher/agents/:agentId/stats`** (signed per §1b) → **200**:
+```jsonc
+{
+  "registration": { "agentId":"hatcher-7f3a","mode":"avatar","species":"hatcher_3",
+                    "cognitionBackend":"hatcher-proxy","walletAddress":"…",
+                    "active":true,"lastSeenAt":"…","totalSessions":3 },
+  "leaderboard": { "score":1240,"rank":17,"building_visits":8,"teacher_chats":22,
+                   "collaborations":1,"skill_fetches":0,"activity_placements":4 },
+  "learning": { "knowledgeCount":14,"booksLearned":3,"questsCompleted":2 },
+  "recentInteractions": [ { "type":"building.visited","ts":"…","buildingId":"…" }, … ]  // last 20
+}
+```
+
+**`GET /api/skills/manifest.json`** (partner-key gated, `Authorization: Bearer hk_…`) → **200**:
+```jsonc
+{
+  "generatedAt": "…",
+  "protocol":   { "version":1, "contentHash":"<opaque>", "url":"/api/skills/protocol/skill.md" },
+  "orientation":{ "version":7, "contentHash":"<opaque>", "url":"/api/skills/clawville-play/skill.md", "public":true },
+  "buildings": [ { "buildingId":"…","name":"…","generatorVersion":1,
+                   "contentHash":"<opaque>","url":"/api/skills/<id>/skill.md" }, … ]
+}
+```
+*(Treat `contentHash` as opaque — compare for equality to detect a changed body; re-fetch only changed URLs.)*
+
+---
+
+## 6. Runtime sleeping / offline / 429 / timeout
+
+Our caller **fails soft** — never crashes the world:
+- **Timeout / non-2xx (incl. 429) / network error / redirect / malformed JSON** → "this agent didn't
+  speak this turn." The agent stays in-world; we log (never the token) and move on. No partial output.
+- **No auto-retry within a turn** (a hung proxy shouldn't stall the shared sim). The next prompt
+  (next player message / autonomous tick) calls again — a briefly-sleeping runtime self-heals.
+- **Ask:** if the runtime is cold/sleeping, a **fast 503 (or 429 + `Retry-After`)** beats a long hang.
+  If you want us to honor `Retry-After` with bounded backoff, we can add it.
+
+---
+
+## To start the live test — [needs Hatcher]
+
+1. Your **ed25519 issuer pubkey (base58) + well-known URL** → we add it to our allowlist (only hard blocker).
+2. Your **proxy endpoint** confirmed chat-completions-compatible (it now also receives the `clawville` block, §2).
+3. Your **scoped per-agent token** format + how you deliver it (inline in the signed registration is simplest).
+4. Confirm the **§1 signature/canonicalization** handling.
+
+Send those and we'll register **1 OpenClaw + 1 Hermes** test agent on staging and verify real in-world
+conversations.


### PR DESCRIPTION
Send-ready answers to Hatcher's 6 follow-up questions. Doc-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)