### PR TITLE
fix(world): readable town directory sign (triangle board, replaces unreadable fingerpost)

### DIFF
--- a/3dStructure.md
+++ b/3dStructure.md
@@ -1104,22 +1104,22 @@ Older history: `git log apps/web/src/lib/three/ apps/web/src/components/three/`.
 
 `apps/web/src/lib/three/arena-buildings.tsx` `triggerCoveWalkIn()` dispatches a `'cove-walkin-start'` DOM CustomEvent when the walk-in starts. `World3DCanvas.tsx` new `CoveEntranceCameraPush` component (mounted in SceneContents, after JumpTicker) listens for this event and for 1.2s smoothly lerps the camera slightly toward the cove (X=-4160, slight Y pull-down) using a cubic ease-out. All lerp values are module-scope scratch (`_covePushTarget`, `_covePushScratch`), zero per-frame allocations. Total entrance flow ≤3s (1.2s push + existing 500ms fade + /cove page-in 500ms).
 
-### §15.3 — Town directional fingerpost (Task 3)
+### §15.3 — Town directory board (Task 3; REVISED 2026-06-19 — single readable board, replaces the 3-arm fingerpost)
 
-`apps/web/src/lib/three/town-directory-sign.tsx` fully rewritten. Old content: two-post wooden board with a static inaccurate PNG (`/town-directory-sign.png` — "Auction / Bazaar / Marketplace", all paused). New content: 3-arm directional fingerpost with CanvasTexture-baked labels.
+`apps/web/src/lib/three/town-directory-sign.tsx`. **Revision history:** old static inaccurate PNG → 3-arm fingerpost → **single front-facing triangle board (current).** The 3-arm fingerpost FAILED founder review: each arm pointed in its literal world direction, so the forward (Bounty) arm's flat text sat edge-on to the spawn camera (unreadable), and the baked labels were too small at spawn distance. The founder asked for the old flat-board readability with the words in a triangle showing directions.
 
-**Geometry:** central hex-prism post (CylinderGeometry, 6 segments, post+cap merged), 3 arm planks (BoxGeometry main + tip), 3 face planes (PlaneGeometry with CanvasTexture). All geometry at module scope, mergeGeometries-merged where possible.
+**Current design — one readable board facing the player:** a single wooden board mounted ON TOP of a hex-prism post (board centered at `y = POST_HEIGHT(260) + BOARD_H/2(150) = 410`, so the post never occludes the board face — the old fingerpost/FOR-SALE-sign post-occlusion trap). Board 400×300×16 wu + crossbar, all merged module-scope geometry. One player-facing (+Z) `PlaneGeometry(376×276)` carries a single CanvasTexture (1024×768, 4:3).
 
-**Arm directions (verified against live collision data):**
-| Arm | rotY | World direction | Destination | World coords |
+**CanvasTexture = triangle layout (player at spawn faces −Z / south; on the +Z face):**
+| Position on board | Glyph | Destination | World dir from player | World coords |
 |---|---|---|---|---|
-| BOUNTY BOARD (↑) | -π/2 | -Z (north) | quest-bounty-pavilion | (0, -1220) |
-| EXCHANGE (→) | 0 | +X (east) | marketplace-stall | (+1273, -120) |
-| COSMETICS (←) | +π | -X (west) | bazaar-stall | (-1273, -120) |
+| TOP centre | ↑ (cyan) | BOUNTY BOARD | straight ahead (south) | (0, −1220) |
+| BOTTOM-RIGHT | → (gold) | EXCHANGE | player's right (east) | (+1273, −120) |
+| BOTTOM-LEFT | ← (magenta) | COSMETICS | player's left (west) | (−1273, −120) |
 
