### PR TITLE
docs(land-memory): multiplayer/global-render note + registry-aligned Known-traps

### DIFF
--- a/.claude/memory/land/MEMORY.md
+++ b/.claude/memory/land/MEMORY.md
@@ -4,7 +4,31 @@ Project-scoped knowledge for the `land` subagent. One line per entry; detail liv
 Precedence: live code > canonical docs (`ARCHITECTURE.md`/`GameFeatures.md`/`3dStructure.md` +
 `.claude/plans/land-economy/`) > this memory (advisory). Verify before trusting.
 
+## Known traps (Phase 0 pre-read - emit these as hard constraints BEFORE any code)
+- **World/DB/UI drift** - the founding defect. The render must reflect DB status/ownership; a
+  buy must update the world; the modal and the world are two VIEWS of one DB. [[world-economy-parity-gap]]
+- **parcelCode is the join key, NOT the DB UUID.** `LAND_PARCELS[i].id === parcelCode`; the API
+  returns the DB UUID as `id`/`parcelId` plus `parcelCode` separately. Join render-to-DB on
+  parcelCode (resolve UUID->parcelCode from the parcels payload). The structures join shipped
+  broken once exactly here. [[multiplayer-render-and-verification]]
+- **Money path is consumed, not owned.** Settlement goes through the CT ledger + the authed
+  `requireAuthOrAgentSession` buy route; never add a new write path or a guest buy. Burn-sink,
+  atomic-under-lock, idempotency-keyed. [[land-money-contract]]
+- **Seed is manual DATA per isolated DB** (not the migrate gate); empty table = a disconnect;
+  EXPLICIT-URL env hazard (Bun auto-loads `.env.local`). [[seed-is-manual-data]]
+- **Iris-Xe render budget** - merged BufferGeometry, no InstancedMesh+ShaderMaterial, no drei
+  Text/Billboard, module-scope scratch only. The automation browser renders land at degraded
+  quality tier 1 (only 2 of 5 tier-bodies) - verify visuals on real hardware, not MCP pixels.
+
+## Consumes (NEVER edit these primitives - file the change to the owner per REGISTRY.md)
+token-economy (`claw-token-ledger`) · auth-identity-session (`require-auth-or-agent`, fingerprint)
+· 3da/world-presence (render substrate `lib/three/**` except `land-*`, world-dimensions SSOT)
+· agent-protocol-partner (Hatcher whitelist / PROTOCOL_VERSION for the Phase-3 agent action surface)
+· knowledge-orientation (Nori + the 3 operational-knowledge surfaces).
+
+## Entries
 - [world-economy-parity-gap](world-economy-parity-gap.md) — THE founding defect: Land Office modal is a full DB economy but the in-world render is a static diorama from the frozen `LAND_PARCELS` constant — no ownership branch, no click-to-buy, never updates on a buy. Menu and gameplay are two universes. OPEN.
 - [file-map-and-deployment-state](file-map-and-deployment-state.md) — every land file (route/seed/render/modal/store/schema/constants) + what's on prod vs staging vs the dirty `feat/poker-mtt-tournament` working tree (which LACKS land routes/render).
 - [land-money-contract](land-money-contract.md) — burn-sink priced buy (atomic, advisory-lock + FOR UPDATE), idempotency-keyed upgrade (Codex BLOCK), server-priced only, E5 parity on write+read+agent path, conservation/no-faucet.
 - [seed-is-manual-data](seed-is-manual-data.md) — parcel seed is a one-off DATA script (not the migrate gate), run per-isolated-DB; empty table = a disconnect (modal empty, world shows 180 lots); EXPLICIT-URL env hazard (Bun auto-loads `.env.local` → once wrote prod).
+- [multiplayer-render-and-verification](multiplayer-render-and-verification.md) — land is GLOBAL state (all server instances read one `land_parcels` table; geometry deterministic) so rendering never forks per server; cross-CLIENT sync is pull-on-fetch not push (a live land event is a follow-up). Includes the world-parity fix staging-verification outcome.

