### PR TITLE
fix(land/preview): strip pad planes (grazing wall)

### DIFF
--- a/apps/web/src/app/preview/land-structures/page.tsx
+++ b/apps/web/src/app/preview/land-structures/page.tsx
@@ -173,11 +173,10 @@ function Structure({ path, x, z }: { path: string; x: number; z: number }) {
 
   return (
     <group position={[x, 0, z]}>
-      {/* Pad under the structure */}
-      <mesh position={[0, -1, 0]} rotation={[-Math.PI / 2, 0, 0]}>
-        <planeGeometry args={[TARGET_MAX_DIM * 1.35, TARGET_MAX_DIM * 1.35]} />
-        <meshStandardMaterial color={0x9fb8c4} roughness={0.95} />
-      </mesh>
+      {/* No pad plane: a large flat MeshStandard plane seen at a grazing orbit
+          angle reads as a thin "wall" sweeping through the scene (same artifact
+          as the removed big ground plane). The models float on the dark scene
+          background instead — a clean asset-viewer look, nothing to sweep. */}
       <primitive
         object={prepared.root}
         scale={prepared.scale}


### PR DESCRIPTION
Removes per-model pad planes; preview now renders only the building models. 🤖 Generated with [Claude Code](https://claude.com/claude-code)