-**CanvasTexture design:** dark wood-grain plank, carved border, colored arrow glyph (cyan=bounty, gold=exchange, magenta=cosmetics), label in warm-white. Side DoubleSide so arms are readable from both directions.
+Title "TOWN CENTER" + carved double border + wood grain. Big high-contrast text (arrows 92–116px, labels 58–70px, warm-white `#fbf3e2` with dark shadow, colored glowing arrows). `anisotropy=8` for crispness at distance. Direction correctness: camera looks −Z with up +Y → camera-right = +X (east), so the texture's right = east = Exchange ✓, left = west = Cosmetics ✓, top = "straight ahead" wayfinding convention = Bounty ✓.
 
-**No async loading.** Old PNG load race (img.onload) eliminated. Textures baked synchronously at module load (`bakeArmTexture()`). SSR-safe: guarded by `typeof document !== 'undefined'`, materials fall back to panel color for SSR.
+**Single-faced** (front +Z only; primary view is the spawn/north side). **No async loading** (no PNG; texture baked synchronously at module load, SSR-guarded by `typeof document`, falls back to wood material for SSR). No drei Text/Billboard, no ShaderMaterial, no per-frame allocs.
 
 ### §15.4 — Spawn scatter (Task 4)
 

--- a/apps/web/src/lib/three/town-directory-sign.tsx
+++ b/apps/web/src/lib/three/town-directory-sign.tsx
@@ -1,24 +1,26 @@
 'use client';
 
 /**
- * TownDirectorySign — 3-arm directional fingerpost at town centre.
+ * TownDirectorySign — a single readable directory board at town centre.
  *
- * Replaces the old inaccurate static PNG (auction/bazaar/marketplace —
- * all paused features) with accurate CanvasTexture-baked arm signs
- * pointing to the three active destinations from the town square.
+ * History: the old static PNG ("Auction / Bazaar / Marketplace") was
+ * inaccurate (all paused). A first rework used a 3-arm fingerpost, but the
+ * arms pointed in literal world directions, so the forward (Bounty) arm's
+ * text sat edge-on to the player and the baked labels were too small —
+ * unreadable. This version is what the founder asked for: ONE flat board
+ * facing the player with the three live destinations laid out as a TRIANGLE
+ * (forward on top, the two flanks below) with big, high-contrast labels.
  *
- * Arm destinations (from the player standing at spawn facing north, the
- * sign being north of them at world Z=-120):
- *   FORWARD / ↑ = Bounty Board   world (0, -1220) — further north
- *   RIGHT   / → = Exchange        world (+1273, -120) — east
- *   LEFT    / ← = Cosmetics       world (-1273, -120) — west
+ * Direction model — player stands at spawn (camera north of the sign,
+ * looking SOUTH at it). On the board's player-facing (+Z) side:
+ *   TOP    ↑  = Bounty Board   (straight ahead / south, world z≈-1220)
+ *   RIGHT  →  = Exchange        (player's right / east,  world x≈+1273)
+ *   LEFT   ←  = Cosmetics       (player's left  / west,  world x≈-1273)
  *
- * All text is baked into CanvasTextures on PlaneGeometry faces.
- * NO drei <Text> / <Billboard> — hard GPU crash on Iris Xe.
- * NO ShaderMaterial — silent WebGPU crash.
- * NO per-frame allocations — component is a pure static mesh, no useFrame.
- *
- * Geometry is built once at module scope and never recreated.
+ * All text is baked into a CanvasTexture on a PlaneGeometry. NO drei
+ * <Text>/<Billboard> (Iris-Xe crash), NO ShaderMaterial (WebGPU crash),
+ * NO per-frame allocation (pure static mesh, no useFrame). Geometry +
+ * materials are built once at module scope.
  *
  * town-ux-2026-06-19
  */
@@ -26,120 +28,160 @@
 import * as THREE from 'three/webgpu';
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 
-// ---------------------------------------------------------------------------
-// Sign world position
-// ---------------------------------------------------------------------------
+// ─── Sign world position ────────────────────────────────────────────────────
 const SIGN_X = 0;
-const SIGN_Y = 0;   // posts rest on sand (sand ≈ Y=-2)
+const SIGN_Y = 0; // post rests on sand (sand ≈ Y=-2)
 const SIGN_Z = -120;
 
