### PR TITLE
Staging → master: perf3 review-cleanup + Hatcher launch-token contract confirmation

### DIFF
--- a/apps/web/src/lib/three/arena-location-npcs.tsx
+++ b/apps/web/src/lib/three/arena-location-npcs.tsx
@@ -18,7 +18,6 @@ import {
   VILLAGE_CENTER_TILE_Z,
   NPC_INSET_WORLD,
 } from '@/lib/three/character-positions';
-import { TERRAIN_LAYER } from '@/lib/three/arena-terrain';
 import { applyStationaryIdleAnimation, idToSeed } from '@/lib/three/procedural-animation';
 import { makeObject3DWebGPUSafe } from '@/lib/three/webgpu-geometry';
 import { getTerrainHeightAt, isTerrainHeightfieldReady } from '@/lib/three/terrain-heightfield';
@@ -43,12 +42,11 @@ const OFFSET_Z = -MAP_HEIGHT / 2;
 // so SpongeBob cast reads as the heroes of each building.
 const CHARACTER_HEIGHT = 96;
 
-// PERF (2026-06-15): _locRaycaster, _locRayOrigin, _locRayDir and the
-// findLocTerrainMesh / getTerrainY raycast path have been replaced by the O(1)
-// bilinear heightfield lookup (terrain-heightfield.ts).  The old raycast was
-// confirmed at ~57% of JS CPU in a prod trace (intersectTriangle +
-// _computeIntersections + attribute reads).  These module-scope objects are
-// retained as no-ops so any future reference resolves without compile errors.
+// PERF (2026-06-15): the raycast terrain lookup (_locRaycaster / _locRayOrigin /
+// _locRayDir / findLocTerrainMesh / getTerrainY) has been REMOVED and replaced
+// by the O(1) bilinear heightfield lookup (getTerrainHeightAt, terrain-heightfield.ts).
+// The old raycast was confirmed at ~57% of JS CPU in a prod trace (intersectTriangle
+// + _computeIntersections + attribute reads). The TERRAIN_LAYER import went with it.
 // PHASE 1.5 — module-scope camera-position scratch for far-NPC mixer gate.
 // Zero per-frame allocations across all 11 location-NPC useFrame calls per frame.
 const _locCamPos = new THREE.Vector3();

--- a/apps/web/src/lib/three/terrain-heightfield.ts
+++ b/apps/web/src/lib/three/terrain-heightfield.ts
@@ -60,10 +60,6 @@ let _rows = 0; // segsY + 1
 let _halfW = 0; // half of plane width  (world X range)
 let _halfH = 0; // half of plane height (world Z range = -localY range)
 
-/** Cell size in world units. */
-let _cellW = 0;
-let _cellH = 0;
-
 /** Flat Float32Array of displaced heights in LOCAL Z (before -2 world offset).
  *  Indexed as heights[row * _cols + col].
  *  Row 0 = most-negative localY (= most-positive worldZ).
@@ -107,8 +103,6 @@ export function initTerrainHeightfield(
   _rows  = rows;
   _halfW = (maxLocalX - minLocalX) / 2; // = w/2 in world X
   _halfH = (maxLocalY - minLocalY) / 2; // = h/2 in world Z (via -localY)
-  _cellW = (maxLocalX - minLocalX) / segsX;
-  _cellH = (maxLocalY - minLocalY) / segsY;
 
   // Copy displaced heights into a flat Float32Array.
   _heights = new Float32Array(cols * rows);
@@ -137,9 +131,10 @@ export function initTerrainHeightfield(
  *   displaced = bilinear(localX, localY)
  *   worldY = displaced + (-2)   (from position={[0,-2,0]})
  *
- * Returns -2 (flat floor fallback) if:
- *   - heightfield not yet initialised (terrain not mounted)
- *   - query point outside plane extents
+ * Returns -2 (flat floor fallback) only if the heightfield is not yet
+ * initialised (terrain not mounted). Queries outside the plane extents CLAMP to
+ * the nearest edge cell (NOT -2) — the terrain plane is far larger than the
+ * playable map, so in practice every entity query lands well inside the grid.
  *
  * Zero per-call allocations — only arithmetic on stack values.
  */

