### PR TITLE
feat(hatcher): protocol pointer on entry + single-source PROTOCOL_VERSION + whitelist-parity rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Allowed alternatives without sign-off: "compiled and rendering — needs your ey
 
 > Every product decision, metric, feature gate, and scope cut traces back here. Added 2026-04-21.
 
-Gamified intersection of humans + AI: humans train agents by playing, agents train each other. Milady bridge is the goal — npm sideload plugin, curated app grid (PR #1839 merged), agent-initiated connect flow.
+Gamified intersection of humans + AI: humans train agents by playing, agents train each other. **Primary distribution is direct-web (`clawville.world`) to a crypto-native audience** (set 2026-06-02). The Milady bridge — npm sideload plugin, curated app grid (PR #1839 merged), agent-initiated connect flow — is now a **secondary acquisition channel**, a funnel back to the site, not the main path.
 
 **Three bidirectional collaboration axes, all first-class:** Agent ↔ Agent · Human-controlled Agent ↔ Agent · Human ↔ Agent.
 
@@ -39,11 +39,13 @@ Gamified intersection of humans + AI: humans train agents by playing, agents tra
 
 ---
 
-## TOP PROJECT PRIORITIES (equal weight)
+## TOP PROJECT PRIORITIES
 
-Every design decision is measured against all four. Equal constraints, not ordered — don't trade off without flagging.
+**#1 — WEB PERFORMANCE (overriding constraint).** _Set 2026-06-02._ Direct-web (`clawville.world`) is the PRIMARY distribution, to a crypto-native audience — the browser experience **is** the product, with no app-store install to amortize a slow load behind. So **desktop browser load-time + sustained FPS are the top constraint, ahead of new feature scope.** Baseline today: ~40–45 FPS on the Iris Xe desktop floor (target 80, floor 60) + a loading bar that reads as frozen. **The render engine and physics performance must be solid before new gameplay scope ships.** Tracking: `docs/perf-audit-2026-05-22.md` (+ `perf-research-2026-05-22.md`, `perf-phase2-recon-2026-05-22.md`). Also load-bearing and currently a GAP: ClawVille is meant to be an **authoritative shared server** (real humans + agents co-present in one live world), not single-player + server-simulated NPCs — see `.claude/plans/multiplayer-phase1.md`.
 
-1. **Ship to Milady AI app store.** Two-track:
+**The four product priorities below are equal weight among themselves, each measured against #1. Don't trade off without flagging.**
+
+1. **Milady AI app store — SECONDARY acquisition channel** (downgraded from primary distribution 2026-06-02; primary is now direct-web at `clawville.world`). Still live as a funnel back to the site. Two-track:
    - **Sideload (LIVE 2026-04-12):** `@clawville/app-clawville@0.1.0` on npm. Installs via `POST /api/plugins/install`. Registers `LAUNCH_CLAWVILLE`. Repo: https://github.com/ItachiDevv/clawville-milady-plugin.
    - **Curated grid (MERGED):** PR `milady-ai/milady#1839` adds ClawVille to `MILADY_CURATED_APP_DEFINITIONS`. See `docs/milady-integration-plan.md`.
 
@@ -61,7 +63,7 @@ Every design decision is measured against all four. Equal constraints, not order
 
 4. **Gamified UI + free promotion + unified leaderboard.** Game layer (3D world, buildings, ClawTokens, quests) wraps one free leaderboard. All three axes feed the same leaderboard. `/dash` = internal metrics.
 
-**Every PR:** if a change helps #1 but hurts #3, or simplifies #2 but blocks #4, discuss before merging. Cosmetic SKUs need an existing `avatar_skins` row + valid asset URL + 3da-validated mesh.
+**Every PR:** weigh it against the **#1 web-performance constraint first** (does it add load weight, draw calls, or per-frame cost?), then the four product priorities — if a change helps one but hurts another, discuss before merging. Cosmetic SKUs need an existing `avatar_skins` row + valid asset URL + 3da-validated mesh.
 
 ---
 
@@ -102,7 +104,7 @@ These cost real money / crash the GPU / leak secrets. They stay inline regardles
 
 - **PUSH FLOW — staging-first (set 2026-05-24):** ALL new work goes to the `staging` branch first. `git push origin staging` → `.github/workflows/deploy-staging.yml` ships to the staging box → verify on `https://staging.clawville.world` + `https://api-staging.clawville.world` → open PR `staging → master` via `gh pr create --base master --head staging` → merge the PR → `.github/workflows/deploy.yml` ships to prod. **NEVER push directly to `master`** unless the user's message contains the literal phrase **`direct to master`** (case-insensitive) — that's the only override, logged as a CI warning. Hotfix is the only legitimate use. Both Coolify boxes share the same Supabase DB, so a staging deploy that mutates state mutates prod data too — treat staging deploys with the same care as prod for anything that writes.
 - **Iris Xe GPU:** NO drei `<Text>` / `<Billboard>` in game/world scenes — hard crash. NO `InstancedMesh + ShaderMaterial` — silent WebGPU crash. NO per-frame `new Vector3()` in `useFrame` — GC thrash.
-- **Local dev:** NEVER run `bun run dev` locally (Iris Xe crash → PC restart). Push → Coolify auto-deploys → test against staging first, then prod.
+- **Local testing FIRST (DEFAULT, set 2026-06-01):** iterate with `bun run build && bun run start` (prod bundle on :3000 — Iris-Xe-SAFE; ONLY `bun run dev`/HMR crashes the WebGPU scene). Test in-browser on `localhost`. NEVER run `bun run dev`. Do **NOT** push unfinished / mid-iteration features to `staging` — it clogs the Coolify build cache and is slow for work we know isn't done. Push to `staging` only when a feature is ready for the user's sign-off, or when a bug genuinely can't reproduce locally. [[feedback_local_testing_bun_run_start]]
 - **Phase 5.1 wallet:** `wallet.secretKey` is returned **EXACTLY ONCE** on first-connect. Subsequent reads MUST omit it. SKILL.md instructs agent to display once + store only pubkey. Server never re-emits — no recovery path. Full spec: `ARCHITECTURE.md §7`.
 - **Verification:** never claim deployed/fixed without evidence (curl, bundle grep, DOM read). "Should work" is banned.
 - **Push-auth fallback chain:** `gh auth status` → `unset GITHUB_TOKEN && gh auth setup-git` → SSH remote → `gh` CLI. Only escalate with all errors quoted. Never hand the push to the user as the first move.
@@ -162,6 +164,14 @@ Sea-themed OpenClaw game on ElizaOS. Users create an avatar, explore a 3D/2D sea
 ## IMPORTANT: ElizaOS is MANDATORY
 
 Core requirement — do NOT remove or stub. Avatar + location chat MUST use ElizaOS runtime (`@clawville/agent-runtime`); orchestrator MUST use `createElizaRuntime`. Deploy to persistent-server platforms (Hetzner+Coolify, Render, Fly.io) — NOT Vercel serverless. Never replace with direct API calls or stubs.
+
+## MANDATORY: Hatcher action whitelist parity (server executor and protocol SKILL.md)
+
+The Hatcher in-world ACTION WHITELIST lives in two files that MUST stay in parity, same diff, with `PROTOCOL_VERSION` bumped together:
+- ENFORCEMENT (authoritative): `apps/api/src/services/npc-simulation.ts` `dispatchHatcherActions` / `executeHatcherAction` is the server hard gate. Only whitelisted verbs execute; everything else is dropped. Safety lives here and never depends on the SKILL.md.
+- DOCUMENTATION: the protocol SKILL.md emitted by `apps/api/src/services/skill-protocol.ts buildProtocolManual` (the single source of `PROTOCOL_VERSION`). This is what a connected agent is TOLD it can do.
+
+When you add, remove, or change a verb or its params in the executor, you MUST update the protocol manual to match AND bump `PROTOCOL_VERSION` in the same diff. A mismatch means agents either attempt actions the server silently drops, or never learn an action the server allows. Connected Hatcher agents poll the manual on entry (via the `protocol` pointer in the registration response) and re-pull when `orientation.version` bumps, so the version bump is how an expanded whitelist reaches them.
 
 ## MANDATORY: Game-flow changes propagate to all three operational-knowledge surfaces in the same diff
 
@@ -270,7 +280,7 @@ Skipping this = the change is not done, regardless of green build or desktop scr
 
 ### Local + Windows gotchas
 
-NEVER run `bun run dev` locally — Iris Xe crashes the Three.js/WebGPU scene → PC restart. Push → staging → prod.
+**Test locally FIRST:** `bun run build && bun run start` (prod bundle on :3000, Iris-Xe-safe) is the default test path for in-progress work — iterate on `localhost`, NOT staging (staging pushes clog the Coolify build cache; reserve them for sign-off-ready features). NEVER run `bun run dev` — Iris Xe crashes the WebGPU scene → PC restart (HMR only; the prod `start` bundle is fine).
 Curl on Git Bash uses schannel and rejects CRLs — always pass `--ssl-no-revoke`.
 
 ## Game Modes

--- a/apps/api/src/routes/partner-hatcher.ts
+++ b/apps/api/src/routes/partner-hatcher.ts
@@ -62,6 +62,7 @@ import { ensureWallet } from '../services/wallet-service';
 import { resolveOrCreateUserByIdentity } from '../services/identity-service';
 import { computeSessionExpiresAt } from '../services/openclaw-session-sweeper';
 import { logEvent } from '../services/event-logger';
+import { protocolPointer, resolveApiBase } from '../services/skill-protocol';
 import { getAgentLeaderboardEntry } from './leaderboard';
 
 export const partnerHatcherRoutes = new Hono<AppContext>();
@@ -317,6 +318,12 @@ function publicAgentRecord(row: typeof openclawBots.$inferSelect) {
     walletAddress: row.walletAddress,
     userId: row.userId,
     sessionExpiresAt: row.sessionExpiresAt,
+    // PUBLIC protocol pointer so a partner knows ON ENTRY exactly which protocol
+    // SKILL.md version to pull (and the contentHash to diff against). All three
+    // fields are public — version, contentHash, relative url — never a secret.
+    // Same `resolveApiBase()` the manifest + served body use, so the hash here
+    // is byte-identical to `/api/skills/manifest.json`'s `protocol.contentHash`.
+    protocol: protocolPointer(resolveApiBase()),
   };
 }
 

--- a/apps/api/src/routes/skills.ts
+++ b/apps/api/src/routes/skills.ts
@@ -28,12 +28,17 @@
 
 import { Hono } from 'hono';
 import type { MiddlewareHandler } from 'hono';
-import { createHash } from 'crypto';
 import { db, buildingSkills, openclawBots, avatars, eq, and } from '@clawville/database';
 import { getBooksForBuilding, BUILDING_OPENCLAW_THEMES } from '@clawville/shared';
 import { lucia } from '../lib/auth';
 import { logEventFromContext } from '../services/event-logger';
 import { requirePartnerKey, partnerRateLimit } from '../middleware/partner-key';
+import {
+  PROTOCOL_VERSION,
+  buildProtocolManual,
+  contentHashOf,
+  resolveApiBase,
+} from '../services/skill-protocol';
 import type { AppContext } from '../types';
 
 export const skillsRoutes = new Hono<AppContext>();
@@ -54,11 +59,6 @@ export const skillsRoutes = new Hono<AppContext>();
 // The `clawville-play` meta skill stays PUBLIC (open-onboarding brand priority).
 // See `.claude/plans/hatcher-integration.md` §4.
 
-/** sha256 → `sha256:<hex>` for manifest content-hash fields. */
-function contentHashOf(content: string): string {
-  return `sha256:${createHash('sha256').update(content).digest('hex')}`;
-}
-
 // Per-partner read limiter — keyed on the validated partnerId, NOT IP (a
 // partner egresses every agent from one IP, so per-IP would mis-bucket the
 // whole partner). Generous ceiling for the manifest poll + per-skill fetches.
@@ -69,118 +69,10 @@ const partnerSkillsRateLimit = partnerRateLimit({ maxPerWindow: 60, windowMs: 60
 // Protocol manual — the STABLE, token-free connection SKILL.md surface.
 // ---------------------------------------------------------------------------
 //
-// This is the static "how to connect + play" protocol manual the three-surface
-// game-flow rule names (CLAUDE.md → surface #2). It deliberately carries NO
-// per-token connect block — that stays dynamic on `/api/agent/connect-skill`.
-// An external/hosted agent fetches THIS once (and re-fetches when the manifest
-// `protocol.contentHash` changes) to learn the universal protocol.
-//
-// PROTOCOL_VERSION bumps when the contract below changes (the manifest exposes
-// it so a partner knows EAGERLY to re-embed before the next play session).
-const PROTOCOL_VERSION = 1;
-
-function buildProtocolManual(apiBase: string): string {
-  return `---
-name: clawville-connection-protocol
-description: Stable, token-free protocol manual for connecting an external or hosted AI agent to ClawVille and playing in-world. Fetch this once and re-fetch when the manifest protocol.contentHash changes.
-version: ${PROTOCOL_VERSION}.0.0
-license: MIT
-metadata:
-  base_url: ${apiBase}
-  surface: connection-protocol-manual
-  protocol_version: ${PROTOCOL_VERSION}
----
-# ClawVille — Connection Protocol Manual
-
-This is the **stable** protocol manual for connecting an autonomous agent to
-ClawVille and playing in-world. It contains NO secrets and NO per-session token —
-fetch it once, and re-fetch only when the manifest's \`protocol.contentHash\`
-changes. The per-token magic-link connect block (for the human-initiated connect
-flow) is served separately at \`GET ${apiBase}/api/agent/connect-skill?token=…\`.
-
-## 1. Connect
-
-\`\`\`http
-POST ${apiBase}/api/agent/connect
-Content-Type: application/json
-
-{
-  "agentId": "your-stable-agent-id",
-  "name": "YourAgentName",
-  "protocol": "nanoclaw"
-}
-\`\`\`
-
-\`protocol\` is one of \`nanoclaw\` (self-managed SSE — easiest), \`openai-compat\`,
-\`anthropic\`, or \`custom-webhook\`. The response includes a \`sessionId\` (use it
-on every subsequent call), an \`orientation\` block (the "you are inside
-ClawVille" world-facts — embed it in your own system prompt), and, on first
-contact, one-time \`identity\` + \`wallet\` blocks (store the keys; they are
-returned exactly once).
-
-## 2. Perceive
-
-\`\`\`http
-GET ${apiBase}/api/agent/:sessionId/perception   (one-shot)
-GET ${apiBase}/api/agent/:sessionId/events       (SSE, pushed every ~2s)
-\`\`\`
-
-Perception = your position + nearby NPCs (incl. other agents) + the 10 nearest
-buildings (with each building's crypto focus) + active conversations/combats +
-game mode.
-
-## 3. Act
-
-All POST, keyed by \`:sessionId\`:
-
-- \`/move\` — \`{ target: {x,z} }\` or \`{ towardBuildingId }\`
-- \`/visit-building\` — \`{ buildingId }\` (+1 ClawToken, logs \`building.visited\`)
-- \`/building/:buildingId/chat\` — RAG teacher chat (+1 ClawToken, logs \`agent.chat.turn\`)
-- \`/chat\` — talk to a nearby NPC/agent
-- \`/emote\`, \`/combat-action\`
-
-## 4. Learn skills
-
-The 10 building skills + the \`clawville-play\` meta skill are published as
-SKILL.md. Discover what changed via the manifest, then fetch the changed bodies:
-
-\`\`\`http
-GET ${apiBase}/api/skills/manifest.json
-GET ${apiBase}/api/skills/clawville-play/skill.md   (public — the entry skill)
-GET ${apiBase}/api/skills/:buildingId/skill.md      (partner-key gated)
-\`\`\`
-
-Poll the manifest every 6–24h; diff each \`contentHash\`; on a change, GET the
-\`url\`, re-chunk (split on \`## \` headings), and re-embed into your RAG store. A
-\`protocol.contentHash\` change is EAGER (re-embed THIS manual before your next
-play session); building-skill changes are LAZY.
-
-## 5. Stay alive
-
-Every session carries a sliding 24h TTL that extends on activity and expires
-silently if you stop acting:
-
-\`\`\`http
-GET ${apiBase}/api/agent/session-status?agentId=<your-agent-id>
-  → 200 { connected: true, ... }   |   410 expired   |   404 unknown
-\`\`\`
-
-On 410, do NOT report "connected" — run the signed challenge → reconnect flow
-(\`GET /api/agent/challenge\` → \`POST /api/agent/reconnect\` with an ed25519
-signature over the raw decoded nonce) to mint a fresh session.
-
-## 6. Disconnect
-
-\`\`\`http
-GET  ${apiBase}/api/agent/challenge
-POST ${apiBase}/api/agent/disconnect
-  { userId, agentId, nonce, signature }
-\`\`\`
-
-Identity-signed (not sessionId-scoped), so a leaked sessionId can't log you out.
-Avatar progress + learned knowledge persist across disconnect.
-`;
-}
+// PROTOCOL_VERSION + buildProtocolManual + contentHashOf + resolveApiBase now
+// live in `services/skill-protocol.ts` (single source of truth), so the manifest
+// block here, the served `/protocol/skill.md` body, the openclaw-client
+// orientation pointer, and the partner-hatcher protocol pointer never drift.
 
 skillsRoutes.get('/', async (c) => {
   const rows = await db
@@ -201,13 +93,6 @@ skillsRoutes.get('/', async (c) => {
     })),
   });
 });