-// ---------------------------------------------------------------------------
-// Geometry constants
-// ---------------------------------------------------------------------------
-const POST_RADIUS  = 10;
-const POST_HEIGHT  = 420;
-const POST_SEGS    = 6;      // hex prism — efficient, distinct from rectangular arms
+// ─── Geometry constants ─────────────────────────────────────────────────────
+const POST_RADIUS = 11;
+const POST_HEIGHT = 260;
+const POST_SEGS = 6; // hex prism
 
-const ARM_W  = 280;    // length along the arm's local X axis
-const ARM_H  = 90;     // plank height
-const ARM_D  = 14;     // plank depth
-const ARM_Y  = 340;    // height above post base where arms attach
-
-// Point (triangle tip) at the destination end of each arm — gives the
-// fingerpost silhouette. Built as a thin box at 60% width + 40% width.
-const TIP_W  = ARM_W * 0.25;
-const TIP_H  = ARM_H * 0.7;
+const BOARD_W = 400;
+const BOARD_H = 300;
+const BOARD_D = 16;
+const BOARD_CY = POST_HEIGHT + BOARD_H / 2; // board sits ON TOP of the post (no front occlusion)
 
 const WOOD_COLOR = 0x6b3a1f;
-const PANEL_COLOR = 0x4a2810;
+const FRAME_COLOR = 0x4a2810;
 
-// ---------------------------------------------------------------------------
-// CanvasTexture baking helpers
-// ---------------------------------------------------------------------------
-const ARM_TEX_W = 512;
-const ARM_TEX_H = 128;
+// ─── CanvasTexture baking ────────────────────────────────────────────────────
+const TEX_W = 1024;
+const TEX_H = 768; // 4:3 to match BOARD_W:BOARD_H (400:300)
 
