### PR TITLE
chore(infra): commit Meshy webhook receiver (Cloudflare Worker)

### DIFF
--- a/infra/meshy-webhook-worker/README.md
+++ b/infra/meshy-webhook-worker/README.md
@@ -1,0 +1,34 @@
+# clawville-meshy-webhook
+
+Cloudflare Worker that receives **Meshy task-status webhooks** (text/image-to-3D, rig, animate completion), verifies a shared secret, logs the payload, and returns `200`. Isolated from the ClawVille game API on purpose — this is asset-pipeline dev tooling.
+
+## Endpoints
+- `POST /` — Meshy posts the task object here on status change.
+- `GET /health` — liveness.
+
+## Deploy
+```bash
+cd infra/meshy-webhook-worker
+# CF auth comes from the keyring (CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID):
+set -a; source ~/.itachi-api-keys; set +a
+bunx wrangler deploy
+# set the shared secret (also pasted into Meshy's form) + the API key for later:
+printf '%s' "$MESHY_WEBHOOK_SECRET" | bunx wrangler secret put MESHY_WEBHOOK_SECRET
+printf '%s' "$MESHY_API_KEY"        | bunx wrangler secret put MESHY_API_KEY
+```
+Deployed URL: `https://clawville-meshy-webhook.<account-subdomain>.workers.dev`
+
+## Register in Meshy (dashboard-only — no API for this)
+Meshy → **API → Webhooks → Create Webhook**:
+- **Payload URL:** the deployed worker URL (`https://clawville-meshy-webhook.<…>.workers.dev/`)
+- **Secret:** the SAME value you set as `MESHY_WEBHOOK_SECRET`.
+
+## Signature verification (learn-then-lock)
+Meshy doesn't publicly document its signature header/algorithm. The worker ships in **non-strict** mode (`WEBHOOK_STRICT="false"`): it logs all non-secret headers so you can identify the real signature header from the first live delivery, then accepts. Watch a delivery:
+```bash
+bunx wrangler tail --format pretty
+```
+Once you see which header carries the signature (and confirm it's HMAC-SHA256 over the raw body with the secret), add it to `SIG_HEADER_CANDIDATES` if missing and set `WEBHOOK_STRICT="true"` in `wrangler.toml`, then redeploy to hard-reject forged deliveries.
+
+## Scaffolded (gated OFF): downstream auto-rig — `FEATURE_GATE: meshy_downstream_rig`
+`maybeTriggerDownstreamRig()` is stubbed and gated behind `ENABLE_DOWNSTREAM_RIG="true"`. When enabled later it will POST a SUCCEEDED mesh task to Meshy's rigging endpoint using `MESHY_API_KEY`. Keep it off until a live payload shape is captured (avoids firing paid rig calls blind).

--- a/infra/meshy-webhook-worker/package.json
+++ b/infra/meshy-webhook-worker/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "clawville-meshy-webhook",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "tail": "wrangler tail --format pretty"
+  },
+  "devDependencies": {
+    "wrangler": "^4.90.0"
+  }
+}