--- a/.claude/memory/land/multiplayer-render-and-verification.md
+++ b/.claude/memory/land/multiplayer-render-and-verification.md
@@ -1,0 +1,50 @@
+---
+name: multiplayer-render-and-verification
+description: "Land is GLOBAL state (one land_parcels table; all server instances read it; LAND_PARCELS geometry is deterministic) so parcel rendering never forks per server. Cross-CLIENT propagation is pull-on-fetch, not real-time push. Plus the staging verification outcome of the world-parity fix."
+category: pattern
+confidence: 0.8
+date: 2026-06-22
+---
+
+# Land + multiplayer: global state, pull-on-fetch sync
+
+**Founder asked 2026-06-22:** "with multiple servers I'm not sure how parcel rendering works."
+
+**Answer (verified against the architecture):** land is GLOBAL world/economy state, NOT
+per-server-instance.
+- ONE `land_parcels` table in the single Supabase DB (prod DB / staging DB are isolated
+  from each other, but within an env there is ONE land table). Every server instance / room
+  reads that same table via `GET /api/land/parcels?status=...`.
+- `LAND_PARCELS` (the geometry constant) is deterministic + pure (no RNG), so all clients
+  agree on where parcel N is. Ownership/status is layered on top from the DB.
+- ClawVille's multiplayer "instances" shard CO-PRESENCE only (which avatars you see, loose
+  cap 12 / hard 20 per instance, NPC substitution on join — see `project_shared_world_instancing`).
+  They do NOT fork world state. A parcel owned by avatar X is owned in EVERY instance's view.
+- ⇒ Parcel rendering is consistent across all servers; there is no per-instance divergence.
+
+**The one caveat — cross-CLIENT propagation is PULL, not PUSH (OPEN enhancement):**
+- The buyer's OWN client updates instantly: the Land Office modal invalidates the
+  `['landParcels']` query on buy/claim, so the for-sale sign vanishes immediately for them.
+- ANOTHER player already in-world picks up the change on their next fetch — world remount,
+  window refocus, or the 60s `useQuery` staleTime — NOT the instant the buy lands. There is
+  no WebSocket/SSE push for land state today (unlike player positions on the world-stream).
+- True real-time cross-player land sync (A buys → B's sign vanishes live) would add a land
+  event on the multiplayer channel + a client handler that invalidates `['landParcels']`.
+  Scoped as a FOLLOW-UP, not part of the world-parity fix. The land agent owns it.
+
+# World-parity fix — staging verification outcome (feat/land-world-parity, dd189b91)
+
+Shipped to staging 2026-06-22 (PR #162). Verified NON-VISUALLY (the automation browser
+can't capture WebGPU pixels + renders at degraded quality tier 1, where only founder+starter
+tier-bodies mount — IDENTICAL on prod, so a browser artifact, NOT a regression):
+- Hydrator fires BOTH `/api/land/parcels?status=available` and `?status=owned` (network-confirmed).
+- API truth: 180 parcels, 5 tiers (founder 8 / a 8 / b 16 / c 40 / starter 108), 178 available,
+  owned = parcel-starter-00/01.
+- Reactive merged sign meshes present (3 plank + 3 post); 35 click-hitboxes added (prod had 0).
+- No money path touched; E5 parity intact (click bridge reuses the authed buy).
+- **Founder confirmed on their real machine 2026-06-22: "yes I do see them"** — so the full
+  tier render works on real hardware; the 2-tier automation-browser count was the degraded-GPU
+  artifact, as suspected. Interactive loop (buy → sign vanishes, owned building renders,
+  click → modal focus) still pending an explicit founder run before prod promote (Rule E4).
+
+Related: [[world-economy-parity-gap]] · [[file-map-and-deployment-state]] · [[land-money-contract]].


### PR DESCRIPTION
Memory-only follow-up to the land world-parity fix (#162). Adds the global-render/multiplayer note (land is global state, not per-server; cross-client sync is pull-on-fetch) + registry-aligned Known-traps + Consumes sections to the land agent's memory. No app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)