-function bakeArmTexture(label: string, arrow: '↑' | '→' | '←', color: string): THREE.CanvasTexture {
+function bakeDirectoryTexture(): THREE.CanvasTexture {
   const canvas = document.createElement('canvas');
-  canvas.width  = ARM_TEX_W;
-  canvas.height = ARM_TEX_H;
+  canvas.width = TEX_W;
+  canvas.height = TEX_H;
   const ctx = canvas.getContext('2d')!;
 
-  // Background — dark plank
-  ctx.fillStyle = '#2e1508';
-  ctx.fillRect(0, 0, ARM_TEX_W, ARM_TEX_H);
+  // Wood plank background (vertical gradient)
+  const grad = ctx.createLinearGradient(0, 0, 0, TEX_H);
+  grad.addColorStop(0, '#3a1d0d');
+  grad.addColorStop(1, '#281207');
+  ctx.fillStyle = grad;
+  ctx.fillRect(0, 0, TEX_W, TEX_H);
 
-  // Carved-wood border
-  ctx.strokeStyle = '#7c5230';
-  ctx.lineWidth   = 3;
-  ctx.strokeRect(3, 3, ARM_TEX_W - 6, ARM_TEX_H - 6);
-
-  // Wood grain lines (subtle)
-  ctx.strokeStyle = 'rgba(100,60,20,0.25)';
-  ctx.lineWidth = 1;
-  for (let y = 16; y < ARM_TEX_H - 8; y += 12) {
+  // Subtle horizontal grain
+  ctx.strokeStyle = 'rgba(120,72,30,0.16)';
+  ctx.lineWidth = 2;
+  for (let y = 24; y < TEX_H; y += 24) {
     ctx.beginPath();
-    ctx.moveTo(8, y);
-    ctx.lineTo(ARM_TEX_W - 8, y);
+    ctx.moveTo(0, y);
+    ctx.lineTo(TEX_W, y);
     ctx.stroke();
   }
 
-  // Arrow glyph
-  ctx.shadowColor  = color;
-  ctx.shadowBlur   = 10;
-  ctx.font         = 'bold 42px Arial, sans-serif';
+  // Carved double border
+  ctx.strokeStyle = '#8a5a30';
+  ctx.lineWidth = 12;
+  ctx.strokeRect(16, 16, TEX_W - 32, TEX_H - 32);
+  ctx.strokeStyle = 'rgba(0,0,0,0.5)';
+  ctx.lineWidth = 2;
+  ctx.strokeRect(30, 30, TEX_W - 60, TEX_H - 60);
+
+  ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  const arrowWidth = 48;
 
-  let arrowX: number;
-  let labelX: number;
-  if (arrow === '→') {
-    // Arrow on the right (pointing east)
-    arrowX = ARM_TEX_W - arrowWidth - 12;
-    ctx.textAlign = 'left';
-    labelX = 16;
-  } else if (arrow === '←') {
-    // Arrow on the left (pointing west)
-    arrowX = 12;
-    ctx.textAlign = 'right';
-    labelX = ARM_TEX_W - 16;
-  } else {
-    // Arrow on top-center for ↑ (Bounty Board, pointing north)
-    arrowX = ARM_TEX_W / 2 - 24;
-    ctx.textAlign = 'center';
-    labelX = ARM_TEX_W / 2;
-  }
-
-  ctx.fillStyle = color;
-  ctx.fillText(arrow, arrowX, ARM_TEX_H / 2);
+  // Title
+  ctx.fillStyle = '#e8c89a';
+  ctx.font = 'bold 56px Georgia, serif';
+  ctx.shadowColor = 'rgba(0,0,0,0.75)';
+  ctx.shadowBlur = 6;
+  ctx.fillText('TOWN CENTER', TEX_W / 2, 78);
   ctx.shadowBlur = 0;
+  ctx.strokeStyle = 'rgba(138,90,48,0.7)';
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.moveTo(140, 124);
+  ctx.lineTo(TEX_W - 140, 124);
+  ctx.stroke();
 
-  // Label text
-  ctx.font         = 'bold 28px Arial, sans-serif';
-  ctx.fillStyle    = '#f5e8d0';
-  ctx.shadowColor  = 'rgba(0,0,0,0.8)';
-  ctx.shadowBlur   = 4;
-  if (arrow === '↑') {
-    ctx.textAlign = 'center';
-    ctx.fillText(label, ARM_TEX_W / 2 + 24, ARM_TEX_H / 2);
-  } else if (arrow === '→') {
-    ctx.textAlign = 'left';
-    ctx.fillText(label, labelX, ARM_TEX_H / 2);
-  } else {
-    ctx.textAlign = 'right';
-    ctx.fillText(label, labelX, ARM_TEX_H / 2);
+  // ── TOP (forward): ↑ Bounty Board — arrow above the label, centred ──
+  drawArrow('↑', TEX_W / 2, 250, '#3ff0e0', 116);
+  drawLabel('BOUNTY BOARD', TEX_W / 2, 350);
+
+  // ── BOTTOM-LEFT: ← Cosmetics ──
+  drawInline('←', 'COSMETICS', TEX_W * 0.26, 600, '#ff86e0', 'arrowLeft');
+  // ── BOTTOM-RIGHT: Exchange → ──
+  drawInline('→', 'EXCHANGE', TEX_W * 0.74, 600, '#ffd24a', 'arrowRight');
+
+  function drawArrow(glyph: string, x: number, y: number, color: string, size: number) {
+    ctx.font = `bold ${size}px Arial, sans-serif`;
+    ctx.fillStyle = color;
+    ctx.shadowColor = color;
+    ctx.shadowBlur = 22;
+    ctx.fillText(glyph, x, y);
+    ctx.shadowBlur = 0;
   }
-  ctx.shadowBlur = 0;
+  function drawLabel(text: string, x: number, y: number) {
+    ctx.font = 'bold 70px Georgia, serif';
+    ctx.fillStyle = '#fbf3e2';
+    ctx.shadowColor = 'rgba(0,0,0,0.85)';
+    ctx.shadowBlur = 5;
+    ctx.fillText(text, x, y);
+    ctx.shadowBlur = 0;
+  }
+  // arrow + label on one baseline, centred as a unit
+  function drawInline(
+    glyph: string,
+    label: string,
+    centerX: number,
+    y: number,
+    color: string,
+    mode: 'arrowLeft' | 'arrowRight',
+  ) {
+    const arrowFont = 'bold 92px Arial, sans-serif';
+    const labelFont = 'bold 58px Georgia, serif';
+    ctx.font = arrowFont;
+    const aw = ctx.measureText(glyph).width;
+    ctx.font = labelFont;
+    const lw = ctx.measureText(label).width;
+    const gap = 22;
+    const total = aw + gap + lw;
+    let x = centerX - total / 2;
+    ctx.textAlign = 'left';
+    if (mode === 'arrowLeft') {
+      ctx.font = arrowFont;
+      ctx.fillStyle = color;
+      ctx.shadowColor = color;
+      ctx.shadowBlur = 20;
+      ctx.fillText(glyph, x, y);
+      ctx.shadowBlur = 0;
+      x += aw + gap;
+      ctx.font = labelFont;
+      ctx.fillStyle = '#fbf3e2';
+      ctx.shadowColor = 'rgba(0,0,0,0.85)';
+      ctx.shadowBlur = 5;
+      ctx.fillText(label, x, y);
+      ctx.shadowBlur = 0;
+    } else {
+      ctx.font = labelFont;
+      ctx.fillStyle = '#fbf3e2';
+      ctx.shadowColor = 'rgba(0,0,0,0.85)';
+      ctx.shadowBlur = 5;
+      ctx.fillText(label, x, y);
+      ctx.shadowBlur = 0;
+      x += lw + gap;
+      ctx.font = arrowFont;
+      ctx.fillStyle = color;
+      ctx.shadowColor = color;
+      ctx.shadowBlur = 20;
+      ctx.fillText(glyph, x, y);
+      ctx.shadowBlur = 0;
+    }
+    ctx.textAlign = 'center';
+  }
 
   const tex = new THREE.CanvasTexture(canvas);
   tex.colorSpace = THREE.SRGBColorSpace;
+  tex.anisotropy = 8; // stay crisp at grazing angles / distance
   tex.needsUpdate = true;
   return tex;
 }
 
-// ---------------------------------------------------------------------------
-// Module-scope geometry
-// ---------------------------------------------------------------------------
+// ─── Module-scope geometry ───────────────────────────────────────────────────
 function translatedGeo(geo: THREE.BufferGeometry, x: number, y: number, z: number) {
   const g = geo.clone();
   g.clearGroups();
@@ -147,139 +189,59 @@ function translatedGeo(geo: THREE.BufferGeometry, x: number, y: number, z: numbe
   return g;
 }
 
-// Central hex post
 const _postGeo = new THREE.CylinderGeometry(POST_RADIUS, POST_RADIUS * 1.3, POST_HEIGHT, POST_SEGS);
-const _capGeo  = new THREE.CylinderGeometry(POST_RADIUS * 1.6, POST_RADIUS, 20, POST_SEGS);
-
-const postMergedGeo = mergeGeometries([
-  translatedGeo(_postGeo, 0, POST_HEIGHT / 2, 0),
-  translatedGeo(_capGeo,  0, POST_HEIGHT + 8, 0),
-]) ?? _postGeo.clone();
+const _capGeo = new THREE.CylinderGeometry(POST_RADIUS * 1.5, POST_RADIUS, 18, POST_SEGS);
+const postMergedGeo =
+  mergeGeometries([
+    translatedGeo(_postGeo, 0, POST_HEIGHT / 2, 0),
+    translatedGeo(_capGeo, 0, POST_HEIGHT + 6, 0),
+  ]) ?? _postGeo.clone();
 postMergedGeo.computeBoundingBox();
 postMergedGeo.computeBoundingSphere();
 
-// Arm plank geometry (pointing in +X direction; rotate in JSX to aim each arm)
-// Main plank body
-const _armBodyGeo = new THREE.BoxGeometry(ARM_W, ARM_H, ARM_D);
-// Tip (pointed end) — extra bit at the +X end to simulate fingerpost arrow
-const _armTipGeo  = new THREE.BoxGeometry(TIP_W, TIP_H, ARM_D);
-const armPlanksGeo = mergeGeometries([
-  translatedGeo(_armBodyGeo, ARM_W / 2, 0, 0),
-  translatedGeo(_armTipGeo,  ARM_W + TIP_W / 2 - 2, 0, 0),
-]) ?? _armBodyGeo.clone();
-armPlanksGeo.computeBoundingBox();
-armPlanksGeo.computeBoundingSphere();
+// Wooden board backing (visible from behind) + a crossbar tying it to the post
+const _boardGeo = new THREE.BoxGeometry(BOARD_W, BOARD_H, BOARD_D);
+const _crossbarGeo = new THREE.BoxGeometry(40, 70, BOARD_D + 4);
+const boardMergedGeo =
+  mergeGeometries([
+    translatedGeo(_boardGeo, 0, BOARD_CY, 0),
+    translatedGeo(_crossbarGeo, 0, POST_HEIGHT - 10, 0),
+  ]) ?? _boardGeo.clone();
+boardMergedGeo.computeBoundingBox();
+boardMergedGeo.computeBoundingSphere();
 
-// Face plane for the CanvasTexture label — same X orientation as armPlanksGeo
-const _armFacePlane = new THREE.PlaneGeometry(ARM_W - 16, ARM_H - 16);
+// Player-facing texture plane (front, +Z)
+const _facePlane = new THREE.PlaneGeometry(BOARD_W - 24, BOARD_H - 24);
 
-// ---------------------------------------------------------------------------
-// Module-scope materials — instantiated once
-// ---------------------------------------------------------------------------
+// ─── Module-scope materials ──────────────────────────────────────────────────
 const woodMat = new THREE.MeshBasicMaterial({ color: WOOD_COLOR });
-const panelMat = new THREE.MeshBasicMaterial({ color: PANEL_COLOR });
+void FRAME_COLOR;
 
-// Per-arm face materials, allocated at module load (SSR-safe: guarded by typeof window)
-let matBounty: THREE.MeshBasicMaterial | null   = null;
-let matExchange: THREE.MeshBasicMaterial | null = null;
-let matCosmetics: THREE.MeshBasicMaterial | null = null;
-
+let faceMat: THREE.MeshBasicMaterial | null = null;
 if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-  matBounty = new THREE.MeshBasicMaterial({
-    map: bakeArmTexture('Bounty Board', '↑', '#00ffee'),
+  faceMat = new THREE.MeshBasicMaterial({
+    map: bakeDirectoryTexture(),
     transparent: true,
     depthWrite: false,
-    side: THREE.DoubleSide,
-    toneMapped: false,
-  });
-  matExchange = new THREE.MeshBasicMaterial({
-    map: bakeArmTexture('Exchange', '→', '#ffe040'),
-    transparent: true,
-    depthWrite: false,
-    side: THREE.DoubleSide,
-    toneMapped: false,
-  });
-  matCosmetics = new THREE.MeshBasicMaterial({
-    map: bakeArmTexture('Cosmetics', '←', '#ff80ff'),
-    transparent: true,
-    depthWrite: false,
-    side: THREE.DoubleSide,
     toneMapped: false,
   });
 }
 
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
+// ─── Component ───────────────────────────────────────────────────────────────
 export default function TownDirectorySign() {
-  // Panel material fallback for SSR (no canvas available server-side)
-  const bMat  = matBounty   ?? panelMat;
-  const eMat  = matExchange  ?? panelMat;
-  const cMat  = matCosmetics ?? panelMat;
-
+  const fMat = faceMat ?? woodMat;
   return (
     <group
       position={[SIGN_X, SIGN_Y, SIGN_Z]}
       userData={{ isOccluder: true }}
       name="town-directory-sign"
     >
-      {/* Central post + cap */}
+      {/* Post + cap + board backing (single merged wooden mesh + the post) */}
       <mesh geometry={postMergedGeo} material={woodMat} />
+      <mesh geometry={boardMergedGeo} material={woodMat} />
 
-      {/* ── BOUNTY BOARD arm — points NORTH (−Z in world). ──
-          The arm plank geometry extends in local +X.
-          rotY = -π/2: maps local +X → world -Z (north, toward Bounty Board). */}
-      <group position={[0, ARM_Y, 0]} rotation={[0, -Math.PI / 2, 0]}>
-        <mesh geometry={armPlanksGeo} material={woodMat} />
-        {/* Label face — slightly in front of plank (+Z local = world +X after rotation; both sides rendered) */}
-        <mesh
-          geometry={_armFacePlane}
-          material={bMat}
-          position={[ARM_W / 2, 0, ARM_D / 2 + 1]}
-        />
-        {/* Back face */}
-        <mesh
-          geometry={_armFacePlane}
-          material={bMat}
-          position={[ARM_W / 2, 0, -(ARM_D / 2 + 1)]}
-          rotation={[0, Math.PI, 0]}
-        />
-      </group>
-
-      {/* ── EXCHANGE arm — points EAST (+X in world). ──
-          rotY = 0: arm extends in local +X = world +X (east, toward Exchange). */}
-      <group position={[0, ARM_Y + ARM_H + 8, 0]} rotation={[0, 0, 0]}>
-        <mesh geometry={armPlanksGeo} material={woodMat} />
-        <mesh
-          geometry={_armFacePlane}
-          material={eMat}
-          position={[ARM_W / 2, 0, ARM_D / 2 + 1]}
-        />
-        <mesh
-          geometry={_armFacePlane}
-          material={eMat}
-          position={[ARM_W / 2, 0, -(ARM_D / 2 + 1)]}
-          rotation={[0, Math.PI, 0]}
-        />
-      </group>
-
-      {/* ── COSMETICS arm — points WEST (−X in world). ──
-          rotY = π: maps local +X → world -X (west, toward Cosmetics / Bazaar).
-          Stacked another ARM_H above exchange arm so arms don't clip each other. */}
-      <group position={[0, ARM_Y + (ARM_H + 8) * 2, 0]} rotation={[0, Math.PI, 0]}>
-        <mesh geometry={armPlanksGeo} material={woodMat} />
-        <mesh
-          geometry={_armFacePlane}
-          material={cMat}
-          position={[ARM_W / 2, 0, ARM_D / 2 + 1]}
-        />
-        <mesh
-          geometry={_armFacePlane}
-          material={cMat}
-          position={[ARM_W / 2, 0, -(ARM_D / 2 + 1)]}
-          rotation={[0, Math.PI, 0]}
-        />
-      </group>
+      {/* Player-facing (+Z) texture board — the readable triangle directory */}
+      <mesh geometry={_facePlane} material={fMat} position={[0, BOARD_CY, BOARD_D / 2 + 1.5]} />
     </group>
   );
 }


### PR DESCRIPTION
Founder flagged the town-center directory sign as unreadable. The 3-arm fingerpost pointed each arm in its literal world direction, so the forward (Bounty) arm's text was edge-on to the spawn camera and all labels were too small.

Replaced with a single front-facing wooden board with the three live destinations in a **triangle**:
- ↑ **Bounty Board** (forward)
- ← **Cosmetics** (left/west) · **Exchange** → (right/east)

Big high-contrast baked CanvasTexture; board mounted on top of the post (no occlusion); Iris-Xe-safe. Verified readable in-browser on localhost. Same-diff doc: 3dStructure.md §15.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)