### PR TITLE
test: verify fixed money gate (no-op)

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -84,3 +84,5 @@ jobs:
         # DATABASE_URL intentionally UNSET → describeIfDb tests skip; the
         # in-memory conservation/idempotency/parity/no-leak suite IS the gate.
         run: cd apps/api && bun test src/services/poker/ src/services/__tests__/
+
+# verify run: agent-runtime build fix


### PR DESCRIPTION
Confirm the agent-runtime-build-fixed gate runs GREEN. Will close.