--- a/docs/hatcher-integration-spec.md
+++ b/docs/hatcher-integration-spec.md
@@ -205,10 +205,26 @@ version bump keeps you current — a verb never exists in one layer without the 
 
 ⚠️ **Needs Hatcher confirmation:**
 1. Your `/launch/exchange` **accepts `mode: "controlled"`** (we now always send it).
-2. **Success response schema** + **error taxonomy** (expired / already-exchanged / unknown-or-revoked grant) —
-   we treat your response, not the URL, as authoritative.
-3. **Re-exchange semantics** — is the same `launchToken` exchanged twice (refresh/retry) an idempotent success or
-   an error? We strip the params after first success, but need to know how to treat the race.
+2. **Success response schema** + **error taxonomy** (expired / unknown-or-revoked grant) — we treat your
+   response, not the URL, as authoritative.
+
+✅ **Confirmed by Hatcher (2026-06-15) — launch-token single-use / re-exchange semantics.** The launch token
+is **one-time use**: a second `/launch/exchange` for the same token returns **`409 CLAWVILLE_LAUNCH_USED`**.
+ClawVille already complies end to end:
+- **First successful exchange is authoritative** — the owner lands in control and the launch state is cleared.
+- **Single-use on our side too** — the token is stripped from the URL the moment it's consumed (before the
+  round-trip resolves) plus a re-entry guard, so a refresh / remount can't replay it.
+- **We never re-POST the same token after it has reached you** — our only auto-retries (a Lucia cookie-race
+  `401`, our own issuer-misconfig, or a browser↔our-API network blip) are **local pre-flight failures** where
+  the token never left us, so the retry is the *first* real exchange.
+- **Any response from your endpoint is terminal** — including `409 CLAWVILLE_LAUNCH_USED`: we **drop the token**
+  and prompt the owner to **relaunch from Hatcher** for a fresh one (never loop on a used token).
+- We key on the HTTP **status class** (`409`), not the `CLAWVILLE_LAUNCH_USED` body string, since we never parse
+  partner response bodies (security). A `409` routes to the relaunch path correctly regardless.
+
+Handler: `apps/web/src/components/game/hatcher-launch-handler.tsx` (success ~ll.121–141, retry/terminal
+classification ~ll.156–189, token strip ~l.235); route maps any non-2xx → `exchange_rejected` + upstream status
+in `apps/api/src/routes/partner-hatcher-launch.ts`.
 
 ---
 

--- a/scripts/decimate-vrm.ts
+++ b/scripts/decimate-vrm.ts
@@ -495,10 +495,18 @@ async function main(): Promise<void> {
   await doc.transform(...transforms);
 
   const glbBytes = await io.writeBinary(doc);
-  fs.writeFileSync(outFile, Buffer.from(glbBytes));
+  // Atomic write (review B2): write the bytes + re-inject VRMC_vrm on a TEMP
+  // file, then rename it over the target as the LAST step. In ship mode `outFile`
+  // is a canonical /avatars/<name>.vrm — if `reinjectVrmExtensions` threw mid-run
+  // a direct write would leave the original decimated-but-VRMC-stripped (an
+  // irrecoverably corrupt VRM with no backup). Temp+rename guarantees the target
+  // is only ever the fully-finished file OR the untouched original.
+  const tmpFile = outFile + '.tmp';
+  fs.writeFileSync(tmpFile, Buffer.from(glbBytes));
   // re-inject VRMC_vrm (+ siblings) — index-stable because simplify never
   // touched the node graph.
-  reinjectVrmExtensions(outFile, vrmExtensions);
+  reinjectVrmExtensions(tmpFile, vrmExtensions);
+  fs.renameSync(tmpFile, outFile);
 
   const outBytes = fs.statSync(outFile).size;
   const outFp = await fingerprint(outFile, io);


### PR DESCRIPTION
Promotes two low-risk doc/cleanup commits to prod:
- `a01f466c` — perf3 (PR #110) review-cleanup punch-list (dead import/vars, comment/doc fixes, decimate-script atomic write). Zero behavior change.
- `c0b9310b` — record Hatcher-confirmed launch-token single-use / 409 CLAWVILLE_LAUNCH_USED contract in the integration spec §6.

Verified settled + healthy on staging (`c0b9310b`).