-
-/** Resolve the public API base URL for absolute links in served markdown. */
-function resolveApiBase(): string {
-  return process.env.CORS_ORIGIN?.includes('clawville.world')
-    ? 'https://api.clawville.world'
-    : `http://localhost:${process.env.PORT ?? 4001}`;
-}
 
 // ---------------------------------------------------------------------------
 // GET /api/skills/manifest.json — single poll target (partner-key gated).

--- a/apps/api/src/services/openclaw-client.ts
+++ b/apps/api/src/services/openclaw-client.ts
@@ -5,19 +5,9 @@ import type {
 } from '@clawville/shared';
 import { signPayload } from './service-issuer';
 import { validateHatcherProxyUrl } from './hatcher-config';
+import { PROTOCOL_VERSION } from './skill-protocol';
 
 type Protocol = AgentWireProtocol;
-
-/**
- * Orientation contract version shipped in `clawville.orientation.version` on the
- * hatcher-proxy cognition body. Bump when the orientation surface
- * (`CLAWVILLE_ORIENTATION_KNOWLEDGE`) or the protocol manual at
- * `/api/skills/protocol/skill.md` changes meaningfully, so a polling partner can
- * detect it needs to re-fetch. Mirrors `PROTOCOL_VERSION` in
- * `apps/api/src/routes/skills.ts` (the manifest's canonical version) — kept as a
- * local literal to avoid a route↔service import cycle.
- */
-const HATCHER_ORIENTATION_VERSION = 1;
 
 /**
  * Hard cap on the raw proxy-cognition reply we will accept (chars). Our
@@ -228,7 +218,10 @@ export class OpenClawClient {
         // keeps the canonical signed bytes clean for the partner's verifier.
         ...(worldState ? { worldState } : {}),
         orientation: {
-          version: HATCHER_ORIENTATION_VERSION,
+          // Single source of truth — the manifest's canonical protocol version
+          // (services/skill-protocol.ts), so this pointer never drifts from the
+          // served `/api/skills/protocol/skill.md` manual.
+          version: PROTOCOL_VERSION,
           url: '/api/skills/protocol/skill.md',
         },
       },

--- a/apps/api/src/services/skill-protocol.ts
+++ b/apps/api/src/services/skill-protocol.ts
@@ -1,0 +1,178 @@
+/**
+ * Connection-protocol single source of truth.
+ *
+ * Centralizes the ClawVille connection-protocol VERSION, the protocol manual
+ * markdown builder, and the content-hash so EVERY surface that references the
+ * protocol agrees byte-for-byte:
+ *   - `routes/skills.ts` — the `/api/skills/manifest.json` protocol block and
+ *     the `/api/skills/protocol/skill.md` served body.
+ *   - `services/openclaw-client.ts` — the `clawville.orientation.version` shipped
+ *     on the hatcher-proxy cognition body.
+ *   - `routes/partner-hatcher.ts` — the `protocol` pointer returned on register /
+ *     patch so a partner knows on entry exactly which protocol manual version to
+ *     pull.
+ *
+ * Lives in `services/` (not a route) so both routes AND the client service can
+ * import it without a route↔route or route↔service import cycle.
+ *
+ * The same-diff game-flow rule (CLAUDE.md surface #2 — connection SKILL.md)
+ * binds here: bump `PROTOCOL_VERSION` whenever the manual contract below changes
+ * so polling partners re-embed eagerly.
+ */
+
+import { createHash } from 'crypto';
+
+/**
+ * PROTOCOL_VERSION bumps when the protocol manual contract below changes (the
+ * manifest exposes it so a partner knows EAGERLY to re-embed before the next
+ * play session). Single source of truth — `skills.ts`, `openclaw-client.ts`,
+ * and `partner-hatcher.ts` all import this rather than re-declare a literal.
+ */
+export const PROTOCOL_VERSION = 1;
+
+/** sha256 → `sha256:<hex>`. Shared hashing so manifest + pointer + served body
+ *  all emit the IDENTICAL hash for the same input bytes. */
+export function contentHashOf(content: string): string {
+  return `sha256:${createHash('sha256').update(content).digest('hex')}`;
+}
+
+/** Resolve the public API base URL for absolute links in served markdown. */
+export function resolveApiBase(): string {
+  return process.env.CORS_ORIGIN?.includes('clawville.world')
+    ? 'https://api.clawville.world'
+    : `http://localhost:${process.env.PORT ?? 4001}`;
+}
+
+/**
+ * The STABLE, token-free connection SKILL.md surface — the three-surface
+ * game-flow "connection SKILL.md" (CLAUDE.md surface #2). It deliberately
+ * carries NO per-token connect block — that stays dynamic on
+ * `/api/agent/connect-skill`. An external/hosted agent fetches THIS once (and
+ * re-fetches when the manifest `protocol.contentHash` changes) to learn the
+ * universal protocol.
+ */
+export function buildProtocolManual(apiBase: string): string {
+  return `---
+name: clawville-connection-protocol
+description: Stable, token-free protocol manual for connecting an external or hosted AI agent to ClawVille and playing in-world. Fetch this once and re-fetch when the manifest protocol.contentHash changes.
+version: ${PROTOCOL_VERSION}.0.0
+license: MIT
+metadata:
+  base_url: ${apiBase}
+  surface: connection-protocol-manual
+  protocol_version: ${PROTOCOL_VERSION}
+---
+# ClawVille — Connection Protocol Manual
+
+This is the **stable** protocol manual for connecting an autonomous agent to
+ClawVille and playing in-world. It contains NO secrets and NO per-session token —
+fetch it once, and re-fetch only when the manifest's \`protocol.contentHash\`
+changes. The per-token magic-link connect block (for the human-initiated connect
+flow) is served separately at \`GET ${apiBase}/api/agent/connect-skill?token=…\`.
+
+## 1. Connect
+
+\`\`\`http
+POST ${apiBase}/api/agent/connect
+Content-Type: application/json
+
+{
+  "agentId": "your-stable-agent-id",
+  "name": "YourAgentName",
+  "protocol": "nanoclaw"
+}
+\`\`\`
+
+\`protocol\` is one of \`nanoclaw\` (self-managed SSE — easiest), \`openai-compat\`,
+\`anthropic\`, or \`custom-webhook\`. The response includes a \`sessionId\` (use it
+on every subsequent call), an \`orientation\` block (the "you are inside
+ClawVille" world-facts — embed it in your own system prompt), and, on first
+contact, one-time \`identity\` + \`wallet\` blocks (store the keys; they are
+returned exactly once).
+
+## 2. Perceive
+
+\`\`\`http
+GET ${apiBase}/api/agent/:sessionId/perception   (one-shot)
+GET ${apiBase}/api/agent/:sessionId/events       (SSE, pushed every ~2s)
+\`\`\`
+
+Perception = your position + nearby NPCs (incl. other agents) + the 10 nearest
+buildings (with each building's crypto focus) + active conversations/combats +
+game mode.
+
+## 3. Act
+
+All POST, keyed by \`:sessionId\`:
+
+- \`/move\` — \`{ target: {x,z} }\` or \`{ towardBuildingId }\`
+- \`/visit-building\` — \`{ buildingId }\` (+1 ClawToken, logs \`building.visited\`)
+- \`/building/:buildingId/chat\` — RAG teacher chat (+1 ClawToken, logs \`agent.chat.turn\`)
+- \`/chat\` — talk to a nearby NPC/agent
+- \`/emote\`, \`/combat-action\`
+
+## 4. Learn skills
+
+The 10 building skills + the \`clawville-play\` meta skill are published as
+SKILL.md. Discover what changed via the manifest, then fetch the changed bodies:
+
+\`\`\`http
+GET ${apiBase}/api/skills/manifest.json
+GET ${apiBase}/api/skills/clawville-play/skill.md   (public — the entry skill)
+GET ${apiBase}/api/skills/:buildingId/skill.md      (partner-key gated)
+\`\`\`
+
+Poll the manifest every 6–24h; diff each \`contentHash\`; on a change, GET the
+\`url\`, re-chunk (split on \`## \` headings), and re-embed into your RAG store. A
+\`protocol.contentHash\` change is EAGER (re-embed THIS manual before your next
+play session); building-skill changes are LAZY.
+
+## 5. Stay alive
+
+Every session carries a sliding 24h TTL that extends on activity and expires
+silently if you stop acting:
+
+\`\`\`http
+GET ${apiBase}/api/agent/session-status?agentId=<your-agent-id>
+  → 200 { connected: true, ... }   |   410 expired   |   404 unknown
+\`\`\`
+
+On 410, do NOT report "connected" — run the signed challenge → reconnect flow
+(\`GET /api/agent/challenge\` → \`POST /api/agent/reconnect\` with an ed25519
+signature over the raw decoded nonce) to mint a fresh session.
+
+## 6. Disconnect
+
+\`\`\`http
+GET  ${apiBase}/api/agent/challenge
+POST ${apiBase}/api/agent/disconnect
+  { userId, agentId, nonce, signature }
+\`\`\`
+
+Identity-signed (not sessionId-scoped), so a leaked sessionId can't log you out.
+Avatar progress + learned knowledge persist across disconnect.
+`;
+}
+
+/** sha256 of the protocol manual built for `apiBase` — reuses `contentHashOf`
+ *  so the hash matches EXACTLY what the manifest + served-body headers emit. */
+export function protocolContentHash(apiBase: string): string {
+  return contentHashOf(buildProtocolManual(apiBase));
+}
+
+/**
+ * PUBLIC protocol pointer for partner responses (register / patch). All three
+ * fields are public — version, content hash, and the relative URL of the
+ * token-free protocol manual. NEVER carries a secret.
+ */
+export function protocolPointer(apiBase: string): {
+  version: number;
+  contentHash: string;
+  url: string;
+} {
+  return {
+    version: PROTOCOL_VERSION,
+    contentHash: protocolContentHash(apiBase),
+    url: '/api/skills/protocol/skill.md',
+  };
+}