--- a/infra/meshy-webhook-worker/src/index.ts
+++ b/infra/meshy-webhook-worker/src/index.ts
@@ -1,0 +1,147 @@
+// ---------------------------------------------------------------------------
+// Cloudflare Worker — ClawVille Meshy webhook receiver
+// ---------------------------------------------------------------------------
+// Receives Meshy task-status events (POST /), verifies the shared secret,
+// logs the payload, and returns 200. Downstream auto-rig is SCAFFOLDED but
+// gated OFF (ENABLE_DOWNSTREAM_RIG !== "true").
+//
+// Meshy webhook registration is DASHBOARD-UI ONLY (no API). After deploying,
+// paste the worker URL + the MESHY_WEBHOOK_SECRET value into:
+//   Meshy → API → Webhooks → Create Webhook  (Payload URL + Secret).
+//
+// Meshy does NOT publicly document its signature header/algorithm, so v1 runs
+// in NON-STRICT mode: it logs all (non-secret) headers — so we can identify the
+// real signature header from the first live delivery — and accepts. Once the
+// header is known, flip WEBHOOK_STRICT="true" to hard-reject forged/unsigned
+// deliveries. See README.md.
+// ---------------------------------------------------------------------------
+
+export interface Env {
+  MESHY_WEBHOOK_SECRET?: string; // shared secret, also pasted into the Meshy form
+  MESHY_API_KEY?: string; // for the scaffolded downstream rig (option 4)
+  WEBHOOK_STRICT?: string; // "true" => require a verified signature
+  ENABLE_DOWNSTREAM_RIG?: string; // "true" => auto-submit mesh→rig on SUCCEEDED
+}
+
+// Header names webhook providers commonly use to carry the HMAC signature.
+const SIG_HEADER_CANDIDATES = [
+  "meshy-signature",
+  "x-meshy-signature",
+  "x-webhook-signature",
+  "webhook-signature",
+  "x-signature",
+  "x-hub-signature-256",
+];
+
+async function hmacSha256Hex(secret: string, body: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
+  return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let out = 0;
+  for (let i = 0; i < a.length; i++) out |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return out === 0;
+}
+
+// verified=true only on a CONFIRMED HMAC-SHA256 match against a known header.
+async function verify(
+  req: Request,
+  rawBody: string,
+  secret: string | undefined,
+): Promise<{ verified: boolean; detail: string }> {
+  if (!secret) return { verified: false, detail: "no secret configured" };
+  for (const h of SIG_HEADER_CANDIDATES) {
+    const provided = req.headers.get(h);
+    if (!provided) continue;
+    const expected = await hmacSha256Hex(secret, rawBody);
+    // tolerate "sha256=<hex>" style prefixes
+    const got = (provided.includes("=") ? provided.split("=").pop()! : provided).trim().toLowerCase();
+    if (timingSafeEqual(got, expected)) return { verified: true, detail: `HMAC-SHA256 ok via '${h}'` };
+    return { verified: false, detail: `header '${h}' present but MISMATCH` };
+  }
+  return { verified: false, detail: "no known signature header present" };
+}
+
+// FEATURE_GATE: meshy_downstream_rig
+// Status: scaffolded stub, gated OFF (ENABLE_DOWNSTREAM_RIG !== "true").
+// Metric to graduate: first live mesh gen confirmed arriving via this webhook.
+// On enable: POST the SUCCEEDED mesh task to Meshy's rigging endpoint using
+//   env.MESHY_API_KEY (payload shape locked from a real delivery first), then
+//   animate. Kept a no-op until then so we never fire PAID rig calls before the
+//   plumbing is confirmed.
+async function maybeTriggerDownstreamRig(env: Env, task: any): Promise<void> {
+  const succeeded = String(task?.status ?? "").toUpperCase() === "SUCCEEDED";
+  if (!succeeded) return;
+  if (env.ENABLE_DOWNSTREAM_RIG !== "true") {
+    console.log(`[downstream-rig] GATED OFF — would consider rig for SUCCEEDED task ${task?.id}`);
+    return;
+  }
+  // TODO(option 4): real implementation once a live payload shape is captured.
+  //   await fetch("https://api.meshy.ai/openapi/v1/rigging", {
+  //     method: "POST",
+  //     headers: { Authorization: `Bearer ${env.MESHY_API_KEY}`, "Content-Type": "application/json" },
+  //     body: JSON.stringify({ input_task_id: task.id, /* ... */ }),
+  //   });
+  console.log(`[downstream-rig] ENABLED (stub, not yet implemented) — task ${task?.id}`);
+}
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+
+    if (req.method === "GET" && url.pathname === "/health") {
+      return Response.json({ ok: true, service: "clawville-meshy-webhook" });
+    }
+    if (req.method !== "POST") {
+      return new Response("method not allowed", { status: 405 });
+    }
+
+    const rawBody = await req.text();
+    const strict = env.WEBHOOK_STRICT === "true";
+    const { verified, detail } = await verify(req, rawBody, env.MESHY_WEBHOOK_SECRET);
+
+    // Log non-secret headers so we can identify Meshy's signature scheme from
+    // the first real delivery, then lock WEBHOOK_STRICT="true".
+    const headerDump: Record<string, string> = {};
+    for (const [k, v] of req.headers) {
+      if (k.toLowerCase() === "authorization") continue;
+      headerDump[k] = v;
+    }
+    console.log(
+      `[meshy-webhook] verify=${verified} (${detail}) strict=${strict} headers=${JSON.stringify(headerDump)}`,
+    );
+
+    if (strict && !verified) {
+      console.warn("[meshy-webhook] REJECTED (strict mode, unverified)");
+      return Response.json({ ok: false, error: "unverified" }, { status: 401 });
+    }
+
+    let task: any = null;
+    try {
+      task = JSON.parse(rawBody);
+    } catch {
+      console.warn("[meshy-webhook] non-JSON body");
+    }
+    console.log(
+      `[meshy-webhook] task id=${task?.id} status=${task?.status} body=${rawBody.slice(0, 2000)}`,
+    );
+
+    try {
+      await maybeTriggerDownstreamRig(env, task);
+    } catch (e) {
+      console.error("[meshy-webhook] downstream error", e);
+    }
+
+    // MUST reply < 400 or Meshy treats it as a failed delivery.
+    return Response.json({ ok: true });
+  },
+};

