### PR TITLE
chore(audit-followup): SUPERSEDED Gemini-history tags + inert literal + gated SSRF-parity task

### DIFF
--- a/3dStructure.md
+++ b/3dStructure.md
@@ -1028,7 +1028,7 @@ Compact log. Single line per change with commit reference where applicable.
 - 2026-04-21 — Perf sweep over all 14 `lib/three/*` files (`matrixAutoUpdate=false` on static meshes, vector pool recycling, scratch-object hoisting). Est. 4-6 ms/frame saved.
 - 2026-04-16 — Building ring expanded 56 → 68 tiles to eliminate overlap. Building target height switched from `max(w,h,d)` → Y-height normalization. `MAX_FOOTPRINT` 1400 → 1000.
 - 2026-05-13 — Building ring expanded 68 → 72 tiles (R=2176 → 2304 wu) for inner-band breathing room post decoration retune. All 10 zone coords recomputed in `tilemap-data.ts`.
-- 2026-04-10 — Ultrathink decommission: `plugin-anthropic` + `plugin-openai` removed. Gemini providers only.
+- 2026-04-10 — Ultrathink decommission: `plugin-anthropic` + `plugin-openai` removed. Gemini providers only. _[SUPERSEDED 2026-06-16: Gemini fully scrubbed — OpenAI (`openai-text-provider` p95 + `openai-embedding-provider` p100) is now the sole LLM backend.]_
 
 - 2026-05-23 — **Experimental: Nanite-style GPU rasterizer spike** (worktree `perf/meshlet-integration` only, NOT on master). Two new files: `apps/web/src/lib/three/experimental/nanite-rasterizer.ts` (exports `NaniteRasterizer`, `geometryToMeshletAsset`, `MeshletAsset`, `RasterizerOptions` — 5-pass compute pipeline: Clear→Frustum→Dispatch→Rasterize→HWArgs, visibility buffer, SW barycentric rasterizer, HW fallback scene) and `apps/web/src/app/preview/meshlet-spike/page.tsx` (loads `building-lighthouse.glb`, single instance, DOM FPS overlay, WebGPU-only — blank/error if `navigator.gpu` absent). Route: `/preview/meshlet-spike`. No production-rendering files touched; spike is fully isolated.
 

--- a/TODO.md
+++ b/TODO.md
@@ -39,7 +39,7 @@ Currently on `@elizaos/core@1.7.1`. Migrate to `2.0.0` in 4 bounded, independent
 - `Plugin.models` remains single-handler-per-key — `{ [ModelType.TEXT_LARGE]: handler }` pattern unchanged.
 - `createMemory(memory, tableName)` second arg retained.
 - `runtime.generateText(prompt, opts)` still on IAgentRuntime — no forced migration to `useModel`.
-- Our Gemini providers port unchanged (priority-based model selection preserved — `gemini-text-provider` priority 95, `gemini-embedding-provider` priority 100).
+- Our OpenAI providers port unchanged (priority-based model selection preserved — `openai-text-provider` priority 95, `openai-embedding-provider` priority 100). _(Gemini fully scrubbed 2026-06-16; both `gemini-*-provider` files deleted.)_
 
 #### Phase 1 — pure runtime port (CURRENT)
 
@@ -295,3 +295,9 @@ Coolify VPS hit 100% disk on 2026-04-16 from accumulated Docker images + build c
 
 - The `pets` → `avatars` rename pass landed 2026-05-08. If you see a leftover `pet` reference anywhere except `pet_session_*` schema columns and the deprecated `seed-bot-pets.ts` script name (kept for historical Git blame), fix it on sight and note the change in the relevant doc's "Recent material changes" log.
 - The four canonical docs (`CLAUDE.md` / `WorldContent.md` / `3dStructure.md` / `ARCHITECTURE.md` / `GameFeatures.md`) have a strict bidirectional sync contract with the code paths they reference. Same-diff updates only. Mismatch is a bug.