--- a/docs/hatcher-followup-answers.md
+++ b/docs/hatcher-followup-answers.md
@@ -1,8 +1,6 @@
 # Hatcher × ClawVille — Answers to Implementation Follow-Ups
 
-Send-ready reply to Hatcher's 6 follow-up questions. Most of this is **built + live on
-ClawVille staging** (`https://api-staging.clawville.world`; prod will be
-`https://api.clawville.world`, identical paths). Companion: `docs/hatcher-agent-entry-flow.md`.
+Companion: `docs/hatcher-agent-entry-flow.md`.
 
 Status legend: **✅ live on staging** · **[needs Hatcher]**.
 
@@ -10,35 +8,34 @@ Status legend: **✅ live on staging** · **[needs Hatcher]**.
 
 ## 1. Exact ed25519 signing format
 
-Three signing contexts. All ed25519 (`nacl.sign.detached`), **base58** encoding,
-32-byte pubkey / 64-byte signature.
+**Quick map to your 5 sub-questions** (full detail in (a), (b), (c) below):
 
-**(a) Your inbound writes** — `POST/PATCH/DELETE /api/partner/hatcher/agents`:
-- **Signed material:** `SHA-256(rawBody)` over the **exact UTF-8 bytes you transmit**. We hash the
-  body as-received — **no canonicalization** — so don't let a serializer reformat between signing and
-  sending.
+| Your ask | Short answer |
+|---|---|
+| Canonical string / body | Writes: the raw request body bytes, exactly as sent (no transform). Reads (GET): the fixed string `clawville-partner-get\n<METHOD>\n<PATH>\n<UNIX_MS>`. Our calls to you: canonical JSON (keys sorted, no whitespace), and you verify the exact bytes we send. |
+| Timestamp header | `X-Hatcher-Timestamp` (unix ms) on reads. None on writes. |
+| Replay window | Reads: plus or minus 5 minutes. Writes: none today (idempotent by `agentId`); we can add a timestamp plus 5 min window to writes if you want it. |
+| Nonce / idempotency | No nonce store. Writes idempotent by `agentId`; reads bounded by the 5 minute window. |
+| Key rotation | One active public key per partner; rotate by sending us a new key (optional dual-key overlap window for zero downtime). |
+
+Three signing contexts. All ed25519 (`nacl.sign.detached`), `base58` encoding, 32-byte pubkey / 64-byte signature.
+
+**(a) Your inbound writes** (`POST/PATCH/DELETE /api/partner/hatcher/agents`):
+- **Signed material:** `SHA-256(rawBody)` over the **exact UTF-8 bytes you transmit**. We hash the body as-received (no canonicalization), so don't let a serializer reformat between signing and sending.
 - **Headers:** `X-Hatcher-Issuer-Pubkey: <base58>`, `X-Hatcher-Signature: <base58>`.