--- a/infra/meshy-webhook-worker/tsconfig.json
+++ b/infra/meshy-webhook-worker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["esnext"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/infra/meshy-webhook-worker/wrangler.toml
+++ b/infra/meshy-webhook-worker/wrangler.toml
@@ -1,0 +1,24 @@
+#:schema node_modules/wrangler/config-schema.json
+# ---------------------------------------------------------------------------
+# Cloudflare Worker — ClawVille Meshy webhook receiver
+# ---------------------------------------------------------------------------
+# Deploys to clawville-meshy-webhook.<account>.workers.dev
+#   POST /        -- Meshy task-status events (verify secret, log, 200)
+#   GET  /health  -- liveness
+#
+# Secrets (NOT in this file — set via `wrangler secret put`):
+#   MESHY_WEBHOOK_SECRET  -- shared secret; paste the SAME value into Meshy's
+#                            Create-Webhook form "Secret" field.
+#   MESHY_API_KEY         -- only used when ENABLE_DOWNSTREAM_RIG="true" later.
+#
+# See ./README.md for deploy + Meshy registration steps.
+# ---------------------------------------------------------------------------
+
+name = "clawville-meshy-webhook"
+main = "src/index.ts"
+compatibility_date = "2024-11-06"
+workers_dev = true
+
+[vars]
+WEBHOOK_STRICT = "false"        # flip to "true" once the signature header is known
+ENABLE_DOWNSTREAM_RIG = "false" # scaffolded option-4 auto-rig; keep off until confirmed


### PR DESCRIPTION
Adds the **Meshy webhook receiver** to `infra/` (parallels `infra/cf-secrets-worker`). Asset-pipeline dev tooling — **not** built/deployed by Coolify, no game-runtime impact.

- Receives Meshy task-status webhooks (`POST /`), verifies a shared secret (learn-then-lock; non-strict until the signature header is identified from a live delivery), logs the payload, returns 200.
- Downstream auto-rig **scaffolded but gated OFF** (`ENABLE_DOWNSTREAM_RIG !== "true"`).
- Deployed directly to Cloudflare via wrangler at `clawville-meshy-webhook.444hoodie.workers.dev`. Secrets (`MESHY_WEBHOOK_SECRET`, `MESHY_API_KEY`) live as **CF Worker secrets**, not in source — secret-scanned clean before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)