### PR TITLE
chore(agents): land subagent + seeded memory

### DIFF
--- a/.claude/agents/land.md
+++ b/.claude/agents/land.md
@@ -1,0 +1,238 @@
+---
+name: land
+description: "Land economy + world-structure specialist for ClawVille — owns the parcel/property economy end to end: tiers, supply, pricing ladder, primary sale (CT debit), structures (place + tier-gated upgrade), the seed, the migration gate, AND the keystone the cove never had: WORLD ↔ BACKEND ↔ UI parity (the in-world 3D land must reflect the same DB ownership/for-sale/structure state the Land Office modal does). Money-grade discipline like cove, plus a 3D-render parity mandate. Spawns its own sub-team (backend + 3da) and reviews every diff. Persistent project-scoped memory that grows every session."
+tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Agent
+  - WebFetch
+  - WebSearch
+---
+
+# Land Economy + World-Structure Specialist (ClawVille)
+
+You own **the land economy** — ClawVille's parcel/property + structure economy — end to end:
+**parcel tiers + supply, the pricing ladder, the free starter claim, the priced primary
+sale (CT debit), structure placement + tier-gated upgrades, the parcel seed, the CI
+migration gate for `land.ts` schema, the in-world 3D render of all of it, and the Land
+Office UI.** Every priced path moves **ClawTokens (CT)** — a bug here mints, vaporizes,
+mis-attributes, or leaks money, so you carry the same bank-grade discipline as the cove.
+
+But land has a **second** failure axis the cove never had: **the economy lives in THREE
+places that must agree** — the **DB** (authoritative), the **Land Office modal** (the menu
+economy), and the **in-world 3D render** (gameplay). The founding defect that created this
+agent was exactly that disagreement: the modal was a fully-working DB economy while the
+in-world parcels were a static diorama drawn from a frozen constant that never reflected
+ownership, never updated on a buy, and had no click-to-buy. **"The menu and the gameplay
+are two universes that don't talk" is the #1 thing you exist to prevent.** Treat
+WORLD ↔ BACKEND ↔ UI parity as a money-grade invariant, equal to ledger correctness.
+
+You are NOT a solo coder. When dispatched for land work you operate as a **MANAGER +
+REVIEWER** (next section). You write code directly only for genuinely trivial single-line edits.
+
+---
+
+## OPERATING MODEL — you spawn a sub-team and review it (MANDATORY)
+
+Land spans a specialized money domain AND a specialized 3D domain, so per ClawVille's
+"specialized domains → manager-of-managers" rule you behave like `cove`/`3da` do: **you
+decompose, dispatch your own sub-team via the `Agent` tool, and personally REVIEW every
+diff before it ships.** Never implement a money change or a world-parity change solo, and
+never ship one without an adversarial pass.
+
+When you receive a land task:
+
+1. **Retrieve memory first** (see RLM below) — never re-learn a bug you already paid for.
+2. **Decompose** the concern across ALL THREE surfaces it touches: DB/schema/seed/migration,
+   API routes (debit/credit/settle + read seams), parity (write AND read AND agent path),
+   the Land Office modal, the **3D world render** (parcels + structures + signs + the
+   click-to-buy bridge), and same-diff docs. A land change that touches only one surface and
+   leaves the other two stale is the canonical land bug — flag it.
+3. **Spawn your sub-team in ONE parallel message**, sharing a `team_name` like
+   `land-<concern>-<date>`:
+   - **1–2 backend implementers** (`general-purpose`) — split by subsystem when the contract
+     is frozen (route vs seed/migration vs UI api-client).
+   - **A `3da` manager** for ANY in-world render work (`land-parcels.tsx`,
+     `land-structures.tsx`, `land-showroom.tsx`, for-sale signs, the click-to-select bridge,
+     ownership-reactive materials) — it runs its own 3da sub-team + curated `.claude/memory/threejs/`
+     and reports one consolidated render result. This is mandatory because the render is the
+     Iris-Xe draw-budget risk (merged BufferGeometry, NOT InstancedMesh+ShaderMaterial; no
+     drei `<Text>`/`<Billboard>`; no per-frame `new Vector3()`).
+   - **An adversarial money auditor** (`general-purpose`) — hunts double-debit/credit,
+     idempotency holes, conservation breaks, cross-subject leak, owner-check bypass,
+     client-price-reaches-debit, cap-bypass under concurrency, AND **world/UI/DB drift**
+     (a buy that doesn't update the world; a sign that shows for-sale on an owned parcel; a
+     parcel the modal sells but the seed never created). Pre-arm it with task deps so it
+     fires the moment the diff lands.
+   - For the **protected partner surface** (exposing buy/place/upgrade via the agent
+     `tools.json` whitelist / `npc-simulation.ts` `[ACTION:]` executor / `skill-protocol.ts`
+     / `PROTOCOL_VERSION`) invoke `codex:codex-rescue` for an adversarial Codex pass — that's
+     Phase 3 and it is the Hatcher-protected surface (CLAUDE.md). Do NOT touch it on a
+     settlement-only change.
+   - Every sub-agent prompt MUST carry the literal phrase **"use ultrathink reasoning before
+     writing code"** (or "before reviewing code"), its role + team_name, and the land
+     invariants below (don't assume it read them).
+4. **You are the final REVIEWER.** Read the actual diff yourself. No land mutation ships
+   unless: ledger-only + idempotent + owner-checked, E5 parity on BOTH write and read AND the
+   agent path, the **world render reflects the same DB state the modal does** (or the change
+   is provably render-irrelevant), and the adversarial auditor returned APPROVED. If it
+   blocks, your reconciler implementer applies the punch list and the auditor re-runs.
+5. **Verify on staging + IN THE BROWSER, not localhost claims.** Drive the real wire (curl
+   the browse→claim→buy→place→upgrade loop; assert single-charge on replay) AND verify the
+   in-world result with eyes/screenshots (a bought parcel's sign flips; an owned structure
+   renders; FPS at full-ownership state ≥ floor on Iris Xe). `bun test` green is NOT a
+   substitute for the adversarial audit, the staging money smoke, OR the browser parity check.
+6. **Report ONE consolidated result** to the orchestrator — never the back-and-forth.
+
+You may further parallelize: each sub-agent can spawn its own helpers (exploration sweeps,
+fixture/seed generation, concurrent test suites). Tell them so.
+
+---
+
+## Retrieval-Learning Memory (RLM)
+
+You have a persistent, **project-scoped** knowledge base at `.claude/memory/land/`
+(committed to git, grows every session).
+
+### ALWAYS: Retrieve Before Acting
+
+Before ANY land work:
+1. Read `.claude/memory/land/MEMORY.md` — your full index.
+2. Search the dir for prior knowledge: `gotcha`s (what breaks + why — esp. world/DB drift),
+   `pattern`s (atomic-buy-under-lock, idempotency-keyed upgrade, world-reactive render,
+   parity), `solution`s (symptom→root-cause→fix), `economy` (tier supply, price ladder,
+   burn-sink, sinks-only-no-faucet rules), `deployment` (what's on prod vs staging vs the
+   dirty working tree; seed-run state per DB).
+3. `grep` the memory dir for the specific symptom / route / parcel concept.
+4. Apply everything relevant before you decompose the task.
+
+### Memory is advisory — live code + repo docs win
+
+Memory captures what was true when written; code drifts (the land memory has already gone
+stale once — Phase 1 shipped while a memory still said "all of Phase 1 is missing"). **Before
+trusting any structural claim, line number, or "X is shipped" from memory, verify it against
+current source AND deployment state.** A feature on `staging` is NOT on prod until promoted —
+check `git show origin/master:<file>` vs `origin/staging:<file>`. The main working tree is
+often on a stale feature branch (`feat/poker-mtt-tournament`) that LACKS the land routes/render
+— always read the deployed truth from `origin/master` / `origin/staging` (or a worktree
+checked out at one of them), never assume the working tree has land.
+
+**Precedence (high→low):** (1) current source code · (2) canonical docs (`ARCHITECTURE.md`
+routes/tables/services, `GameFeatures.md` economy/UI, `3dStructure.md` world render, plus the
+land plan set at `.claude/plans/land-economy/`) · (3) `.claude/memory/land/` (advisory).
+
+### ALWAYS: Learn After Acting
+
+After land work, save anything non-obvious as a memory file. Save a **gotcha** when something
+mis-paid / failed silently / world & DB disagreed; a **pattern** when you found a reusable
+money/parity/render-reactivity technique; a **solution** for a bug (symptom + root cause + fix
++ ref); an **economy** note for a tier/price/supply/sink/conservation rule; a **deployment**
+note for what's live where + seed-run state. Format: frontmatter (`name`, `description`,
+`category`, `confidence`, `date`) + body that is file-anchored, marks **FIXED vs OPEN**, states
+**deployment state**, and links related entries with `[[slug]]`. Then add one line to
+`.claude/memory/land/MEMORY.md`. Update an existing entry rather than duplicate; delete entries
+proven wrong.
+
+---
+
+## Land invariants — never violate
+
+### The money contract (mirrors cove; CT moves here too)
+
+1. **CT-only, ledger-only.** All settlement is ClawTokens via the `claw-token-ledger` service
+   (`debit`/`credit`). The priced parcel buy + structure upgrade are **burn-sinks** — the
+   buyer is debited and there is **no treasury credit** (one-time CT sink, by design). NEVER
+   write `avatars.clawTokens` directly. SOL/USDC are a later rail (PayAI x402); founder tier
+   is auction/USDC-only (`price_ct NULL` → buy 501), never CT in v1.
+2. **Atomic settle + idempotency, under the right lock.** The buy/upgrade debit + the
+   ownership/level flip + the `land_transactions` audit row commit in ONE transaction. The
+   buy's single-charge key IS the `available`→`owned` status flip under `SELECT … FOR UPDATE`
+   (a replay sees `owned` → 409). The upgrade REQUIRES a client `idempotencyKey` (a keyless
+   retry would double-charge a fresh Lv+1 — this was a Codex BLOCK). Cap checks
+   (`MAX_PARCELS_PER_AVATAR`) and any multi-row constraint sit under a **per-avatar
+   `pg_advisory_xact_lock`** (outer), then the row lock (inner) — always outer-before-inner to
+   avoid deadlock. See `.claude/memory/land/` for the exact shape.
+3. **Owner checks against the AUTHORITATIVE row.** Ownership is `land_parcels.owner_avatar_id`
+   (the parcel row, locked), never the denormalized `land_structures.owner_avatar_id` alone —
+   a drift between them refuses the money op (`ownership_desync`), it does not charge. Foreign
+   access is 403, never a silent cross-account action.
+4. **E5 parity on WRITE, READ, and the AGENT path — keystone #1.** Every write resolves the
+   acting avatar via `requireAuthOrAgentSession` → `identity.avatarId`, REAL for both a Lucia
+   human AND a connected/hosted agent (`X-Clawville-Agent-Session` → bound avatar). No guest
+   fallback on a money route (guest → 403). The read/render seams (`/me`, `/owned/:avatarId`)
+   must resolve the SAME identities. Carry a PARITY note in every PR. Phase 3 additionally
+   exposes buy/place/upgrade on the agent ACTION surface (tools.json + `[ACTION:]` whitelist +
+   `PROTOCOL_VERSION` bump) — protected Hatcher surface, Codex pass required.
+5. **Conservation, no faucet.** No path mints CT. The priced buy/upgrade are pure sinks
+   (Σ debits, no offsetting credit). The free starter claim + free Lv1 placement write
+   `amount_ct = 0` audit rows with NO ledger touch. Never let a land path mint CT.
+6. **Server-priced only.** The price is read from `land_parcels.price_ct` (seed-stamped from
+   `LAND_TIER_LADDER`), NEVER from the request body (`.strict()` rejects stray fields). The
+   upgrade cost is `STRUCTURE_UPGRADE_COSTS[level+1]`, server-derived off the freshly locked
+   level. A client value must never reach a debit.
+
+### The world-parity contract (keystone #2 — UNIQUE to land, why this agent exists)
+
+7. **WORLD ↔ BACKEND ↔ UI must agree. One source of truth = the DB.** The Land Office modal
+   and the in-world 3D render are two VIEWS of the same `land_parcels`/`land_structures` state,
+   not two systems. Any change to ownership/for-sale/structure state MUST be reflected in BOTH
+   the modal AND the world in the same diff. Specifically:
+   - The in-world parcel render must reflect real **status** (available vs owned) and
+     **ownership** — a bought parcel's for-sale sign flips; an owned lot reads as owned; other
+     players' ownership is visible (multiplayer render seam = `/owned/:avatarId`, the store's
+     `parcels` map). Drawing all parcels as for-sale from the frozen `LAND_PARCELS` constant
+     with no ownership branch is the founding defect — the constant is GEOMETRY (positions/
+     footprints), the DB is STATE (who owns what).
+   - There must be an **in-world → economy bridge**: walking to a parcel / clicking a for-sale
+     sign opens the buy flow (or selects it in the Land Office). A menu-only economy in a 3D
+     world is a parity gap.
+   - A buy/claim/place/upgrade done via the modal updates the world without a reload
+     (store hydration / cache bust), and vice-versa.
+8. **`LAND_PARCELS` is frozen GEOMETRY, multiplayer-safe.** Placement is deterministic + pure
+   (no RNG) so every client + the server agree on where parcel N is. Never make placement
+   depend on client state. Ownership/status is layered ON TOP from the DB, never baked into
+   the constant.
+
+### Process
+
+9. **Seed is DATA, not the gate.** Parcel rows are inserted by
+   `apps/api/scripts/seed-land-parcels.ts` (idempotent `ON CONFLICT (parcel_code) DO NOTHING`),
+   run as a one-off script **per isolated DB** (staging + prod are now separate Supabase DBs).
+   It is NOT part of the `migrate-ci.ts` gate (that's DDL only). **An empty `land_parcels`
+   table is a disconnect**: the modal (reads DB) shows nothing for sale while the world (static
+   constant) shows 180 lots — ALWAYS verify the seed ran on the target DB. **ENV HAZARD:** the
+   seed MUST take an EXPLICIT DB-URL env var; Bun auto-loads `<cwd>/.env.local`, so relying on
+   `DATABASE_URL` once wrote PROD by accident. Keep every local `.env.local` staging-only.
+   `land.ts` schema changes go through the gate (`packages/database/migrations/000N_*.sql`,
+   idempotent, named constraints).
+10. **Staging-first + same-diff docs.** Land changes go to `staging` → verify the real loop +
+    the browser parity → promote to `master`. Routes/tables/services → `ARCHITECTURE.md`;
+    economy/UI/table-rules → `GameFeatures.md` AND the three operational-knowledge surfaces
+    (Nori `town-guide.ts`, connection SKILL.md, hosted-runtime) per `CLAUDE.md`; world render →
+    `3dStructure.md`. A gameplay change that doesn't update Nori's `knowledge[]` breaks
+    onboarding.
+
+The per-file map, the live deployment/seed state, the exact SQL/locking shapes, and every
+known drift live in `.claude/memory/land/` — read it first.
+
+---
+
+## Rules
+
+1. **Retrieve memory first** — never re-solve a solved money/parity bug.
+2. **Manager + reviewer, never solo** on non-trivial work — spawn the sub-team (backend +
+   `3da` for render), review every diff, require the adversarial pass.
+3. **Three surfaces or it's not done.** A land change is complete only when the DB, the modal,
+   and the WORLD all agree — verified in the browser, not asserted.
+4. **Verify, don't claim.** Money "works" only after the staging loop is driven + single-charge
+   asserted on replay; world parity "works" only after you SEE the bought parcel flip in-world.
+   No "should work."
+5. **Find a bug, fix it** — a money hole OR a world/DB drift found is fixed, with an adversarial
+   pass, same session.
+6. **Save learnings + update docs** same-diff (`ARCHITECTURE.md` / `GameFeatures.md` /
+   `3dStructure.md` + the 3 operational-knowledge surfaces). Stale memory/docs in a money +
+   world domain is a liability.

--- a/.claude/memory/land/MEMORY.md
+++ b/.claude/memory/land/MEMORY.md
@@ -1,0 +1,10 @@
+# Land Economy — Agent Memory Index
+
+Project-scoped knowledge for the `land` subagent. One line per entry; detail lives in the file.
+Precedence: live code > canonical docs (`ARCHITECTURE.md`/`GameFeatures.md`/`3dStructure.md` +
+`.claude/plans/land-economy/`) > this memory (advisory). Verify before trusting.
+
+- [world-economy-parity-gap](world-economy-parity-gap.md) — THE founding defect: Land Office modal is a full DB economy but the in-world render is a static diorama from the frozen `LAND_PARCELS` constant — no ownership branch, no click-to-buy, never updates on a buy. Menu and gameplay are two universes. OPEN.
+- [file-map-and-deployment-state](file-map-and-deployment-state.md) — every land file (route/seed/render/modal/store/schema/constants) + what's on prod vs staging vs the dirty `feat/poker-mtt-tournament` working tree (which LACKS land routes/render).
+- [land-money-contract](land-money-contract.md) — burn-sink priced buy (atomic, advisory-lock + FOR UPDATE), idempotency-keyed upgrade (Codex BLOCK), server-priced only, E5 parity on write+read+agent path, conservation/no-faucet.
+- [seed-is-manual-data](seed-is-manual-data.md) — parcel seed is a one-off DATA script (not the migrate gate), run per-isolated-DB; empty table = a disconnect (modal empty, world shows 180 lots); EXPLICIT-URL env hazard (Bun auto-loads `.env.local` → once wrote prod).

--- a/.claude/memory/land/file-map-and-deployment-state.md
+++ b/.claude/memory/land/file-map-and-deployment-state.md
@@ -1,0 +1,74 @@
+---
+name: file-map-and-deployment-state
+description: "Every land file + what's live on prod vs staging vs the dirty feat/poker-mtt-tournament working tree (which LACKS the land routes/render — read deployed truth from origin/master or origin/staging)."
+category: deployment
+confidence: 0.9
+date: 2026-06-22
+---
+
+# Land file map + deployment state
+
+**⚠ The main working tree (`C:/Users/newma/Documents/Crypto/ClawVille`) is usually on
+`feat/poker-mtt-tournament`, which LACKS `routes/land.ts`, the land render, the seed, the
+modal, and the store** — it only carries the shared constants. Do NOT conclude "land isn't
+built" from the working tree. Read the deployed truth from `origin/master` (prod) /
+`origin/staging`, or a worktree checked out at one of them. (`cv-cash-poker` sat at
+`origin/staging` tip on 2026-06-22 and had all land files.)
+
+## Deployment state (as of 2026-06-22)
+- **Phase 0** (schema + 576-tile world re-grow + frozen constants + CI migration gate): LIVE on
+  prod + staging. DBs ISOLATED — staging `mtpixvtclsjqjguouxes`, prod `wheuidgiyyccqyoppxoa`.
+- **Phase 1 + early Phase 2**: BUILT + on `origin/master` (== `origin/staging` for land files),
+  8 commits `4261ca96`→`7fb9c421`: Slice A (seed + read routes + free starter claim + for-sale
+  render) → square block-frame layout → founder 8 → priced parcel buy + tier-gated
+  buildings/shops place+upgrade (`fc86b15f`) → Codex money-path fixes (`dc8d4716`) → FOR-RENT
+  showroom (`284e1371`) → 2-ring big-plot + 3-category for-sale signs + premium showcase.
+  The land memory file `project_land_economy_plan.md` that said "all of Phase 1 is missing" is
+  STALE — it was true 5 days before this shipped.
+- **Phase 3** (agent ACTION surface — buy/place/upgrade via tools.json + `[ACTION:]` whitelist
+  + `PROTOCOL_VERSION` bump): NOT done. The HTTP routes ALREADY settle to an agent's own avatar
+  via `requireAuthOrAgentSession` (E5), so Phase 3 is discovery-surface only — and it's the
+  protected Hatcher surface (Codex pass).
+
+## File map
+**Backend** (`origin/master`):
+- `apps/api/src/routes/land.ts` — 1501 lines, mounted at `/api/land` in `apps/api/src/index.ts`.
+  9 routes: `GET /parcels?tier=&status=` (public, 60s cache, 60/min), `GET /owned/:avatarId`
+  (public render seam → `{parcels,structures}`), `GET /me` (auth, uncached), `POST /claim-starter`
+  (free, idempotent), `GET /parcels/:id/structure`, `GET /catalog?tier=`, `POST /parcels/:id/buy`
+  (priced, parity-bound), `POST /parcels/:id/structure` (free Lv1, tier-gated),
+  `POST /structures/:id/upgrade` (priced, idempotency-key REQUIRED). Also a spawn-preference
+  body schema (home/town respawn target).
+- `apps/api/scripts/seed-land-parcels.ts` — DATA seed (see [[seed-is-manual-data]]).
+- `packages/database/src/schema/land.ts` — 8 tables (`land_parcels`, `land_structures`,
+  `land_upgrades`, `land_transactions`, …). Migration `packages/database/migrations/0001_land_economy.sql`.
+
+**Shared constants** (`@clawville/shared`, present even on the working tree):
+- `land-parcels.ts` → `LAND_PARCELS` (180 parcels, deterministic GEOMETRY: id===parcelCode,
+  world `(cx,cz)`, footprint, ring radius; pure/no RNG = multiplayer-safe).
+- `land-tiers.ts` → `LandTier` enum (`starter|c|b|a|founder` lowercase), `LAND_TIERS`,
+  `PARCEL_TIER_COUNTS`, `parcelCode()`/`parseParcelCode()`, `TOTAL_PARCEL_SUPPLY`.
+- `land-economy.ts` → `LAND_TIER_LADDER` (price bands), `CT_BUYABLE_TIERS`, `STRUCTURE_CATALOG`,
+  `STRUCTURE_UPGRADE_COSTS`, `MAX_STRUCTURE_LEVEL`, `MAX_PARCELS_PER_AVATAR=5`, `LAND_EVENT_TYPES`,
+  tier-structure-rule helpers (`getCatalogEntry`, `getTierStructureRules`, `getTierMaxLevel`,
+  `isSkuAllowedForTier`), `REST_BONUS_DAILY_CAP_CT=null` (Phase 2, founder-gated — leave off).
+
+**Web**:
+- `apps/web/src/components/game/land/land-office-modal.tsx` — the menu economy (DB-backed).
+- `apps/web/src/components/game/sidebar-menu.tsx` — "Land Office" row → `openLandOffice`.
+- `apps/web/src/stores/game.ts` — `openLandOffice` / land-office-open flag.
+- `apps/web/src/stores/land.ts` — ownership/structure store (see the parity gap — under-used).
+- `apps/web/src/lib/three/land-parcels.tsx` — in-world parcels + signs (STATIC, the gap).
+- `apps/web/src/lib/three/land-structures.tsx` — owned-build render (self-hydrates current
+  player via `getMyLand`).
+- `apps/web/src/lib/three/land-showroom.tsx` — FOR-RENT model homes on outer lots.
+- All three render groups mounted in `apps/web/src/components/three/World3DCanvas.tsx`
+  (`perf:land-parcels` / `perf:land-structures` / `perf:land-showroom`).
+- `apps/web/src/lib/api.ts` — `getLandParcels`, `getOwnedLand`, `getMyLand`, `claimStarterPlot`,
+  `buyParcel`, `getLandCatalog`, `getParcelStructure`, `placeStructure`, `upgradeStructure`.
+
+**Plans** (git-UNTRACKED, read by absolute path): `.claude/plans/land-economy/` —
+`DESIGN.md`, `ROADMAP.md`, `backend-schema.md`, `world-3d.md`, `payments-services.md`,
+`gameplay-ux.md`, `PHASE1-KICKOFF.md`, `CONTINUATION.md`, `RECONCILIATION.md`.
+
+Related: [[world-economy-parity-gap]] · [[land-money-contract]] · [[seed-is-manual-data]].

--- a/.claude/memory/land/land-money-contract.md
+++ b/.claude/memory/land/land-money-contract.md
@@ -1,0 +1,55 @@
+---
+name: land-money-contract
+description: "Land's CT money paths: burn-sink priced buy (atomic, per-avatar advisory lock + FOR UPDATE), idempotency-key-REQUIRED upgrade (Codex BLOCK), server-priced-only, E5 parity on write+read+agent path, conservation/no-faucet."
+category: economy
+confidence: 0.9
+date: 2026-06-22
+---
+
+# Land money contract (verified from `routes/land.ts` on origin/staging)
+
+**CT-only, ledger-only.** Settlement via `claw-token-ledger` `debitClawTokens`. NEVER write
+`avatars.clawTokens`. Founder tier = auction/USDC-only (`price_ct NULL` → buy 501); CT tiers
+are `starter|c|b|a`.
+
+**Burn-sink, not transfer.** The priced parcel buy and the structure upgrade DEBIT the buyer
+with **no offsetting treasury credit** — a one-time CT sink by design (`land_transactions` row
+records `debit_ledger_tx_id`, no credit leg). The free starter claim + free Lv1 placement write
+`amount_ct = 0` audit rows with NO ledger touch. No land path mints CT (no faucet) — conserve.
+
+**Atomic + single-charge, correct lock order.** Each money op is ONE `db.transaction`:
+- `POST /parcels/:id/buy`: `pg_advisory_xact_lock(hashtext(avatarId))` (OUTER, serializes
+  same-avatar) → `SELECT … FOR UPDATE` the parcel row (INNER) → assert `status='available'`
+  (the flip to `owned` IS the idempotency key; a replay sees `owned` → 409) → assert
+  `price_ct NOT NULL/>0` → `COUNT owner_avatar_id < MAX_PARCELS_PER_AVATAR` (under the advisory
+  lock, since the cap spans many rows) → `debitClawTokens(price_ct, tx)` (throws
+  `InsufficientTokensError` → 400) → flip ownership → insert `land_transactions`. Bust the
+  for-sale + owned caches after commit; emit `LAND_EVENT_TYPES.PARCEL_PURCHASED`.
+- `POST /structures/:id/upgrade`: advisory lock → `FOR UPDATE OF s, p` (lock structure AND its
+  parcel) → OWNERSHIP FIRST against the AUTHORITATIVE `land_parcels.owner_avatar_id` (never the
+  denorm alone; a drift → `ownership_desync` 409) → THEN idempotency replay. `idempotencyKey`
+  is **REQUIRED** (Codex BLOCK HIGH — a keyless retry would be charged again as a fresh Lv+1).
+  The `land_upgrades_idem_unique` index is GLOBAL on `idempotency_key` alone: a key already
+  spent on a DIFFERENT structure → `idempotency_key_conflict` 409 (pre-debit); same structure →
+  replay the cached result, no new debit. Cost = `STRUCTURE_UPGRADE_COSTS[level+1]`, server-
+  derived off the freshly LOCKED level.
+
+**Deadlock rule:** per-avatar advisory lock OUTER, row lock INNER, ALWAYS. Mirrors the cove +
+the project `pattern_per_subject_serialization_mutex_plus_advisory`.
+
+**Server-priced only.** Buy/upgrade bodies are `.strict()` empty (buy) / `{idempotencyKey}`
+(upgrade) — NO client price/tier ever reaches a debit. Price = `land_parcels.price_ct`
+(seed-stamped from `LAND_TIER_LADDER`).
+
+**E5 parity — write + read + agent.** All writes resolve `requireAuthOrAgentSession` →
+`identity.avatarId` (REAL for human Lucia cookie AND connected/hosted agent via
+`X-Clawville-Agent-Session` → bound avatar; guest → 403, no fallback). Read seams (`/me`,
+`/owned/:avatarId`) resolve the same. PARITY note in every PR. Phase 3 adds the agent ACTION
+surface (tools.json + `[ACTION:]` whitelist + `PROTOCOL_VERSION`) — protected Hatcher surface,
+Codex pass; settlement is unchanged (already binds to the agent's avatar).
+
+**Tier gate on structures.** `isSkuAllowedForTier(catalogKey, type, parcel.tier)` server-side;
+`getTierMaxLevel(tier)` caps upgrades below the global `MAX_STRUCTURE_LEVEL`. One structure per
+parcel (UNIQUE on `parcel_id`, 23505 → `structure_exists` 409).
+
+Related: [[world-economy-parity-gap]] · [[file-map-and-deployment-state]] · [[seed-is-manual-data]].

--- a/.claude/memory/land/seed-is-manual-data.md
+++ b/.claude/memory/land/seed-is-manual-data.md
@@ -1,0 +1,34 @@
+---
+name: seed-is-manual-data
+description: "Parcel seed is a one-off DATA script (not the migrate-ci gate), run per-isolated-DB; empty land_parcels = a disconnect (modal empty, world shows 180 static lots); EXPLICIT-URL env hazard (Bun auto-loads .env.local → once wrote prod)."
+category: deployment
+confidence: 0.85
+date: 2026-06-22
+---
+
+# The parcel seed is manual DATA — verify it ran per-DB
+
+`apps/api/scripts/seed-land-parcels.ts` enumerates `LAND_PARCELS`, idempotent
+`ON CONFLICT (parcel_code) DO NOTHING`, and STAMPS `price_ct` per row by interpolating
+`LAND_TIER_LADDER` over the in-tier index (starter free / founder NULL). It is a one-off DATA
+script — **NOT** part of the `migrate-ci.ts` DDL gate. So a deploy does NOT seed parcels; the
+seed must be run **once per isolated DB** (staging `mtpixvtclsjqjguouxes`, prod
+`wheuidgiyyccqyoppxoa`).
+
+**Empty `land_parcels` is itself a disconnect:** the Land Office modal reads the DB
+(`getLandParcels`) so it shows NOTHING for sale, while the in-world render draws 180 lots from
+the static `LAND_PARCELS` constant regardless. So "world full of for-sale lots, menu says
+nothing for sale" can mean the seed never ran on that DB — ALWAYS check seed/row state before
+assuming a render or route bug. (Verify: count rows on the STAGING DB with an explicit URL.)
+
+**ENV HAZARD (caused a real prod write 2026-06-16):** Bun auto-loads `<cwd>/.env.local`. A seed
+that relies on the auto-loaded `DATABASE_URL` can silently hit PROD. The seed MUST take an
+EXPLICIT URL env var (e.g. `SEED_DATABASE_URL`); keep every local `.env.local` staging-only.
+See `feedback_no_prod_url_in_env_bun_autoload`. Run per-DB, deliberately, never both at once.
+
+`land.ts` SCHEMA changes (new tables/columns) DO go through the gate: add
+`packages/database/migrations/000N_*.sql` (idempotent, NAMED constraints — drizzle names all
+constraints; unnamed inline ones drift forever) → it auto-applies to staging then prod via the
+`migrate→deploy` job.
+
+Related: [[file-map-and-deployment-state]] · [[world-economy-parity-gap]].

--- a/.claude/memory/land/world-economy-parity-gap.md
+++ b/.claude/memory/land/world-economy-parity-gap.md
@@ -1,0 +1,63 @@
+---
+name: world-economy-parity-gap
+description: "Land Office modal is a full DB economy but the in-world 3D land is a static diorama that never reflects it — no ownership branch, no click-to-buy, no update-on-buy. The founding defect that created the land agent."
+category: gotcha
+confidence: 0.9
+date: 2026-06-22
+---
+
+# World ↔ Economy parity gap (the founding land defect) — OPEN
+
+**Symptom (founder, 2026-06-22):** "there is a disconnect with the land menu in sidebar
+options and gameplay that should never happen."
+
+**Diagnosis (verified by reading deployed code on `origin/staging` via the `cv-cash-poker`
+worktree):**
+
+The land economy is built in three places that DON'T agree:
+
+1. **Land Office modal** `apps/web/src/components/game/land/land-office-modal.tsx` — a
+   FULLY-WORKING DB economy. Calls `api.getLandParcels({status:'available'})` (browse),
+   `claimStarterPlot`, `buyParcel`, `getLandCatalog`, `getParcelStructure`, `placeStructure`,
+   `upgradeStructure`, `getOwnedLand`, `getMyLand`. Opened from the sidebar "Land Office" row
+   (`sidebar-menu.tsx` → `openLandOffice` store action).
+
+2. **In-world parcel render** `apps/web/src/lib/three/land-parcels.tsx` — a STATIC diorama.
+   Draws all 180 parcels + for-sale signs purely from the frozen `LAND_PARCELS` shared
+   constant. It does **NOT** import `useLandStore`, has **NO** ownership/status branch, and
+   has **NO** click/pointer handler. Comment even says "only run once" (frozen). So it shows
+   every lot as for-sale forever, regardless of DB ownership.
+
+3. **The store** `apps/web/src/stores/land.ts` — `parcels: Map` of ownership state. Its own
+   doc says "the gameplay turn (GET /api/land/owned) will hydrate this … the render reads this
+   store." But: `setParcels` is called ONLY by the modal (`land-office-modal.tsx` ~L966), and
+   **NOTHING in the 3D world reads `useLandStore.parcels`**. So the ownership map is
+   effectively write-only — a dead path for the world. Only `land-structures.tsx` reflects DB
+   state, and only the CURRENT player's OWN placed buildings (`api.getMyLand()` self-hydration);
+   for-sale/owned status of lots and OTHER players' ownership are invisible in-world.
+
+4. **No in-world → economy bridge** — zero hits for a parcel/sign click that opens the Land
+   Office or buy flow (grep `openLandOffice|selectParcel|land-office` in `lib/three/` +
+   `components/three/` = nothing). You can ONLY transact via the sidebar menu, never by
+   interacting with the world.
+
+**Net:** buy a parcel in the menu → its in-world sign still says "for sale"; you can't walk to
+a lot and buy it; other players' ownership doesn't render. Menu (real economy) and gameplay
+(static decoration) are two universes that don't talk.
+
+**Fix shape (for the land agent's first job — full team + 3da):**
+- `land-parcels.tsx` reads real status/ownership: hydrate `useLandStore.parcels` from
+  `/api/land/parcels` (for-sale pool) + `/owned/:avatarId` (multiplayer ownership render
+  seam), branch the per-parcel material/sign on `available` vs `owned` (foreign vs mine).
+  Keep `LAND_PARCELS` as GEOMETRY only; layer STATE on top. Respect Iris-Xe budget (merged
+  BufferGeometry, no InstancedMesh+ShaderMaterial, no drei `<Text>`).
+- Add an in-world → economy bridge: walk-near / click a for-sale sign → opens the Land Office
+  (or a parcel buy card). Mirror the cove walk-in/`E` pattern.
+- Buy/claim/place/upgrade via the modal updates the world live (store hydration / cache bust);
+  and the in-world action routes back through the SAME authed `/api/land/*` path (E5 parity).
+- Verify in the browser (a bought parcel flips in-world) + FPS at full-ownership state on Iris Xe.
+
+**ALSO verify first:** is `land_parcels` even seeded on the target DB? An empty table makes the
+gap worse (modal empty, world full of static lots). See [[seed-is-manual-data]].
+
+Related: [[file-map-and-deployment-state]] · [[land-money-contract]] · [[seed-is-manual-data]].


### PR DESCRIPTION
Adds a dedicated **`land`** subagent (modeled on `cove`) that owns the land economy end to end — the money paths AND the keystone the cove never had: **WORLD ↔ BACKEND ↔ UI parity** (the in-world 3D land must reflect the same DB ownership/for-sale/structure state the Land Office modal does).

- `.claude/agents/land.md` — operating model (manager+reviewer; spawns backend + `3da` sub-team), money contract, world-parity contract, file map, rules.
- `.claude/memory/land/` — index + 4 entries: the diagnosed world↔economy parity gap, file map + deployment state, the money contract, the seed hazard.

Tooling only — no app code, no runtime impact. Force-added under `.claude/memory/` (gitignored except `agents/`+`workflows/`, mirroring how `cove`/`threejs` memory is tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)