-- **Replay/nonce:** none on writes — idempotent by `agentId` (POST upserts, DELETE no-ops if gone).
-  We can add a timestamp+window to writes if you want hard replay protection there — just ask.
+- **Replay / nonce:** none on writes. They are idempotent by `agentId` (POST upserts, DELETE no-ops if gone). We can add a timestamp plus window to writes if you want hard replay protection there; just let us know your preference.
 
-**(b) Your inbound reads** — `GET …/stats` (no body):
-- **Signed material:** `SHA-256(challenge)`, `challenge = "clawville-partner-get\n<METHOD>\n<PATH>\n<UNIX_MS>"`
-  (newline-joined, fixed order). `METHOD`=`GET`; `PATH`=path only, leading slash, **no query string**;
-  `UNIX_MS`=the value in the header.
+**(b) Your inbound reads** (`GET .../stats`, no body):
+- **Signed material:** `SHA-256(challenge)`, where `challenge = "clawville-partner-get\n<METHOD>\n<PATH>\n<UNIX_MS>"` (newline-joined, fixed order). `METHOD`=`GET`; `PATH`=path only, leading slash, **no query string**; `UNIX_MS`=the value in the header.
 - **Headers:** `X-Hatcher-Issuer-Pubkey`, `X-Hatcher-Signature`, `X-Hatcher-Timestamp: <unix ms int>`.
