### PR TITLE
feat(cosmetics): Phase B proportion-aware hat/glasses fit + chibi geometric fix

### DIFF
--- a/apps/web/src/app/preview/cosmetics/CosmeticsPreviewScene.tsx
+++ b/apps/web/src/app/preview/cosmetics/CosmeticsPreviewScene.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+/**
+ * CosmeticsPreviewScene — dev/QA only.
+ *
+ * Per-avatar cosmetic tuner: pick ONE avatar, the camera zooms to it, and you get
+ * the full hat + glasses knobs to perfect THAT avatar. Bake the values, move on.
+ * Base placement comes from computeCosmeticHeadFit (auto-fit, or bone-anchored
+ * override for hermes/chibi); the sliders apply NUDGES on top + the scalp-hide
+ * radius. WebGL renderer (screenshottable).
+ */
+
+import { Suspense, useEffect, useRef, useState } from 'react';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import * as THREE from 'three';
+
+import { useVRMInstance, disposeVRMInstance } from '@/lib/three/vrm-loader';
+import {
+  computeVRMAvatarFit,
+  computeCosmeticHeadFit,
+  hideHeadGeometryUnderHat,
+  RIG_HEAD_OVERRIDE,
+} from '@/lib/three/vrm-avatar-sizing';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { MeshoptDecoder } from 'meshoptimizer';
+import { applyFattenedFrustumCulling } from '@/lib/three/vrm-loader';
+
+// ---------------------------------------------------------------------------
+// Avatars
+// ---------------------------------------------------------------------------
+
+interface AvatarDef {
+  instanceId: string;
+  vrmPath: string;
+  animatorId: string;
+  rigKey: string;
+  label: string;
+  xOffset: number;
+  focusY: number; // approx head world-Y for the focus camera
+}
+
+const AVATARS: AvatarDef[] = [
+  { instanceId: 'cp-milady', vrmPath: '/avatars/milady-official-1.vrm', animatorId: 'vrm-milady',   rigKey: 'milady', label: 'Milady', xOffset: -600, focusY: 250 },
+  { instanceId: 'cp-hermes', vrmPath: '/avatars/hermes-female.vrm',     animatorId: 'hermes-female', rigKey: 'hermes', label: 'Hermes', xOffset: -300, focusY: 250 },
+  { instanceId: 'cp-tekk',   vrmPath: '/avatars/tekk.vrm',              animatorId: 'tekk',          rigKey: 'tekk',   label: 'Tekk',   xOffset: 0,    focusY: 300 },
+  { instanceId: 'cp-phanes', vrmPath: '/avatars/phanes.vrm?v=1',        animatorId: 'hermes-male',   rigKey: 'phanes', label: 'Phanes', xOffset: 300,  focusY: 270 },
+  { instanceId: 'cp-chibi',  vrmPath: '/avatars/eliza-chibi.vrm?v=2',   animatorId: 'chibi',         rigKey: 'chibi',  label: 'chibi',  xOffset: 600,  focusY: 90 },
+];
+
+const HAT_URL = '/cosmetics/hats/top-hat.glb';
+const GLASSES_URL = '/cosmetics/glasses/classic-black.glb';
+
+// ---------------------------------------------------------------------------
+// Per-rig NUDGE state (what the sliders edit; bake into the code when happy)
+// ---------------------------------------------------------------------------
+
+interface Nudge {
+  hatY: number; hatScale: number; hatRot: number;       // hat: up/down (wu), size ×, tilt-back (rad)
+  glY: number; glScale: number; glFwd: number;          // glasses: up/down (wu), size ×, forward (wu)
+  hideR: number;                                         // scalp-hide radius, fraction of head width
+}
+function defaultNudge(): Nudge {
+  return { hatY: 0, hatScale: 1, hatRot: 0, glY: 0, glScale: 1, glFwd: 0, hideR: 0.62 };
+}
+type NudgeMap = Record<string, Nudge>;
+function defaultNudges(): NudgeMap {
+  const m: NudgeMap = {};
+  for (const a of AVATARS) m[a.rigKey] = defaultNudge();
+  return m;
+}
+
+// ---------------------------------------------------------------------------
+// Loaders
+// ---------------------------------------------------------------------------
+
+let _glbLoader: GLTFLoader | null = null;
+function getGLBLoader(): GLTFLoader {
+  if (!_glbLoader) { _glbLoader = new GLTFLoader(); _glbLoader.setMeshoptDecoder(MeshoptDecoder); }
+  return _glbLoader;
+}
+const _glbCache = new Map<string, Promise<THREE.Group>>();
+function loadCosmetic(url: string): Promise<THREE.Group> {
+  let p = _glbCache.get(url);
+  if (!p) {
+    p = new Promise<THREE.Group>((resolve, reject) => {
+      getGLBLoader().load(url, (g) => { applyFattenedFrustumCulling(g.scene); resolve(g.scene); }, undefined, reject);
+    });
+    _glbCache.set(url, p);
+  }
+  return p.then((g) => g.clone(true));
+}
+function disposeGroup(g: THREE.Object3D) {
+  g.traverse((c) => {
+    if ((c as THREE.Mesh).isMesh) {
+      (c as THREE.Mesh).geometry?.dispose();
+      const mat = (c as THREE.Mesh).material;
+      if (Array.isArray(mat)) mat.forEach((m) => m.dispose()); else mat?.dispose();
+    }
+  });
+}
+const _box = new THREE.Box3();
+const _size = new THREE.Vector3();
+const _scale = new THREE.Vector3();
+const _pos = new THREE.Vector3();
+
+// ---------------------------------------------------------------------------
+// One avatar + its cosmetics (re-attaches when its nudge changes)
+// ---------------------------------------------------------------------------
+
+function AvatarWithCosmetics({ def, nudge }: { def: AvatarDef; nudge: Nudge }) {
+  const vrm = useVRMInstance(def.vrmPath, def.instanceId);
+  const groupRef = useRef<THREE.Group>(null);
+
+  useEffect(() => {
+    if (!vrm || !groupRef.current) return;
+    const group = groupRef.current;
+    const { scale, offsetY } = computeVRMAvatarFit(vrm, def.animatorId);
+    vrm.scene.scale.setScalar(scale);
+    vrm.scene.position.set(0, offsetY, 0);
+    group.add(vrm.scene);
+    vrm.scene.updateMatrixWorld(true);
+    return () => { group.remove(vrm.scene); disposeVRMInstance(def.vrmPath, def.instanceId); };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [vrm, def.instanceId, def.animatorId, def.vrmPath]);
+
+  const nKey = `${nudge.hatY},${nudge.hatScale},${nudge.hatRot},${nudge.glY},${nudge.glScale},${nudge.glFwd},${nudge.hideR}`;
+
+  useEffect(() => {
+    if (!vrm) return;
+    let mounted = true;
+    const attached: THREE.Group[] = [];
+    const restores: Array<() => void> = [];
+    const headBone = vrm.humanoid?.getRawBoneNode?.('head') ?? null;
+    const { scale } = computeVRMAvatarFit(vrm, def.animatorId);
+    const override = RIG_HEAD_OVERRIDE[def.rigKey]; // auto-fit for milady/tekk/phanes; bone-anchored for hermes/chibi
+
+    (async () => {
+      for (const category of ['hat', 'glasses'] as const) {
+        const url = category === 'hat' ? HAT_URL : GLASSES_URL;
+        let glb: THREE.Group;
+        try { glb = await loadCosmetic(url); } catch { continue; }
+        if (!mounted || !headBone) { disposeGroup(glb); continue; }
+        const fit = computeCosmeticHeadFit(vrm, category, scale, def.rigKey, override);
+        if (!fit) { disposeGroup(glb); continue; }
+        _box.setFromObject(glb); _box.getSize(_size);
+        const assetW = _size.x;
+        headBone.getWorldScale(_scale);
+        const boneSX = _scale.x;
+        let s = 1;
+        if (assetW > 1e-6 && boneSX > 1e-6) s = Math.max(0.01, Math.min(1000, fit.desiredWorldWidth / (assetW * boneSX)));
+
+        const grp = new THREE.Group();
+        grp.name = `cosmetic-preview-${category}`;
+        grp.position.copy(fit.localPosition);
+        grp.scale.setScalar(s);
+        if (category === 'hat') {
+          grp.position.y += nudge.hatY;
+          grp.scale.multiplyScalar(nudge.hatScale);
+          grp.rotation.x += nudge.hatRot;
+        } else {
+          grp.position.y += nudge.glY;
+          grp.position.z += nudge.glFwd;
+          grp.scale.multiplyScalar(nudge.glScale);
+        }
+        grp.frustumCulled = false;
+        grp.add(glb);
+        headBone.add(grp);
+        attached.push(grp);
+
+        if (category === 'hat') {
+          grp.updateWorldMatrix(true, false);
+          grp.getWorldPosition(_pos);
+          restores.push(hideHeadGeometryUnderHat(vrm, _pos.y, _pos.x, _pos.z, fit.headWidthWU * nudge.hideR));
+        }
+      }
+    })();
+
+    return () => {
+      mounted = false;
+      restores.forEach((r) => r());
+      attached.forEach((g) => { g.parent?.remove(g); disposeGroup(g); });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [vrm, def.instanceId, def.animatorId, def.rigKey, nKey]);
+
+  useFrame((_, dt) => { if (vrm) vrm.update(dt); });
+
+  return <group ref={groupRef} position={[def.xOffset, 0, 0]} />;
+}
+
+// ---------------------------------------------------------------------------
+// Camera — frames the focused avatar, or the whole row for 'all'
+// ---------------------------------------------------------------------------
+
+function CameraRig({ focus }: { focus: string }) {
+  const { camera } = useThree();
+  useEffect(() => {
+    const a = AVATARS.find((x) => x.rigKey === focus);
+    if (a) {
+      camera.position.set(a.xOffset, a.focusY + 10, 340);
+      camera.lookAt(a.xOffset, a.focusY - 20, 0);
+    } else {
+      camera.position.set(0, 220, 900);
+      camera.lookAt(0, 200, 0);
+    }
+    camera.updateProjectionMatrix();
+  }, [camera, focus]);
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Control panel
+// ---------------------------------------------------------------------------
+
+function Slider({ label, value, min, max, step, onChange }: {
+  label: string; value: number; min: number; max: number; step: number; onChange: (v: number) => void;
+}) {
+  return (
+    <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 11, fontFamily: 'monospace', color: '#cbe8ff' }}>
+      <span style={{ width: 96, flexShrink: 0 }}>{label}</span>
+      <input type="range" min={min} max={max} step={step} value={value} onChange={(e) => onChange(parseFloat(e.target.value))} style={{ flex: 1 }} />
+      <span style={{ width: 46, textAlign: 'right', color: '#7dd3fc' }}>{value.toFixed(2)}</span>
+    </label>
+  );
+}
+
+function Panel({ focus, setFocus, nudges, setNudges }: {
+  focus: string; setFocus: (f: string) => void; nudges: NudgeMap; setNudges: (n: NudgeMap) => void;
+}) {
+  const n = nudges[focus];
+  const set = (mut: (x: Nudge) => void) => {
+    const next = structuredClone(nudges); mut(next[focus]); setNudges(next);
+  };
+  const btn = (rig: string, label: string) => (
+    <button key={rig} onClick={() => setFocus(rig)} style={{
+      fontSize: 11, fontFamily: 'monospace', padding: '4px 8px', cursor: 'pointer',
+      background: focus === rig ? '#2563eb' : 'rgba(30,58,95,0.6)', color: '#e6f3ff',
+      border: '1px solid #1e3a5f', borderRadius: 5,
+    }}>{label}</button>
+  );
+  return (
+    <div style={{
+      position: 'absolute', top: 40, left: 16, width: 320, padding: 12,
+      background: 'rgba(8,16,30,0.94)', border: '1px solid #1e3a5f', borderRadius: 8,
+      display: 'flex', flexDirection: 'column', gap: 6, zIndex: 10,
+    }}>
+      <div style={{ fontSize: 12, fontFamily: 'monospace', color: '#7dd3fc' }}>cosmetic tuner — one avatar at a time</div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 4 }}>
+        {AVATARS.map((a) => btn(a.rigKey, a.label))}
+        {btn('all', 'all')}
+      </div>
+      {n && (
+        <>
+          <div style={{ fontSize: 11, fontFamily: 'monospace', color: '#9fd0ff' }}>HAT</div>
+          <Slider label="up / down" value={n.hatY} min={-40} max={40} step={0.5} onChange={(v) => set((x) => { x.hatY = v; })} />
+          <Slider label="size ×" value={n.hatScale} min={0.3} max={3} step={0.02} onChange={(v) => set((x) => { x.hatScale = v; })} />
+          <Slider label="tilt back" value={n.hatRot} min={-0.5} max={0.5} step={0.01} onChange={(v) => set((x) => { x.hatRot = v; })} />
+          <Slider label="hair hide R" value={n.hideR} min={0.2} max={1.1} step={0.01} onChange={(v) => set((x) => { x.hideR = v; })} />
+          <div style={{ fontSize: 11, fontFamily: 'monospace', color: '#9fd0ff', marginTop: 4 }}>GLASSES</div>
+          <Slider label="up / down" value={n.glY} min={-30} max={30} step={0.5} onChange={(v) => set((x) => { x.glY = v; })} />
+          <Slider label="size ×" value={n.glScale} min={0.3} max={3} step={0.02} onChange={(v) => set((x) => { x.glScale = v; })} />
+          <Slider label="forward" value={n.glFwd} min={-20} max={20} step={0.5} onChange={(v) => set((x) => { x.glFwd = v; })} />
+          <div style={{ fontSize: 10, fontFamily: 'monospace', color: '#64748b', marginTop: 4, userSelect: 'all' }}>
+            {focus}: hatY={n.hatY} hatScale={n.hatScale} hatRot={n.hatRot} hideR={n.hideR} glY={n.glY} glScale={n.glScale} glFwd={n.glFwd}
+          </div>
+        </>
+      )}
+      {focus === 'all' && <div style={{ fontSize: 10, fontFamily: 'monospace', color: '#64748b' }}>Pick an avatar above to tune it.</div>}
+    </div>
+  );
+}
+
+function LabelOverlay({ focus }: { focus: string }) {
+  if (focus !== 'all') return null;
+  return (
+    <div style={{ position: 'absolute', bottom: 24, left: 0, right: 0, display: 'flex', justifyContent: 'center', gap: 120, pointerEvents: 'none' }}>
+      {AVATARS.map((a) => (
+        <div key={a.instanceId} style={{ color: '#7dd3fc', fontFamily: 'monospace', fontSize: 11, textShadow: '0 1px 2px rgba(0,0,0,0.9)' }}>{a.label}</div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
+export default function CosmeticsPreviewScene() {
+  const [focus, setFocus] = useState<string>('milady');
+  const [nudges, setNudges] = useState<NudgeMap>(() => defaultNudges());
+  return (
+    <>
+      <Canvas camera={{ fov: 45, near: 1, far: 10000, position: [0, 220, 900] }} style={{ width: '100%', height: '100%' }} dpr={[1, 1.5]} frameloop="always">
+        <CameraRig focus={focus} />
+        <hemisphereLight args={[0xb0d8ff, 0x4a3010, 1.2]} />
+        <directionalLight position={[200, 500, 300]} intensity={1.8} castShadow={false} />
+        <mesh rotation={[-Math.PI / 2, 0, 0]} receiveShadow={false}>
+          <planeGeometry args={[2000, 1000]} />
+          <meshStandardMaterial color={0x1a2a3a} roughness={0.9} metalness={0} />
+        </mesh>
+        {AVATARS.map((def) => (
+          <Suspense key={def.instanceId} fallback={null}>
+            <AvatarWithCosmetics def={def} nudge={nudges[def.rigKey]} />
+          </Suspense>
+        ))}
+      </Canvas>
+      <Panel focus={focus} setFocus={setFocus} nudges={nudges} setNudges={setNudges} />
+      <LabelOverlay focus={focus} />
+    </>
+  );
+}

--- a/apps/web/src/app/preview/cosmetics/page.tsx
+++ b/apps/web/src/app/preview/cosmetics/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+/**
+ * /preview/cosmetics — dev/QA only route
+ *
+ * Renders 5 humanoid VRMs side-by-side, each wearing a hat and glasses,
+ * so the cosmetic head-fit algorithm (computeCosmeticHeadFit) can be
+ * verified visually across all avatar types.
+ *
+ * IMPORTANT: Uses a DEFAULT WebGL renderer (not WebGPU) so that
+ * chrome-devtools MCP can capture screenshots (WebGPU swapchain is not
+ * capturable by CDP screenshotting). Never import from 'three/webgpu' here.
+ *
+ * Iris Xe constraints still apply to this file (no drei <Text>/<Billboard>,
+ * no InstancedMesh + ShaderMaterial, no per-frame new Vector3()), though
+ * this is a QA route and is WebGL — so drei Html labels are safe here.
+ */
+
+import dynamic from 'next/dynamic';
+
+const CosmeticsPreviewScene = dynamic(
+  () => import('./CosmeticsPreviewScene'),
+  { ssr: false },
+);
+
+export default function CosmeticsPreviewPage() {
+  return (
+    <div style={{ width: '100vw', height: '100vh', background: '#0a1628', position: 'relative' }}>
+      <div style={{
+        position: 'absolute',
+        top: 8,
+        left: 8,
+        color: '#7dd3fc',
+        fontFamily: 'monospace',
+        fontSize: 12,
+        zIndex: 10,
+        pointerEvents: 'none',
+      }}>
+        /preview/cosmetics — dev/QA only — WebGL (screenshottable)
+      </div>
+      <CosmeticsPreviewScene />
+    </div>
+  );
+}

--- a/apps/web/src/lib/three/cosmetic-loader.tsx
+++ b/apps/web/src/lib/three/cosmetic-loader.tsx
@@ -39,6 +39,10 @@ import { MeshoptDecoder } from 'meshoptimizer';
 import { useQuery } from '@tanstack/react-query';
 import { emitParticles } from '@/lib/three/particle-system';
 import { applyFattenedFrustumCulling } from '@/lib/three/vrm-loader';
+import {
+  computeCosmeticHeadFit,
+  type CosmeticHeadFitResult,
+} from '@/lib/three/vrm-avatar-sizing';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -80,9 +84,11 @@ export interface CosmeticLoaderProps {
   avatarId: string;
   /**
    * The avatar's rig type. Determines which variant is selected.
-   * Must match a `rigType` value in cosmetic_variants.
+   * Must match a `rigType` value in cosmetic_variants. Pass 'universal' for
+   * any humanoid VRM rig — the loader prefers 'universal' variants first.
+   * Non-humanoid rigs (lobster, crab, etc.) receive no hat/glasses placement.
    */
-  rigType: 'milady-vrm' | 'lobster' | 'crab' | string;
+  rigType: 'milady-vrm' | 'lobster' | 'crab' | 'universal' | string;
   /**
    * Current scene context. Board cosmetics only render when
    * context === 'activity:reef-race'. World cosmetics render everywhere except
@@ -94,6 +100,26 @@ export interface CosmeticLoaderProps {
    * All bone lookups and children are attached to / relative to this object.
    */
   parentObject: THREE.Object3D;
+  /**
+   * Optional: the loaded VRM instance for HUMANOID avatars.
+   * When provided, HatOrGlassesRenderer uses computeCosmeticHeadFit() for
+   * proportion-aware placement — the cosmetic is scaled to the avatar's
+   * actual head size and positioned at the correct height/forward-offset.
+   *
+   * When absent (non-humanoid GLB avatars), the renderer falls back to the
+   * legacy bone-name lookup path (findHeadBone). Hat/glasses on non-humanoid
+   * rigs are a Phase D concern.
+   */
+  vrm?: {
+    humanoid?: { getRawBoneNode?: (name: string) => THREE.Object3D | null } | null;
+    scene: THREE.Object3D;
+  } | null;
+  /**
+   * The world render scale applied to vrm.scene (from computeVRMAvatarFit).
+   * Required by computeCosmeticHeadFit to convert head metrics from rig-native
+   * units to world units. Ignored when vrm is absent.
+   */
+  vrmRenderScale?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -406,15 +432,30 @@ export function useEquippedCosmetics(
 /**
  * HatOrGlassesRenderer — attaches a GLB to a head bone.
  *
- * Reads boneAnchor, offsetXYZ, scale, rotationXYZ from assetMeta.
- * Falls back to findHeadBone() if boneAnchor is not specified.
+ * Phase B (2026-06-07): When `vrm` + `vrmRenderScale` are provided, uses
+ * `computeCosmeticHeadFit()` for proportion-aware placement (axis-sign safe,
+ * works across all humanoid rigs: Milady, Hermes, Tekk, Phanes, chibi).
+ *
+ * Any per-item assetMeta nudge (offsetXYZ / scaleHint / rotationXYZ) is
+ * applied ON TOP of the computed fit so artists can tweak individual items
+ * without breaking the universal baseline.
+ *
+ * Fallback (legacy path): when vrm is absent, falls back to findHeadBone()
+ * with the raw assetMeta offsets.  This covers non-humanoid GLB avatars
+ * (Phase D) and any callsite that hasn't been wired up yet.
  */
 function HatOrGlassesRenderer({
   parentObject,
   variant,
+  category,
+  vrm,
+  vrmRenderScale,
 }: {
   parentObject: THREE.Object3D;
   variant: OwnedCosmetic['variants'][0];
+  category: 'hat' | 'glasses';
+  vrm?: CosmeticLoaderProps['vrm'];
+  vrmRenderScale?: number;
   // onDispose accepted for backwards compat but no longer used — React's
   // own useEffect cleanup handles disposal correctly across variant changes.
   onDispose?: (fn: () => void) => void;
@@ -422,15 +463,20 @@ function HatOrGlassesRenderer({
   // Re-run effect whenever asset content changes (URL or meta). Including
   // assetMeta as a JSON-stringified dep means changing offsetXYZ/scale/etc
   // via re-seed automatically re-attaches with the new values without a
-  // page reload.
+  // page reload. Also re-runs if the VRM changes (vrm identity check via
+  // vrm?.scene?.uuid).
   const metaKey = JSON.stringify(variant.assetMeta ?? {});
+  const vrmSceneId = vrm?.scene?.uuid ?? 'no-vrm';
 
   useEffect(() => {
     const meta = variant.assetMeta ?? {};
-    const boneAnchorName = (meta.boneAnchor as string | undefined) ?? null;
-    const offsetXYZ = (meta.offsetXYZ as [number, number, number] | undefined) ?? [0, 0, 0];
-    const scaleFactor = (meta.scale as number | undefined) ?? 1;
+    // Per-item assetMeta nudge — applied ON TOP of auto-fit.
+    const nudgeOffsetXYZ = (meta.offsetXYZ as [number, number, number] | undefined) ?? [0, 0, 0];
+    const nudgeScaleMult = (meta.scaleHint as number | undefined) ??
+                          (meta.scale as number | undefined) ?? 1;
     const rotationXYZ = (meta.rotationXYZ as [number, number, number] | undefined) ?? [0, 0, 0];
+    // Legacy boneAnchor (only used when VRM fit is unavailable)
+    const boneAnchorName = (meta.boneAnchor as string | undefined) ?? null;
 
     let mounted = true;
     let attachedGroup: THREE.Group | null = null;
@@ -451,34 +497,64 @@ function HatOrGlassesRenderer({
         return;
       }
 
-      // Find the bone to attach to
-      anchor = boneAnchorName
-        ? (findBone(parentObject, boneAnchorName) ?? findHeadBone(parentObject))
-        : findHeadBone(parentObject);
-
-      if (!anchor) {
-        // No head bone found — this can happen for rig types that don't have one.
-        // Attach at parent root as fallback so at least something renders.
-        console.warn('[CosmeticLoader] No head bone found, attaching at root', variant.assetUrl);
-        anchor = parentObject;
+      // ─── Phase B: proportion-aware head fit (humanoid VRM path) ──────────
+      let fit: CosmeticHeadFitResult | null = null;
+      if (vrm && vrmRenderScale) {
+        fit = computeCosmeticHeadFit(vrm, category, vrmRenderScale);
       }
 
-      // Wrap in a container group so we can apply the offset without
-      // modifying the loaded GLB's transform (which may be needed for other
-      // clones later)
-      attachedGroup = new THREE.Group();
-      attachedGroup.name = `cosmetic-hat-${variant.id}`;
-      attachedGroup.position.set(offsetXYZ[0], offsetXYZ[1], offsetXYZ[2]);
-      attachedGroup.scale.setScalar(scaleFactor);
-      attachedGroup.rotation.set(rotationXYZ[0], rotationXYZ[1], rotationXYZ[2]);
-      // Intentionally kept false on this Group wrapper (not a SkinnedMesh / Mesh).
-      // A Group's frustum test uses its children's world AABBs; leaving it true would
-      // cull the wrapper before Three.js can check the children's actual bounds.
-      // The GLB meshes INSIDE (glbGroup) already have correct culling applied by
-      // applyFattenedFrustumCulling in loadGlbAsset above.
-      attachedGroup.frustumCulled = false;
-      attachedGroup.add(glbGroup);
-      anchor.add(attachedGroup);
+      if (fit) {
+        // AUTO-FIT PATH: anchor = raw head bone (the bone the animator drives).
+        // getRawBoneNode returns the same Object3D that is the parent of the
+        // head geometry; parenting to it means the cosmetic follows head
+        // animation naturally (the animator drives it via the VRMCharacterAnimator
+        // order: mixer.update → vrm.update → updateMatrixWorld).
+        anchor = vrm!.humanoid?.getRawBoneNode?.('head') ?? findHeadBone(parentObject);
+        if (!anchor) {
+          console.warn('[CosmeticLoader] VRM has no head bone, attaching at root', variant.assetUrl);
+          anchor = parentObject;
+        }
+
+        attachedGroup = new THREE.Group();
+        attachedGroup.name = `cosmetic-${category}-${variant.id}`;
+        // Apply computed position then add nudge on top.
+        attachedGroup.position.copy(fit.localPosition);
+        attachedGroup.position.x += nudgeOffsetXYZ[0];
+        attachedGroup.position.y += nudgeOffsetXYZ[1];
+        attachedGroup.position.z += nudgeOffsetXYZ[2];
+        // Scale: auto-fit uniform scale × per-item scaleHint multiplier.
+        attachedGroup.scale.setScalar(fit.localScale * nudgeScaleMult);
+        attachedGroup.rotation.set(rotationXYZ[0], rotationXYZ[1], rotationXYZ[2]);
+        attachedGroup.frustumCulled = false;
+        attachedGroup.add(glbGroup);
+        anchor.add(attachedGroup);
+      } else {
+        // ─── LEGACY PATH: bone name lookup + raw assetMeta offsets ──────────
+        // Used for non-humanoid avatars (Phase D) and fallback when vrm is
+        // absent.  Preserves previous behaviour exactly.
+        anchor = boneAnchorName
+          ? (findBone(parentObject, boneAnchorName) ?? findHeadBone(parentObject))
+          : findHeadBone(parentObject);
+
+        if (!anchor) {
+          console.warn('[CosmeticLoader] No head bone found, attaching at root', variant.assetUrl);
+          anchor = parentObject;
+        }
+
+        attachedGroup = new THREE.Group();
+        attachedGroup.name = `cosmetic-${category}-${variant.id}`;
+        attachedGroup.position.set(nudgeOffsetXYZ[0], nudgeOffsetXYZ[1], nudgeOffsetXYZ[2]);
+        attachedGroup.scale.setScalar(nudgeScaleMult);
+        attachedGroup.rotation.set(rotationXYZ[0], rotationXYZ[1], rotationXYZ[2]);
+        // Intentionally kept false on this Group wrapper (not a SkinnedMesh / Mesh).
+        // A Group's frustum test uses its children's world AABBs; leaving it true
+        // would cull the wrapper before Three.js checks the children's actual bounds.
+        // The GLB meshes INSIDE (glbGroup) already have correct culling applied by
+        // applyFattenedFrustumCulling in loadGlbAsset above.
+        attachedGroup.frustumCulled = false;
+        attachedGroup.add(glbGroup);
+        anchor.add(attachedGroup);
+      }
     }).catch((err) => {
       console.error('[CosmeticLoader] Failed to load hat/glasses GLB', variant.assetUrl, err);
     });
@@ -499,7 +575,7 @@ function HatOrGlassesRenderer({
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [variant.assetUrl, variant.id, metaKey, parentObject]);
+  }, [variant.assetUrl, variant.id, metaKey, parentObject, vrmSceneId, category, vrmRenderScale]);
 
   return null;
 }
@@ -796,9 +872,11 @@ function AuraFrameUpdater({ parentObject }: { parentObject: THREE.Object3D }) {
  * Example:
  *   <CosmeticLoader
  *     avatarId={avatar.id}
- *     rigType="milady-vrm"
+ *     rigType="universal"
  *     context="world"
- *     parentObject={avatarRef.current}
+ *     parentObject={vrm.scene}
+ *     vrm={vrm}
+ *     vrmRenderScale={vrmRenderScale}
  *   />
  */
 export function CosmeticLoader({
@@ -806,6 +884,8 @@ export function CosmeticLoader({
   rigType,
   context,
   parentObject,
+  vrm,
+  vrmRenderScale,
 }: CosmeticLoaderProps) {
   const equipped = useEquippedCosmetics(avatarId, context, rigType);
 
@@ -875,7 +955,9 @@ export function CosmeticLoader({
               key={item.id}
               parentObject={parentObject}
               variant={variant}
-              onDispose={onDispose}
+              category={cat as 'hat' | 'glasses'}
+              vrm={vrm}
+              vrmRenderScale={vrmRenderScale}
             />
           );
         }
@@ -913,18 +995,19 @@ export function CosmeticLoader({
         }
 
         if (cat === 'palette') {
-          return (
-            <PaletteRenderer
-              key={item.id}
-              parentObject={parentObject}
-              variant={variant}
-              onDispose={onDispose}
-            />
-          );
+          // Phase B guard: PaletteRenderer is a stub (UV-region blit not implemented).
+          // Returning null prevents log spam from OutfitRenderer and avoids any
+          // unexpected material mutations on the player avatar until the full
+          // canvas-composite blit is built. DB palette rows are safe — they just
+          // don't visually render yet.
+          return null;
         }
 
         if (cat === 'outfit') {
-          return <OutfitRenderer key={item.id} variant={variant} />;
+          // Phase B guard: OutfitRenderer is a stub (Marvelous Designer skin binding
+          // not implemented). Returning null suppresses the console.info noise that
+          // the previous stub emitted on every equipped outfit row.
+          return null;
         }
 
         if (cat === 'emote') {

--- a/apps/web/src/lib/three/cosmetic-loader.tsx
+++ b/apps/web/src/lib/three/cosmetic-loader.tsx
@@ -41,8 +41,16 @@ import { emitParticles } from '@/lib/three/particle-system';
 import { applyFattenedFrustumCulling } from '@/lib/three/vrm-loader';
 import {
   computeCosmeticHeadFit,
+  hideHeadGeometryUnderHat,
+  SCALP_HIDE_RADIUS_FACTOR,
   type CosmeticHeadFitResult,
 } from '@/lib/three/vrm-avatar-sizing';
+
+// Scratch objects for equip-time calculations — never allocated per frame.
+// Declared module-scope so they're never re-created per effect run.
+const _scratchSize   = new THREE.Vector3();
+const _scratchScale  = new THREE.Vector3();
+const _scratchBox    = new THREE.Box3();
 
 // ---------------------------------------------------------------------------
 // Types
@@ -120,6 +128,10 @@ export interface CosmeticLoaderProps {
    * units to world units. Ignored when vrm is absent.
    */
   vrmRenderScale?: number;
+  /** Avatar rig key (e.g. 'hermes', 'chibi') for per-rig fit overrides
+   *  (RIG_HEAD_OVERRIDE in vrm-avatar-sizing). Derived from the avatar's
+   *  animatorId. Omit/undefined → pure auto-fit (correct for well-rigged VRMs). */
+  avatarRigKey?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -167,16 +179,20 @@ function scopeCompatible(skuScope: string, context: CosmeticContext): boolean {
 
 /**
  * Pick the best variant for the current rig.
- * Priority: exact rig match > 'universal'
+ * Priority: exact rig match > 'universal' > first available row.
+ *
+ * The "first available" fallback prevents nothing rendering when the DB still
+ * has legacy rows under a specific rigType (e.g. 'milady-vrm') while the
+ * caller passes 'universal'. Without this fallback: exact=undefined,
+ * universal=undefined → null → NOTHING renders (BUG 3).
  */
 function pickVariant(
   variants: OwnedCosmetic['variants'],
   rigType: string,
 ): OwnedCosmetic['variants'][0] | null {
-  const exact = variants.find((v) => v.rigType === rigType);
-  if (exact) return exact;
+  const exact     = variants.find((v) => v.rigType === rigType);
   const universal = variants.find((v) => v.rigType === 'universal');
-  return universal ?? null;
+  return exact ?? universal ?? variants[0] ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -450,12 +466,14 @@ function HatOrGlassesRenderer({
   category,
   vrm,
   vrmRenderScale,
+  avatarRigKey,
 }: {
   parentObject: THREE.Object3D;
   variant: OwnedCosmetic['variants'][0];
   category: 'hat' | 'glasses';
   vrm?: CosmeticLoaderProps['vrm'];
   vrmRenderScale?: number;
+  avatarRigKey?: string;
   // onDispose accepted for backwards compat but no longer used — React's
   // own useEffect cleanup handles disposal correctly across variant changes.
   onDispose?: (fn: () => void) => void;
@@ -481,6 +499,7 @@ function HatOrGlassesRenderer({
     let mounted = true;
     let attachedGroup: THREE.Group | null = null;
     let anchor: THREE.Object3D | null = null;
+    let scalpRestore: (() => void) | null = null;
 
     loadGlbAsset(variant.assetUrl).then((glbGroup) => {
       if (!mounted) {
@@ -500,7 +519,7 @@ function HatOrGlassesRenderer({
       // ─── Phase B: proportion-aware head fit (humanoid VRM path) ──────────
       let fit: CosmeticHeadFitResult | null = null;
       if (vrm && vrmRenderScale) {
-        fit = computeCosmeticHeadFit(vrm, category, vrmRenderScale);
+        fit = computeCosmeticHeadFit(vrm, category, vrmRenderScale, avatarRigKey);
       }
 
       if (fit) {
@@ -515,6 +534,38 @@ function HatOrGlassesRenderer({
           anchor = parentObject;
         }
 
+        // BUG 2 FIX — asset-aware, bone-scale-aware local scale.
+        //
+        // The cosmetic Group is parented to the head bone whose world scale
+        // already includes the avatar render-scale (~169–320×). Setting
+        // localScale = desiredWorldWidth / 30 was wrong: effective world size
+        // = boneWorldScale × groupLocalScale, so we need:
+        //
+        //   groupLocalScale = desiredWorldWidth / (assetWidth × boneWorldScale)
+        //
+        // where assetWidth is the GLB's authored X-axis span (glbGroup not yet
+        // added to any scene so it is in authored/asset-local units).
+        //
+        // If assetWidth is 0 or cannot be measured (degenerate asset), fall
+        // back to a scale of 1.0 so we at least render something visible.
+        _scratchBox.setFromObject(glbGroup);
+        _scratchBox.getSize(_scratchSize);
+        const assetWidth = _scratchSize.x;
+
+        anchor.getWorldScale(_scratchScale);
+        const boneWorldScaleX = _scratchScale.x;
+
+        let groupLocalScale: number;
+        if (assetWidth > 1e-6 && boneWorldScaleX > 1e-6) {
+          groupLocalScale = (fit.desiredWorldWidth / (assetWidth * boneWorldScaleX)) * nudgeScaleMult;
+          // Clamp to a sane range to guard against degenerate inputs.
+          groupLocalScale = Math.max(0.01, Math.min(1000, groupLocalScale));
+        } else {
+          // Degenerate asset or bone scale — fall back so something renders.
+          groupLocalScale = nudgeScaleMult;
+          console.warn('[CosmeticLoader] Cannot measure asset width or bone scale; using fallback scale', variant.assetUrl, { assetWidth, boneWorldScaleX });
+        }
+
         attachedGroup = new THREE.Group();
         attachedGroup.name = `cosmetic-${category}-${variant.id}`;
         // Apply computed position then add nudge on top.
@@ -522,12 +573,27 @@ function HatOrGlassesRenderer({
         attachedGroup.position.x += nudgeOffsetXYZ[0];
         attachedGroup.position.y += nudgeOffsetXYZ[1];
         attachedGroup.position.z += nudgeOffsetXYZ[2];
-        // Scale: auto-fit uniform scale × per-item scaleHint multiplier.
-        attachedGroup.scale.setScalar(fit.localScale * nudgeScaleMult);
+        // Scale: asset-aware + bone-scale-corrected local scale.
+        attachedGroup.scale.setScalar(groupLocalScale);
         attachedGroup.rotation.set(rotationXYZ[0], rotationXYZ[1], rotationXYZ[2]);
         attachedGroup.frustumCulled = false;
         attachedGroup.add(glbGroup);
         anchor.add(attachedGroup);
+
+        // Hide the head/scalp geometry UNDER the hat so baked-in hair can't poke
+        // through it (most avatars are a single fused mesh; see hideHeadGeometryUnderHat).
+        if (category === 'hat' && vrm) {
+          attachedGroup.updateWorldMatrix(true, false);
+          const hatWorld = new THREE.Vector3();
+          attachedGroup.getWorldPosition(hatWorld);
+          scalpRestore = hideHeadGeometryUnderHat(
+            vrm,
+            hatWorld.y,
+            hatWorld.x,
+            hatWorld.z,
+            fit.headWidthWU * SCALP_HIDE_RADIUS_FACTOR,
+          );
+        }
       } else {
         // ─── LEGACY PATH: bone name lookup + raw assetMeta offsets ──────────
         // Used for non-humanoid avatars (Phase D) and fallback when vrm is
@@ -561,6 +627,7 @@ function HatOrGlassesRenderer({
 
     return () => {
       mounted = false;
+      if (scalpRestore) { scalpRestore(); scalpRestore = null; } // restore hidden head geometry
       if (attachedGroup && anchor) {
         anchor.remove(attachedGroup);
         attachedGroup.traverse((c) => {
@@ -886,6 +953,7 @@ export function CosmeticLoader({
   parentObject,
   vrm,
   vrmRenderScale,
+  avatarRigKey,
 }: CosmeticLoaderProps) {
   const equipped = useEquippedCosmetics(avatarId, context, rigType);
 
@@ -958,6 +1026,7 @@ export function CosmeticLoader({
               category={cat as 'hat' | 'glasses'}
               vrm={vrm}
               vrmRenderScale={vrmRenderScale}
+              avatarRigKey={avatarRigKey}
             />
           );
         }

--- a/apps/web/src/lib/three/player-avatar.tsx
+++ b/apps/web/src/lib/three/player-avatar.tsx
@@ -685,17 +685,22 @@ function PlayerAvatarVRMInner({ reg }: { reg: ModelRegistryEntry }) {
         position={[0, vrmFootOffsetY, 0]}
       />
       {/*
-        Equipped cosmetics (hats / glasses / aura / particles) for the
-        player's Milady VRM. The loader subscribes to /api/cosmetics/owned
-        and attaches GLBs to the head bone or other anchors. avatarId='self'
-        because the API resolves the caller avatar from the session cookie —
-        the prop is forward-compat for future per-NPC cosmetic rendering.
+        Equipped cosmetics (hats / glasses / aura / particles) for the player VRM.
+        rigType='universal' — the loader prefers 'universal' variants, then falls
+        back to an exact rig match. This works for all humanoid VRMs (Milady,
+        Hermes, Tekk, Phanes, chibi) without needing per-rig variant rows in the DB.
+        vrm + vrmRenderScale enable computeCosmeticHeadFit for proportion-aware,
+        axis-sign-safe hat/glasses placement (Phase B). avatarId='self' because the
+        API resolves the caller avatar from the session cookie — prop is
+        forward-compat for future per-NPC cosmetic rendering.
       */}
       <CosmeticLoader
         avatarId="self"
-        rigType="milady-vrm"
+        rigType="universal"
         context="world"
         parentObject={vrm.scene}
+        vrm={vrm}
+        vrmRenderScale={vrmRenderScale}
       />
     </group>
   );

--- a/apps/web/src/lib/three/vrm-avatar-sizing.ts
+++ b/apps/web/src/lib/three/vrm-avatar-sizing.ts
@@ -217,178 +217,526 @@ export function computeVRMAvatarFit(
  * @param category - 'hat' | 'glasses'
  * @param renderScale - the world scale applied to vrm.scene (from computeVRMAvatarFit).
  *   Required to convert head-bone native units → world units.
- * @returns { localPosition, localScale, headWidthWU } or null if no head bone.
- *   localPosition: THREE.Vector3 in head-bone-local space for the cosmetic Group.
- *   localScale:    uniform scale (scalar) for the cosmetic Group.
- *   headWidthWU:   head width in world units (diagnostic, also used by caller for
- *                  per-category override math).
+ * @returns { localPosition, desiredWorldWidth, headWidthWU } or null if no head bone.
+ *   localPosition:     THREE.Vector3 in head-bone-local space for the cosmetic Group.
+ *   desiredWorldWidth: target world-space width the cosmetic should occupy.
+ *                      HatOrGlassesRenderer converts this to a local scale after
+ *                      measuring the GLB asset width and bone world scale.
+ *   headWidthWU:       head width in world units (diagnostic + nudge math).
  */
 export interface CosmeticHeadFitResult {
   localPosition: THREE.Vector3;
-  localScale:    number;
-  /** head bounding-box width in world units (useful for debugging + nudge math) */
+  /**
+   * Desired WORLD width (world units) the cosmetic should occupy.
+   * = headWidthWU * CATEGORY_WIDTH_FACTOR[category].
+   * HatOrGlassesRenderer converts this to a local scale after measuring
+   * the GLB asset's authored width and the bone's world scale, eliminating
+   * the magic-30 and the bone-world-scale-frame error (BUG 2).
+   */
+  desiredWorldWidth: number;
+  /** head width in world units (diagnostic + used for nudge math in caller) */
   headWidthWU:   number;
 }
 
 /**
- * Reference head width (world units) the cosmetic GLBs were authored for.
+ * Ratio of head width to head height for a typical humanoid VRM head.
+ * Used as fallback by computeCosmeticHeadFit when no skinned head verts
+ * are found (non-skinned rig).  Value ≈ 0.85 (a humanoid head is slightly
+ * narrower than it is tall).
+ * Tunable by the orchestrator in browser: adjust here and rebuild.
+ */
+export const HEAD_WIDTH_TO_HEIGHT = 0.85;
+
+/**
+ * Per-category desired world width of the cosmetic as a fraction of headWidthWU.
+ * hat:    slightly wider than the head (brim overhang)
+ * glasses: slightly narrower than the head width (lens-to-lens span)
+ * Tunable by the orchestrator in browser: adjust here and rebuild.
+ */
+export const CATEGORY_WIDTH_FACTOR: Record<'hat' | 'glasses', number> = {
+  hat:     1.15,   // crown wide enough to CONTAIN the top hair (reduce poke-through)
+  glasses: 0.62,   // span eye-to-eye and sit ON the face (not head-wide goggles)
+};
+
+/**
+ * Per-rig head-fit overrides for avatars whose skin weights CORRUPT the
+ * automatic head measurement (no clean strong-weight signal exists on them):
+ *   - the chibi weights its whole upper body to the head bone → head measured
+ *     ~2.5x too big → giant hat that reads as floating;
+ *   - Hermes weights only her upper skull → head measured small/high → the hat
+ *     is swallowed by her (un-head-weighted) hair.
+ * Keyed by the avatar's rig key. Applied ON TOP of the measured head box:
+ *   widthMul     — scales head width + depth (→ cosmetic size)
+ *   heightMul    — scales head height (→ hat drop depth + glasses eye span)
+ *   topShiftFrac — shifts the head TOP up(+)/down(-) by a fraction of head height
+ * Tunable in /preview/cosmetics. A new corrupted rig gets an entry here — and
+ * should be flagged by a head-weight sanity check in the avatar pipeline.
+ */
+export interface RigHeadOverride {
+  /** When true, DISCARD the corrupt vert measurement and anchor the head box to
+   *  the head BONE using the metre dims below × bone world scale. */
+  boneAnchored?: boolean;
+  /** Crown Y relative to the head bone, native metres (× bone scale). MAY be
+   *  NEGATIVE — some broken rigs place the head MESH below the 'head' bone. */
+  headTopAboveBoneM?: number;
+  /** Head height (drives hat drop + glasses eye span), native metres. Falls back
+   *  to headTopAboveBoneM when omitted. Kept SEPARATE so the crown can sit below
+   *  the bone while the head still has a positive height. */
+  headHeightM?: number;
+  /** Head width / depth, native metres (× bone scale). */
+  headWidthM?: number;
+  headDepthM?: number;
+  /** When true, IGNORE the head bone AND skin-weight measurement entirely and
+   *  measure the head as the TOP SLAB of the posed body AABB: crown = body
+   *  max.y, head = the top `headFraction` of total body height, centred on the
+   *  body's X/Z. For chibi-class rigs whose auto-rig (Mixamo OR Meshy) both
+   *  drops the 'head' bone far below the real head AND rigidly weights 40–60% of
+   *  the body to it — so neither boneAnchored nor vert-weight finds the head, but
+   *  the silhouette top always does (pigtails/side-hair cancel on a symmetric
+   *  body, so the centre stays put and width is derived from height, not the raw
+   *  slab). */
+  geometricTopSlab?: boolean;
+  /** Head height as a fraction of total body height, for geometricTopSlab
+   *  (default 0.42). Tunable on /preview/cosmetics. */
+  headFraction?: number;
+}
+
+export const RIG_HEAD_OVERRIDE: Record<string, RigHeadOverride> = {
+  // These rigs weight the head bone so badly the vert measurement is wrong in
+  // BOTH position and size — so we bone-anchor them. Metres tuned on
+  // /preview/cosmetics (?{rig}Top=&{rig}H=&{rig}W=).
+  //
+  // Hermes: SOLVED — looks worn (top hat at her hairline). ✅
+  hermes: { boneAnchored: true, headTopAboveBoneM: 0.22, headWidthM: 0.32 },
+  // chibi: GEOMETRIC TOP-SLAB measure (2026-06-19). MEASURED ground truth: both
+  // chibis' auto-rigs place the 'head' bone at 42–58% of body height (eliza 57.6%,
+  // milady 42%) — FAR below the real head (crown at ~100%) — so the old
+  // boneAnchored override dropped the hat to the low bone → it landed on the
+  // neck/chest (the user-reported bug). A faithful Meshy re-rig was validated and
+  // does NOT help: Meshy weights 41%+ of the body (chest→crown) to the head bone
+  // too — a chibi's head dominates the silhouette, so no auto-rigger isolates it.
+  // The head IS reliably the top ~42% of the silhouette, so we measure it
+  // geometrically instead of trusting the broken bone/weights. headFraction tuned
+  // so the head spans ~crown..neck (eliza 1.10→1.90, milady 1.10→1.90 in rig m).
+  chibi: { geometricTopSlab: true, headFraction: 0.42 },
+};
+
+/**
+ * How far the hat DROPS onto the head, as a fraction of measured head height.
+ * A real hat is not balanced on the crown — the head goes UP INTO the hat, so
+ * the hat base sits BELOW the crown (around the upper head / hairline).
+ * 0.0 = base at crown (floats); 0.30 ≈ base ~1/3 down the head so the brim
+ * sits BELOW the hairline (crown contains the top hair) = worn look, not plonked.
+ * Tunable by the orchestrator in browser.
+ */
+const HAT_DROP_FRACTION = 0.30;
+
+/**
+ * Glasses sit at this fraction of measured head height BELOW the head top.
+ * Eyes are roughly mid-face, ~0.52 down from the crown on a stylized head.
+ * Tunable by the orchestrator in browser.
+ */
+const GLASSES_EYE_FRACTION = 0.52;
+
+/**
+ * How far forward glasses are offset, as a fraction of measured head DEPTH,
+ * along the face-forward direction — places the lenses just in front of the
+ * face surface (depth/2 ≈ face front) instead of floating off the head.
+ */
+const GLASSES_FORWARD_FACTOR = 0.45;
+
+/**
+ * Minimum skinned-vertex weight contribution from the head bone for a vertex
+ * to be included in the head AABB measurement.  0.5 means the head bone must
+ * be the dominant influence (> 50 % of the total weight for that vertex).
+ */
+const HEAD_WEIGHT_THRESHOLD = 0.5;
+
+/**
+ * Sign multiplier for the glasses facing offset.
  *
- * The procedural placeholder GLBs (generate-cosmetic-glbs.mjs) were built in
- * metric. A Milady VRM at renderScale ≈ 169 has a head bbox ≈ 28–34 wu wide.
- * We use 30 wu as the design reference — cosmetics authored at 1× scale look
- * correct on Milady at 30 wu.  Larger/smaller heads get cosmetics scaled
- * proportionally.
+ * Three.js `Object3D.getWorldDirection(target)` returns the object's LOCAL +Z
+ * axis in world space — NOT the facing direction.  All ClawVille VRMs end up
+ * facing WORLD -Z after load:
+ *   - Milady VRM0: `VRMUtils.rotateVRM0` applies a π Y-rotation → faces -Z.
+ *   - VRM1.x (Hermes/Tekk/Phanes/chibi): `faceYaw = Math.PI` → faces -Z.
+ *
+ * Therefore `scene.getWorldDirection()` returns the BACK of the avatar (+Z in
+ * world = behind).  Adding it directly would push glasses behind the head.
+ *
+ * Fix: multiply by `GLASSES_FACING_SIGN = -1` to flip the vector so it
+ * points face-forward.
+ *
+ * The orchestrator can verify the sign in the `/preview/cosmetics` route:
+ * if glasses appear behind the head, flip this to +1.
  */
-export const COSMETIC_REF_HEAD_WIDTH_WU = 30;
-
-/**
- * Hat clearance: extra vertical gap between measured head-top and hat base,
- * in world units.  Prevents the hat from clipping into hair.
- */
-const HAT_CLEARANCE_WU = 2;
-
-/**
- * Glasses sit at this fraction below head-top-to-head-bottom.
- * 0.25 ≈ eye-level on a typical humanoid head.
- */
-const GLASSES_EYE_FRACTION = 0.25;
-
-/**
- * How far forward (in world units, relative to head width) glasses are offset
- * from the head-bone origin along the BODY-FACING direction.  Prevents clipping
- * into the face.
- */
-const GLASSES_FORWARD_FACTOR = 0.5;
+export const GLASSES_FACING_SIGN = -1;
 
 export function computeCosmeticHeadFit(
   vrm: {
-    humanoid?: { getRawBoneNode?: (name: string) => THREE.Object3D | null } | null;
+    humanoid?: {
+      getRawBoneNode?: (name: string) => THREE.Object3D | null;
+      getNormalizedBoneNode?: (name: string) => THREE.Object3D | null;
+    } | null;
     scene: THREE.Object3D;
   } | null | undefined,
   category: 'hat' | 'glasses',
   renderScale: number,
+  rigKey?: string,
+  /** Dev tuning: explicit override that wins over the RIG_HEAD_OVERRIDE table. */
+  tuningOverride?: RigHeadOverride,
 ): CosmeticHeadFitResult | null {
   if (!vrm) return null;
 
+  // renderScale is retained in the signature for backwards-compat with existing callers
+  // but is no longer used internally — the new algorithm works in world space directly
+  // since vrm.scene is already at renderScale in the scene by the time equip runs.
+  void renderScale;
+
   // 1. Get the raw head bone (what the animator actually drives — NOT the
   //    normalized bone used by the AnimationMixer).
-  const headBone =
-    vrm.humanoid?.getRawBoneNode?.('head') ?? null;
+  const headBone = vrm.humanoid?.getRawBoneNode?.('head') ?? null;
   if (!headBone) return null;
 
   // Ensure world matrices are current.  The VRM is already at renderScale
   // in the scene at this point (caller applies scale before calling equip).
   vrm.scene.updateMatrixWorld(true);
 
-  // 2. World position of the head bone.
-  // Scratch vectors — local to this call, never allocated per frame.
-  const headBoneWorldPos = new THREE.Vector3();
-  headBone.getWorldPosition(headBoneWorldPos);
-
-  // 3. Build WORLD-space AABB of the head region.
-  //    We walk DIRECT children of the head bone and any non-SkinnedMesh
-  //    descendants whose geometry origin is close to the head bone.
-  //    SkinnedMesh bind-pose bboxes are unreliable (see
-  //    gotcha: skinned-mesh-bbox-inflation.md) — we skip them.
+  // 2. HEAD-ISOLATED AABB via skinned-vertex traversal.
   //
-  //    If no geometry is found under the head bone we fall back to a
-  //    fraction of the full body bbox so chibi / low-poly VRMs still get
-  //    a sensible estimate.
-  const headBox = new THREE.Box3();
-  headBone.traverse((child) => {
-    const mesh = child as THREE.Mesh;
-    if (!mesh.isMesh) return;
-    if ((mesh as THREE.SkinnedMesh).isSkinnedMesh) return; // unreliable bbox
-    if (!mesh.geometry) return;
-    mesh.geometry.computeBoundingBox();
-    const geoBbox = mesh.geometry.boundingBox;
-    if (!geoBbox) return;
-    // Expand the accumulating box with this mesh's geometry in world space.
-    const tempBox = geoBbox.clone().applyMatrix4(mesh.matrixWorld);
-    headBox.union(tempBox);
-  });
-
-  // Fallback: if head subtree has no usable geometry, estimate from full bbox.
-  const usedFallback = headBox.isEmpty();
-  if (usedFallback) {
-    // Estimate head as top 15 % of total body bbox height.
-    const bodyBox = new THREE.Box3().setFromObject(vrm.scene as unknown as THREE.Object3D);
-    const bodyHeight = bodyBox.max.y - bodyBox.min.y;
-    const headTopEst = bodyBox.max.y;
-    const headBottomEst = headTopEst - bodyHeight * 0.15;
-    const headHalfWidthEst = bodyHeight * 0.08; // typical head width ≈ 16% of body height
-    headBox.min.set(
-      headBoneWorldPos.x - headHalfWidthEst,
-      headBottomEst,
-      headBoneWorldPos.z - headHalfWidthEst,
-    );
-    headBox.max.set(
-      headBoneWorldPos.x + headHalfWidthEst,
-      headTopEst,
-      headBoneWorldPos.z + headHalfWidthEst,
-    );
+  //    Walk all SkinnedMesh nodes in vrm.scene.  For each mesh:
+  //      a. Find the head bone's index in the skeleton's bone array.
+  //      b. Iterate all vertices; for each, check the 4 skin-influence pairs
+  //         (skinIndex, skinWeight).  Include the vertex IFF the head bone's
+  //         total weight contribution >= HEAD_WEIGHT_THRESHOLD (0.5).
+  //      c. Call sm.applyBoneTransform(vertexIndex, tmp) to pose the vertex
+  //         at the current skeleton state (Three.js r182 SkinnedMesh.js:319).
+  //      d. sm.localToWorld(tmp) to convert to world space.
+  //      e. Expand headBox.
+  //
+  //    Cosmetics are plain THREE.Group (no SkinnedMesh), so they are auto-
+  //    excluded from the vertex loop — no name-prefix check needed.
+  //
+  //    If headBox is still empty after the loop (non-skinned rig, or avatar
+  //    scene has no meshes yet), fall back to the BONE-ANCHORED body-bbox
+  //    estimate (the previous "reconciler pass" algorithm) so the function
+  //    never returns null on a valid VRM with a head bone.
+  // 2. ROBUST GEOMETRIC HEAD MEASUREMENT (rig-independent). Production auto-rigs
+  //    vary wildly in how they skin the head — the chibi weights its whole upper
+  //    body to the head bone; Hermes weights only her upper skull — so we do NOT
+  //    trust skin weights for the head EXTENT. Two passes:
+  //      PASS 1 (seed): collect verts STRONGLY weighted to the head bone (>= 0.9).
+  //        Only the actual skull is ever weighted that high, so this rejects
+  //        arms/torso even on a bad rig → a clean head CENTRE + rough scale.
+  //        Drops the threshold if a rig has too few strong verts.
+  //      PASS 2 (geometric expand): from that seed, scan ALL skinned verts that
+  //        are geometrically NEAR the seed centre (seed-scaled radius) and above
+  //        its base → the full head+hair AABB by LOCATION, not weight. Captures
+  //        hair the head bone doesn't own (fixes Hermes) and excludes far body
+  //        verts (fixes chibi).
+  const seedBox = new THREE.Box3();
+  const tmp = new THREE.Vector3();
+  let seedCount = 0;
+  for (const seedThreshold of [0.9, 0.7, 0.5]) {
+    seedBox.makeEmpty();
+    seedCount = 0;
+    vrm.scene.traverse((child) => {
+      const sm = child as THREE.SkinnedMesh;
+      if (!sm.isSkinnedMesh || !sm.skeleton || !sm.geometry) return;
+      const headBoneIndex = sm.skeleton.bones.indexOf(headBone as THREE.Bone);
+      if (headBoneIndex === -1) return;
+      const si = sm.geometry.getAttribute('skinIndex') as THREE.BufferAttribute | undefined;
+      const sw = sm.geometry.getAttribute('skinWeight') as THREE.BufferAttribute | undefined;
+      const pos = sm.geometry.getAttribute('position') as THREE.BufferAttribute | undefined;
+      if (!si || !sw || !pos) return;
+      // equip-on-load race: refresh boneMatrices so applyBoneTransform is valid.
+      sm.skeleton.update();
+      for (let i = 0; i < pos.count; i++) {
+        let w = 0;
+        for (let s = 0; s < 4; s++) if (si.getComponent(i, s) === headBoneIndex) w += sw.getComponent(i, s);
+        if (w < seedThreshold) continue;
+        tmp.fromBufferAttribute(pos, i);
+        sm.applyBoneTransform(i, tmp);
+        sm.localToWorld(tmp);
+        if (!isFinite(tmp.x) || !isFinite(tmp.y) || !isFinite(tmp.z)) continue;
+        seedBox.expandByPoint(tmp);
+        seedCount++;
+      }
+    });
+    if (seedCount >= 8) break;
   }
 
-  const headSize = new THREE.Vector3();
-  headBox.getSize(headSize);
+  // 3. Derive measurement values from the geometric head AABB (or fall back).
+  let headTopWorldY: number;
+  let headWidthWU: number;
+  let headHeightWU: number;
+  let headDepthWU: number;
+  let headCenterX: number;
+  let headCenterZ: number;
+  const eps = 1e-4;
 
-  const headTopWorldY  = headBox.max.y;
-  const headWidthWU    = headSize.x; // WORLD units at current renderScale
-  const headHeightWU   = headSize.y;
+  if (seedCount >= 8 && !seedBox.isEmpty()) {
+    const seedCenter = new THREE.Vector3(); seedBox.getCenter(seedCenter);
+    const seedSize = new THREE.Vector3(); seedBox.getSize(seedSize);
 
-  // Scale cosmetic proportional to measured head width vs the reference.
-  // Clamp to a reasonable range to avoid absurdly large/tiny cosmetics on
-  // edge cases (e.g. a very low-poly head mesh with a 1-triangle bbox).
-  const rawScale = headWidthWU / COSMETIC_REF_HEAD_WIDTH_WU;
-  const localScale = Math.max(0.25, Math.min(4.0, rawScale));
+    // The strong-weight seed IS the head (skull): clean across rigs because only
+    // the skull is ever weighted >=0.9, so arms/torso (chibi) are already gone.
+    // Use it directly for WIDTH / DEPTH / CENTRE. Then a TIGHT, UPWARD-ONLY scan
+    // extends the TOP to a hair crown sitting DIRECTLY above the skull (radius =
+    // skull half-width, y strictly above the seed top, capped) so the hat clears
+    // the hair WITHOUT catching shoulders, wings, or side-hair (which inflated
+    // the earlier greedy expansion: Milady w 71->137, Tekk caught its wings).
+    const topRadius = Math.max(seedSize.x, seedSize.z, eps) * 0.55;
+    const topR2 = topRadius * topRadius;
+    const crownCeil = seedBox.max.y + Math.max(seedSize.y, eps) * 0.6; // hair adds <=60% skull height
+    const gtmp = new THREE.Vector3();
+    let crownY = seedBox.max.y;
+    vrm.scene.traverse((child) => {
+      const sm = child as THREE.SkinnedMesh;
+      if (!sm.isSkinnedMesh || !sm.skeleton || !sm.geometry) return;
+      const pos = sm.geometry.getAttribute('position') as THREE.BufferAttribute | undefined;
+      if (!pos) return;
+      sm.skeleton.update();
+      const step = pos.count > 15000 ? 3 : 1; // subsample huge meshes
+      for (let i = 0; i < pos.count; i += step) {
+        gtmp.fromBufferAttribute(pos, i);
+        sm.applyBoneTransform(i, gtmp);
+        sm.localToWorld(gtmp);
+        if (!isFinite(gtmp.y) || gtmp.y <= seedBox.max.y || gtmp.y > crownCeil) continue;
+        const dx = gtmp.x - seedCenter.x;
+        const dz = gtmp.z - seedCenter.z;
+        if (dx * dx + dz * dz > topR2) continue; // directly above the skull only
+        if (gtmp.y > crownY) crownY = gtmp.y;
+      }
+    });
 
-  // 4. Compute WORLD-SPACE target position of the cosmetic.
+    headTopWorldY = crownY;
+    headHeightWU  = Math.max(crownY - seedBox.min.y, eps);
+    headWidthWU   = Math.min(Math.max(seedSize.x, eps), headHeightWU * 1.4);
+    headDepthWU   = Math.min(Math.max(seedSize.z, eps), headHeightWU * 1.4);
+    headCenterX   = seedCenter.x;
+    headCenterZ   = seedCenter.z;
+  } else {
+    // FALLBACK PATH: no head-weighted verts found (non-skinned rig or T-pose
+    // skeleton not bound).  Use the bone-anchored body-bbox approach so the
+    // function never returns null for a valid VRM with a head bone.
+    const headBoneWorldPos = new THREE.Vector3();
+    headBone.getWorldPosition(headBoneWorldPos);
+
+    const bodyBox = new THREE.Box3();
+    vrm.scene.traverse((child) => {
+      const mesh = child as THREE.Mesh;
+      if (!mesh.isMesh) return;
+      if (!mesh.geometry) return;
+      // Skip cosmetic Groups (they are not Mesh, but guard anyway).
+      if (child.name.startsWith('cosmetic-')) return;
+      const meshBox = new THREE.Box3().setFromObject(mesh);
+      if (meshBox.isEmpty()) return;
+      bodyBox.union(meshBox);
+    });
+
+    if (bodyBox.isEmpty()) return null;
+
+    headTopWorldY = bodyBox.max.y;
+    headHeightWU  = Math.max(headTopWorldY - headBoneWorldPos.y, eps);
+    headWidthWU   = headHeightWU * HEAD_WIDTH_TO_HEIGHT;
+    headDepthWU   = headWidthWU; // assume square cross-section for fallback
+    headCenterX   = headBoneWorldPos.x;
+    headCenterZ   = headBoneWorldPos.z;
+  }
+
+  // 3b. Per-rig correction for avatars whose skin weights corrupt the auto
+  //     measurement (see RIG_HEAD_OVERRIDE). For the worst rigs we DISCARD the
+  //     vert measurement and anchor to the head BONE (reliable) + override dims.
+  const rigOverride = tuningOverride ?? (rigKey ? RIG_HEAD_OVERRIDE[rigKey] : undefined);
+  if (rigOverride?.boneAnchored) {
+    const hb = new THREE.Vector3(); headBone.getWorldPosition(hb);
+    const hsc = new THREE.Vector3(); headBone.getWorldScale(hsc);
+    const boneScale = (Math.abs(hsc.x) + Math.abs(hsc.y) + Math.abs(hsc.z)) / 3 || 1;
+    const topAboveM = rigOverride.headTopAboveBoneM ?? 0.13;
+    // Crown can be ABOVE or BELOW the bone (broken rigs displace the head mesh).
+    headTopWorldY = hb.y + topAboveM * boneScale;
+    // Height is SEPARATE (defaults to topAbove) so a negative crown still has size.
+    headHeightWU  = Math.max((rigOverride.headHeightM ?? Math.abs(topAboveM)) * boneScale, eps);
+    headWidthWU   = Math.max((rigOverride.headWidthM ?? 0.15) * boneScale, eps);
+    headDepthWU   = Math.max((rigOverride.headDepthM ?? rigOverride.headWidthM ?? 0.15) * boneScale, eps);
+    headCenterX   = hb.x;
+    headCenterZ   = hb.z;
+  } else if (rigOverride?.geometricTopSlab) {
+    // GEOMETRIC TOP-SLAB: discard bone + skin-weight entirely. Measure the full
+    // posed body AABB; the crown is its max.y; the head is the top `headFraction`
+    // of total height, centred on the body's X/Z. Width is derived from the head
+    // HEIGHT (not the raw slab) so pigtails / side-hair don't inflate it. Runs
+    // ONCE at equip — vert traversal is fine here (NOT per frame).
+    const bodyBox = new THREE.Box3();
+    const btmp = new THREE.Vector3();
+    vrm.scene.traverse((child) => {
+      const sm = child as THREE.SkinnedMesh;
+      if (!sm.isSkinnedMesh || !sm.skeleton || !sm.geometry) return;
+      if (sm.name.startsWith('cosmetic-')) return;
+      const pos = sm.geometry.getAttribute('position') as THREE.BufferAttribute | undefined;
+      if (!pos) return;
+      sm.skeleton.update();
+      const stride = pos.count > 15000 ? 3 : 1; // subsample huge meshes
+      for (let i = 0; i < pos.count; i += stride) {
+        btmp.fromBufferAttribute(pos, i);
+        sm.applyBoneTransform(i, btmp);
+        sm.localToWorld(btmp);
+        if (isFinite(btmp.x) && isFinite(btmp.y) && isFinite(btmp.z)) bodyBox.expandByPoint(btmp);
+      }
+    });
+    if (!bodyBox.isEmpty()) {
+      const bsz = new THREE.Vector3(); bodyBox.getSize(bsz);
+      const bctr = new THREE.Vector3(); bodyBox.getCenter(bctr);
+      const frac = rigOverride.headFraction ?? 0.42;
+      headTopWorldY = bodyBox.max.y;                                  // crown
+      headHeightWU  = Math.max(bsz.y * frac, eps);                    // top frac of body
+      headWidthWU   = Math.max(headHeightWU * HEAD_WIDTH_TO_HEIGHT, eps);
+      headDepthWU   = headWidthWU;
+      headCenterX   = bctr.x;
+      headCenterZ   = bctr.z;
+    }
+  }
+
+  // 4. desiredWorldWidth: the world width we want the cosmetic to occupy.
+  const desiredWorldWidth = headWidthWU * CATEGORY_WIDTH_FACTOR[category];
+
+  // 5. Compute WORLD-SPACE target position of the cosmetic.
   //
-  //    Hat: hover directly above the head top, slightly inward along Y.
-  //    Glasses: at eye level (fraction below head top) with a forward offset
-  //    along the body-facing direction.
+  //    Hat:    hover directly above the head top + HAT_CLEARANCE_WU.
+  //    Glasses: at eye level (GLASSES_EYE_FRACTION below head-top) with a
+  //             forward offset along the body-facing direction.
   //
-  //    Body facing direction in WORLD space:
-  //    We read the avatar scene's +Z-local axis in world space and NEGATE it
-  //    to get the facing direction. All ClawVille VRMs face -Z after load
-  //    (memory: feedback_vrm_facing_formula — Milady VRM0 gets rotateVRM0
-  //    which adds π, flipping to face -Z; Hermes/Tekk/Phanes/chibi VRM1.x
-  //    face +Z natively and get faceYaw=Math.PI applied in the picker/world
-  //    scene, also ending at -Z).  So the face direction = scene.getWorldDirection()
-  //    which returns the -Z local axis in world space.
-  const facingDirWorld = new THREE.Vector3();
-  vrm.scene.getWorldDirection(facingDirWorld); // −Z axis in world space = face forward
+  //    FACING DIRECTION (robust, per-avatar):
+  //    The NORMALIZED head bone faces world -Z by VRM spec — true for BOTH VRM0
+  //    and VRM1 after three-vrm normalization, and it tracks the scene's
+  //    rotation. So its world -Z axis IS the avatar's face-forward, regardless
+  //    of rig convention. This fixes glasses rendering behind/inside the head on
+  //    the VRM1 rigs, where the global getWorldDirection sign was wrong (it only
+  //    held for one orientation). Falls back to the legacy raw direction.
+  const facingDirWorld = new THREE.Vector3(0, 0, -1);
+  const normHeadBone = vrm.humanoid?.getNormalizedBoneNode?.('head') ?? null;
+  if (normHeadBone) {
+    // The normalized bone tree is updated by vrm.update() (a separate hierarchy
+    // from the raw skeleton). Force its world matrix current in case equip runs
+    // before the first vrm.update() — otherwise the face quaternion is stale.
+    normHeadBone.updateWorldMatrix(true, false);
+    const faceQuat = new THREE.Quaternion();
+    normHeadBone.getWorldQuaternion(faceQuat);
+    facingDirWorld.set(0, 0, -1).applyQuaternion(faceQuat);
+  } else {
+    vrm.scene.getWorldDirection(facingDirWorld);
+    facingDirWorld.multiplyScalar(GLASSES_FACING_SIGN);
+  }
+  facingDirWorld.y = 0; // keep forward horizontal
+  if (facingDirWorld.lengthSq() < 1e-8) facingDirWorld.set(0, 0, -1);
+  facingDirWorld.normalize();
 
   let targetWorldPos: THREE.Vector3;
 
   if (category === 'hat') {
-    // Place at head top + clearance, above head bone center XZ.
-    const centerX = (headBox.min.x + headBox.max.x) * 0.5;
-    const centerZ = (headBox.min.z + headBox.max.z) * 0.5;
+    // Drop the hat DOWN onto the head (base below the crown) so the head fills
+    // the hat opening — a worn look, not balanced-on-top.
     targetWorldPos = new THREE.Vector3(
-      centerX,
-      headTopWorldY + HAT_CLEARANCE_WU * localScale,
-      centerZ,
+      headCenterX,
+      headTopWorldY - headHeightWU * HAT_DROP_FRACTION,
+      headCenterZ,
     );
   } else {
-    // 'glasses': place at eye level, shifted forward.
+    // 'glasses': eye level (measured head height below the crown) + forward offset
+    // along the face-forward dir, sized by measured head DEPTH so the lenses sit
+    // just in front of the face surface.
     const eyeLevelWorldY = headTopWorldY - headHeightWU * GLASSES_EYE_FRACTION;
-    const forwardOffsetWU = headWidthWU * GLASSES_FORWARD_FACTOR;
-    const centerX = (headBox.min.x + headBox.max.x) * 0.5;
-    const centerZ = (headBox.min.z + headBox.max.z) * 0.5;
+    const forwardOffsetWU = headDepthWU * GLASSES_FORWARD_FACTOR;
     targetWorldPos = new THREE.Vector3(
-      centerX + facingDirWorld.x * forwardOffsetWU,
+      headCenterX + facingDirWorld.x * forwardOffsetWU,
       eyeLevelWorldY,
-      centerZ + facingDirWorld.z * forwardOffsetWU,
+      headCenterZ + facingDirWorld.z * forwardOffsetWU,
     );
   }
 
-  // 5. Convert world-space target position to HEAD-BONE-LOCAL space via the
-  //    bone's inverse world matrix.  This is AXIS-SIGN SAFE — it handles any
-  //    rig convention (VRM0 +Z forward, VRM1 -Z forward, Mixamo cm origin,
-  //    VRoid m origin) without a single hardcoded ±Z.
+  // 6. Convert world-space target → HEAD-BONE-LOCAL via the bone's inverse
+  //    world matrix.  AXIS-SIGN SAFE for any rig convention.
   const invBoneMat = new THREE.Matrix4().copy(headBone.matrixWorld).invert();
   const localPosition = targetWorldPos.clone().applyMatrix4(invBoneMat);
 
-  return { localPosition, localScale, headWidthWU };
+  // Guard final output for NaN (degenerate matrix inversion).
+  if (!isFinite(localPosition.x) || !isFinite(localPosition.y) || !isFinite(localPosition.z)) {
+    return null;
+  }
+
+  return { localPosition, desiredWorldWidth, headWidthWU };
+}
+
+/**
+ * Tunable: how far the hat's "hide footprint" radius is, as a fraction of head
+ * width, and how far BELOW the brim plane we start hiding (so the brim line
+ * itself is clean). Tuned on /preview/cosmetics (?{rig}HideR=&{rig}HideY=).
+ */
+export const SCALP_HIDE_RADIUS_FACTOR = 0.62;
+export const SCALP_HIDE_DROP_WU = 2;
+
+/**
+ * Hide the avatar's body-mesh geometry UNDER a hat so baked-in hair/scalp cannot
+ * poke through it. Most ClawVille avatars are a SINGLE fused mesh (hair baked
+ * into the body, one material — see VRM inspection 2026-06-07), so the hair can't
+ * be hidden by toggling a separate mesh. Instead we drop the index-buffer
+ * TRIANGLES whose posed centroid is inside the hat footprint (above the brim
+ * plane, within `radius`); the opaque hat covers the removed region. The face
+ * (below the brim) is untouched.
+ *
+ * Reversible — returns a restore fn (call on unequip / hat swap). Posed positions
+ * use applyBoneTransform (with skeleton.update first, per the equip-on-load race),
+ * computed once per vertex. NOT called for glasses.
+ */
+export function hideHeadGeometryUnderHat(
+  vrm: { scene: THREE.Object3D },
+  brimWorldY: number,
+  centerX: number,
+  centerZ: number,
+  radius: number,
+): () => void {
+  const restores: Array<() => void> = [];
+  const r2 = radius * radius;
+  const yFloor = brimWorldY - SCALP_HIDE_DROP_WU;
+  const tmp = new THREE.Vector3();
+  vrm.scene.traverse((child) => {
+    const sm = child as THREE.SkinnedMesh;
+    if (!sm.isSkinnedMesh || !sm.skeleton || !sm.geometry) return;
+    if (sm.name.startsWith('cosmetic-')) return;
+    const geo = sm.geometry;
+    const pos = geo.getAttribute('position') as THREE.BufferAttribute | undefined;
+    const index = geo.index;
+    if (!pos || !index) return;
+    sm.skeleton.update();
+    const n = pos.count;
+    const wx = new Float32Array(n);
+    const wy = new Float32Array(n);
+    const wz = new Float32Array(n);
+    for (let v = 0; v < n; v++) {
+      tmp.fromBufferAttribute(pos, v);
+      sm.applyBoneTransform(v, tmp);
+      sm.localToWorld(tmp);
+      wx[v] = tmp.x; wy[v] = tmp.y; wz[v] = tmp.z;
+    }
+    const src = index.array;
+    const kept: number[] = [];
+    let removed = 0;
+    for (let t = 0; t < src.length; t += 3) {
+      const a = src[t], b = src[t + 1], c = src[t + 2];
+      const cx = (wx[a] + wx[b] + wx[c]) / 3;
+      const cy = (wy[a] + wy[b] + wy[c]) / 3;
+      const cz = (wz[a] + wz[b] + wz[c]) / 3;
+      const dx = cx - centerX, dz = cz - centerZ;
+      if (cy >= yFloor && dx * dx + dz * dz <= r2) { removed++; continue; }
+      kept.push(a, b, c);
+    }
+    if (removed === 0) return;
+    const Arr = (src as Uint8Array | Uint16Array | Uint32Array).constructor as
+      | Uint16ArrayConstructor
+      | Uint32ArrayConstructor;
+    geo.setIndex(new THREE.BufferAttribute(new Arr(kept), 1));
+    restores.push(() => geo.setIndex(index));
+  });
+  return () => restores.forEach((r) => r());
 }

--- a/apps/web/src/lib/three/vrm-avatar-sizing.ts
+++ b/apps/web/src/lib/three/vrm-avatar-sizing.ts
@@ -23,6 +23,8 @@
  *   - apps/web/src/lib/three/arena-npcs.tsx (wandering NPCs)
  *   - apps/web/src/lib/three/player-avatar.tsx (player-controlled VRM)
  *   - any future VRM render site
+ *
+ * cosmetic-loader.tsx also calls computeCosmeticHeadFit (defined below).
  */
 
 import * as THREE from 'three';
@@ -169,4 +171,224 @@ export function computeVRMAvatarFit(
   // rigs box.min.y is negative (feet below hips/pivot) → offsetY > 0.
   const offsetY = -box.min.y * scale;
   return { scale, offsetY };
+}
+
+// ---------------------------------------------------------------------------
+// Cosmetic head-fit helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Axis-sign-safe cosmetic placement in head-bone-LOCAL space.
+ *
+ * DESIGN RATIONALE (2026-06-07 plan §"DESIGN REFINEMENT"):
+ *
+ *   Every ClawVille humanoid VRM (Milady, Hermes, Tekk, Phanes, chibi) has
+ *   a VRM humanoid 'head' bone. The convention (VRM0 vs VRM1, Mixamo vs
+ *   VRoid rig origin) differs across rigs. Rather than hardcoding ±Z forward,
+ *   we:
+ *
+ *     1. Find the head bone's WORLD position at rest (matrixWorld already
+ *        updated by computeVRMAvatarFit / caller's updateMatrixWorld).
+ *     2. Measure the head region's WORLD-space bounding box by traversing
+ *        geometry children of the head bone subtree (skipping SkinnedMesh
+ *        nodes whose bind-pose bbox is unreliable at scale — see
+ *        gotcha skinned-mesh-bbox-inflation.md).
+ *     3. Derive hat/glasses target position in WORLD space (head-top + lift
+ *        for hats; eye-level + body-forward-offset for glasses).
+ *     4. Convert to HEAD-BONE-LOCAL via boneMat.invert().  This is
+ *        convention-agnostic — the matrix handles any sign combination.
+ *
+ *   The GLB cosmetic assets were authored in metric (meters) for a Mixamo-
+ *   scale rig where the head-bone-local frame is approximately the same size
+ *   as a real head (~0.2m wide). The `scale` output enlarges them into world
+ *   units proportional to the measured head width.
+ *
+ *   Per-item assetMeta nudges (optional offsetXYZ / scaleHint) are applied
+ *   ON TOP of the computed fit by the caller (HatOrGlassesRenderer).
+ *
+ * PERFORMANCE: this function is called ONCE at equip time (effect setup),
+ * NOT per frame. Internal scratch vectors/matrices are local to the call —
+ * per the Iris Xe invariant, no per-frame allocations.
+ *
+ * @param vrm - the loaded VRM instance (must have humanoid + scene).
+ *   vrm.scene.matrixWorld must be up to date (call updateMatrixWorld first,
+ *   which computeVRMAvatarFit already does; callers that don't go through
+ *   that helper should call vrm.scene.updateMatrixWorld(true) before here).
+ * @param category - 'hat' | 'glasses'
+ * @param renderScale - the world scale applied to vrm.scene (from computeVRMAvatarFit).
+ *   Required to convert head-bone native units → world units.
+ * @returns { localPosition, localScale, headWidthWU } or null if no head bone.
+ *   localPosition: THREE.Vector3 in head-bone-local space for the cosmetic Group.
+ *   localScale:    uniform scale (scalar) for the cosmetic Group.
+ *   headWidthWU:   head width in world units (diagnostic, also used by caller for
+ *                  per-category override math).
+ */
+export interface CosmeticHeadFitResult {
+  localPosition: THREE.Vector3;
+  localScale:    number;
+  /** head bounding-box width in world units (useful for debugging + nudge math) */
+  headWidthWU:   number;
+}
+
+/**
+ * Reference head width (world units) the cosmetic GLBs were authored for.
+ *
+ * The procedural placeholder GLBs (generate-cosmetic-glbs.mjs) were built in
+ * metric. A Milady VRM at renderScale ≈ 169 has a head bbox ≈ 28–34 wu wide.
+ * We use 30 wu as the design reference — cosmetics authored at 1× scale look
+ * correct on Milady at 30 wu.  Larger/smaller heads get cosmetics scaled
+ * proportionally.
+ */
+export const COSMETIC_REF_HEAD_WIDTH_WU = 30;
+
+/**
+ * Hat clearance: extra vertical gap between measured head-top and hat base,
+ * in world units.  Prevents the hat from clipping into hair.
+ */
+const HAT_CLEARANCE_WU = 2;
+
+/**
+ * Glasses sit at this fraction below head-top-to-head-bottom.
+ * 0.25 ≈ eye-level on a typical humanoid head.
+ */
+const GLASSES_EYE_FRACTION = 0.25;
+
+/**
+ * How far forward (in world units, relative to head width) glasses are offset
+ * from the head-bone origin along the BODY-FACING direction.  Prevents clipping
+ * into the face.
+ */
+const GLASSES_FORWARD_FACTOR = 0.5;
+
+export function computeCosmeticHeadFit(
+  vrm: {
+    humanoid?: { getRawBoneNode?: (name: string) => THREE.Object3D | null } | null;
+    scene: THREE.Object3D;
+  } | null | undefined,
+  category: 'hat' | 'glasses',
+  renderScale: number,
+): CosmeticHeadFitResult | null {
+  if (!vrm) return null;
+
+  // 1. Get the raw head bone (what the animator actually drives — NOT the
+  //    normalized bone used by the AnimationMixer).
+  const headBone =
+    vrm.humanoid?.getRawBoneNode?.('head') ?? null;
+  if (!headBone) return null;
+
+  // Ensure world matrices are current.  The VRM is already at renderScale
+  // in the scene at this point (caller applies scale before calling equip).
+  vrm.scene.updateMatrixWorld(true);
+
+  // 2. World position of the head bone.
+  // Scratch vectors — local to this call, never allocated per frame.
+  const headBoneWorldPos = new THREE.Vector3();
+  headBone.getWorldPosition(headBoneWorldPos);
+
+  // 3. Build WORLD-space AABB of the head region.
+  //    We walk DIRECT children of the head bone and any non-SkinnedMesh
+  //    descendants whose geometry origin is close to the head bone.
+  //    SkinnedMesh bind-pose bboxes are unreliable (see
+  //    gotcha: skinned-mesh-bbox-inflation.md) — we skip them.
+  //
+  //    If no geometry is found under the head bone we fall back to a
+  //    fraction of the full body bbox so chibi / low-poly VRMs still get
+  //    a sensible estimate.
+  const headBox = new THREE.Box3();
+  headBone.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (!mesh.isMesh) return;
+    if ((mesh as THREE.SkinnedMesh).isSkinnedMesh) return; // unreliable bbox
+    if (!mesh.geometry) return;
+    mesh.geometry.computeBoundingBox();
+    const geoBbox = mesh.geometry.boundingBox;
+    if (!geoBbox) return;
+    // Expand the accumulating box with this mesh's geometry in world space.
+    const tempBox = geoBbox.clone().applyMatrix4(mesh.matrixWorld);
+    headBox.union(tempBox);
+  });
+
+  // Fallback: if head subtree has no usable geometry, estimate from full bbox.
+  const usedFallback = headBox.isEmpty();
+  if (usedFallback) {
+    // Estimate head as top 15 % of total body bbox height.
+    const bodyBox = new THREE.Box3().setFromObject(vrm.scene as unknown as THREE.Object3D);
+    const bodyHeight = bodyBox.max.y - bodyBox.min.y;
+    const headTopEst = bodyBox.max.y;
+    const headBottomEst = headTopEst - bodyHeight * 0.15;
+    const headHalfWidthEst = bodyHeight * 0.08; // typical head width ≈ 16% of body height
+    headBox.min.set(
+      headBoneWorldPos.x - headHalfWidthEst,
+      headBottomEst,
+      headBoneWorldPos.z - headHalfWidthEst,
+    );
+    headBox.max.set(
+      headBoneWorldPos.x + headHalfWidthEst,
+      headTopEst,
+      headBoneWorldPos.z + headHalfWidthEst,
+    );
+  }
+
+  const headSize = new THREE.Vector3();
+  headBox.getSize(headSize);
+
+  const headTopWorldY  = headBox.max.y;
+  const headWidthWU    = headSize.x; // WORLD units at current renderScale
+  const headHeightWU   = headSize.y;
+
+  // Scale cosmetic proportional to measured head width vs the reference.
+  // Clamp to a reasonable range to avoid absurdly large/tiny cosmetics on
+  // edge cases (e.g. a very low-poly head mesh with a 1-triangle bbox).
+  const rawScale = headWidthWU / COSMETIC_REF_HEAD_WIDTH_WU;
+  const localScale = Math.max(0.25, Math.min(4.0, rawScale));
+
+  // 4. Compute WORLD-SPACE target position of the cosmetic.
+  //
+  //    Hat: hover directly above the head top, slightly inward along Y.
+  //    Glasses: at eye level (fraction below head top) with a forward offset
+  //    along the body-facing direction.
+  //
+  //    Body facing direction in WORLD space:
+  //    We read the avatar scene's +Z-local axis in world space and NEGATE it
+  //    to get the facing direction. All ClawVille VRMs face -Z after load
+  //    (memory: feedback_vrm_facing_formula — Milady VRM0 gets rotateVRM0
+  //    which adds π, flipping to face -Z; Hermes/Tekk/Phanes/chibi VRM1.x
+  //    face +Z natively and get faceYaw=Math.PI applied in the picker/world
+  //    scene, also ending at -Z).  So the face direction = scene.getWorldDirection()
+  //    which returns the -Z local axis in world space.
+  const facingDirWorld = new THREE.Vector3();
+  vrm.scene.getWorldDirection(facingDirWorld); // −Z axis in world space = face forward
+
+  let targetWorldPos: THREE.Vector3;
+
+  if (category === 'hat') {
+    // Place at head top + clearance, above head bone center XZ.
+    const centerX = (headBox.min.x + headBox.max.x) * 0.5;
+    const centerZ = (headBox.min.z + headBox.max.z) * 0.5;
+    targetWorldPos = new THREE.Vector3(
+      centerX,
+      headTopWorldY + HAT_CLEARANCE_WU * localScale,
+      centerZ,
+    );
+  } else {
+    // 'glasses': place at eye level, shifted forward.
+    const eyeLevelWorldY = headTopWorldY - headHeightWU * GLASSES_EYE_FRACTION;
+    const forwardOffsetWU = headWidthWU * GLASSES_FORWARD_FACTOR;
+    const centerX = (headBox.min.x + headBox.max.x) * 0.5;
+    const centerZ = (headBox.min.z + headBox.max.z) * 0.5;
+    targetWorldPos = new THREE.Vector3(
+      centerX + facingDirWorld.x * forwardOffsetWU,
+      eyeLevelWorldY,
+      centerZ + facingDirWorld.z * forwardOffsetWU,
+    );
+  }
+
+  // 5. Convert world-space target position to HEAD-BONE-LOCAL space via the
+  //    bone's inverse world matrix.  This is AXIS-SIGN SAFE — it handles any
+  //    rig convention (VRM0 +Z forward, VRM1 -Z forward, Mixamo cm origin,
+  //    VRoid m origin) without a single hardcoded ±Z.
+  const invBoneMat = new THREE.Matrix4().copy(headBone.matrixWorld).invert();
+  const localPosition = targetWorldPos.clone().applyMatrix4(invBoneMat);
+
+  return { localPosition, localScale, headWidthWU };
 }


### PR DESCRIPTION
Ships the Phase-B proportion-aware cosmetic hat/glasses fit system to prod, isolated (cherry-pick of 1ec1e1a8 + the head-fit rewrite + chibi geometric fix, NOT staging→master). Same feature verified live on staging.

**What:** `computeCosmeticHeadFit` (seed-based head measurement + RIG_HEAD_OVERRIDE + CATEGORY_WIDTH_FACTOR) + the `cosmetic-loader.tsx` Phase-B rewrite + a `player-avatar.tsx` cosmetic-props tweak + `/preview/cosmetics` dev tuner. Fixes hat/glasses placement for all humanoid VRMs; the **chibi** uses a geometric top-slab measure so its hat sits on the crown (was the neck — founder-signed-off).

**Merge:** 3-way cherry-pick onto master; code auto-merged (master's Hatcher sizing + player-avatar evolution preserved), only 3dStructure.md conflicted (kept master's).

**Verified on staging /preview/cosmetics:** chibi hat on crown ✅; Milady + Tekk hats correct ✅; Phanes shows no hat = PRE-EXISTING auto-fit gap (not a regression), Hatcher agent avatar, low-impact. Web build green on master's codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)