+
+---
+
+## 🔒 Security hardening backlog
+
+- [ ] **(LOW, gated) Hatcher launch-exchange SSRF parity** — `apps/api/src/routes/partner-hatcher-launch.ts:244` validates the outbound exchange URL with the *synchronous* `validateHatcherProxyUrl()` (host-allowlist only), whereas the portal session-issue fetches use the DNS-resolving `validateHatcherProxyUrlResolved()` (security #2, 2026-06-16). Risk is **LOW** — the exchange URL is a hard-coded literal (not partner-steerable), `redirect:'manual'` backstops a rebind hop, and a 10s `AbortController` bounds it. For parity / defense-in-depth, swap to `validateHatcherProxyUrlResolved()` to add a guard-time private-IP reject. **GATED: protected partner surface** — per `CLAUDE.md`, any change to `partner-hatcher-launch.ts` requires a Codex adversarial pass + the mock-Hatcher harness gate before ship; logic is comment-equivalent, **no `PROTOCOL_VERSION` bump** (no wire change). Surfaced by the 2026-06-18 staging audit (Codex review).

--- a/docs/ultrathink-migration-decision.md
+++ b/docs/ultrathink-migration-decision.md
@@ -12,6 +12,12 @@
 > extended-reasoning support back later, start from §5 Option B
 > (port to Gemini 2.5 thinking mode).
 >
+> **SUPERSEDED note (2026-06-16):** this doc predates the OpenAI migration —
+> every "Gemini" reference below is historical. OpenAI (`openai-text-provider`
+> p95 + `openai-embedding-provider` p100) is now ClawVille's sole LLM backend;
+> both `gemini-*-provider` files were deleted. Future extended-reasoning work
+> should target OpenAI, not Gemini 2.5.
+>
 > **What was removed:**
 > - `packages/agent-runtime/src/plugins/ultrathink-provider.ts` (deleted)
 > - `ThinkingEffort`, `THINKING_BUDGET`, `AgentThinkingConfig`, `AGENT_THINKING_DEFAULTS` from `packages/shared/src/types/collaboration.ts`

--- a/packages/agent-runtime/src/eliza-runtime.ts
+++ b/packages/agent-runtime/src/eliza-runtime.ts
@@ -276,7 +276,9 @@ export class ElizaRuntime {
       knowledge: customization?.knowledge || [],
       plugins,
       settings: {
-        model: 'claude-3-5-haiku-20241022',
+        // Inert: text-model selection is by plugin PRIORITY (OpenClaw 100 > openai-text 95),
+        // NOT this field. Kept accurate after the Anthropic + Gemini scrubs.
+        model: 'gpt-4o-mini',
       } as any,
       style,
     };


### PR DESCRIPTION
Cleanup of the **NIT/LOW residue** the 2026-06-18 staging audit (my Claude agents + Codex dual review) surfaced. **None are regressions** — the 3 shipped session changes (portal SSRF, CF boot preflight, Gemini scrub, image port) were all verified INTACT, build-green, and live on staging.

### (b) Gemini-history cleanup
- `eliza-runtime.ts`: inert stale `model: 'claude-3-5-haiku-20241022'` → `gpt-4o-mini` (selection is by plugin **priority**; this field is ignored — comment added).
- `3dStructure.md:1031`: dated "Gemini providers only" changelog line tagged `[SUPERSEDED]`.
- `TODO.md` ElizaOS-v2 fact: "Gemini providers" → "OpenAI providers".
- `docs/ultrathink-migration-decision.md`: superseded note (Gemini refs historical; OpenAI sole backend).

### (c) Gated hardening task
New **Security hardening backlog** in `TODO.md`: **Hatcher launch-exchange SSRF parity** — `partner-hatcher-launch.ts:244` uses the *sync* host-allowlist guard vs portal's DNS-resolved guard. **LOW** (fixed-literal URL + `redirect:'manual'` + 10s timeout). **GATED** to the protected-partner-surface protocol (Codex + mock-Hatcher harness) before any ship; no `PROTOCOL_VERSION` bump.

**Verification:** `agent-runtime` tsc exit 0; no runtime/wire/behavior change (eliza literal is inert, rest is docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)