-- **Replay window:** **±5 min** (matches your `authNonceExpirySecs:300`); no nonce store (window is
-  the bound — read-only own-data endpoint).
+- **Replay window:** plus or minus 5 minutes (matches your `authNonceExpirySecs:300`). No nonce store; the window is the bound (read-only own-data endpoint).
 
-**(c) Our outbound cognition callback** — you **verify** these:
-- **Signed material:** `SHA-256(canonicalJSON(body))` — we sort keys + strip whitespace and send
-  **exactly those canonical bytes**. Verify against the bytes you receive; **don't re-parse-then-re-stringify**.
-- **Headers we send:** `X-Clawville-Issuer-Pubkey`, `X-Clawville-Signature`, plus
-  `Authorization: Bearer <your scoped token>`.
-- **Our pubkey:** fetch + cache from `https://api-staging.clawville.world/.well-known/clawville-issuer.json`.
+**(c) Our outbound cognition callback** (you **verify** these):
+- **Signed material:** `SHA-256(canonicalJSON(body))`. We sort keys and strip whitespace and send **exactly those canonical bytes**. Verify against the bytes you receive; **do not re-parse then re-stringify**.
+- **Headers we send:** `X-Clawville-Issuer-Pubkey`, `X-Clawville-Signature`, plus `Authorization: Bearer <your scoped token>`.
+- **Our pubkey:** fetch and cache from `https://api-staging.clawville.world/.well-known/clawville-issuer.json`.
 
-**Key rotation:** one active pubkey per partner in our allowlist; to rotate, send the new key and we
-swap the env on both boxes at an agreed instant. Zero-downtime → we can run a brief **dual-key overlap
-window**; tell us if you need it.
+**Key rotation:** one active public key per partner in our allowlist. To rotate, send the new key and we swap the env on both servers at an agreed instant. For zero downtime we can run a brief **dual-key overlap window**; just tell us if you need it.
 
 ---
 


### PR DESCRIPTION
Single-sources `PROTOCOL_VERSION` into a new `skill-protocol.ts` service (skills.ts + openclaw-client.ts now import it, dropping the duplicate). Hatcher register/patch responses gain a public `protocol: { version, contentHash, url }` pointer so a connected agent pulls the current protocol SKILL.md on entry; `orientation.version` stays the per-turn staleness signal.

Adds a CLAUDE.md MANDATORY rule: the action whitelist must stay in parity across the server executor (enforcement) and the protocol SKILL.md (documentation), version-bumped same-diff.

Audited APPROVED (0 blocking), tsc clean for apps/api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)