### PR TITLE
fix(db): prepare:false for Supabase transaction pooler — PROD HOTFIX (fixes broken cove games)

### DIFF
--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -27,7 +27,20 @@ function getDb(): PostgresJsDatabase<typeof schema> {
     throw new Error('DATABASE_URL environment variable is not set');
   }
 
-  const client = postgres(connectionString);
+  // `prepare: false` is REQUIRED for the Supabase transaction pooler (port :6543,
+  // Supavisor transaction mode), which our DATABASE_URL uses on both staging+prod.
+  // postgres.js defaults to NAMED prepared statements cached per backend connection,
+  // but the transaction pooler hands a DIFFERENT backend to each transaction, so a
+  // cached named statement isn't available on the next one. Over the pooler this
+  // intermittently corrupts multi-statement transactions (db.transaction =
+  // BEGIN/INSERT/COMMIT): VERIFIED live, ~1/6 (staging) to ~1/3 (prod) of slot
+  // /session/open inserts returned a RETURNING row that was NEVER persisted (direct
+  // DB query returned []), causing session_not_found on the next spin and
+  // intermittently breaking EVERY cove game + the CT ledger (all settle inside a
+  // transaction). `prepare: false` disables named prepared statements — Supabase's
+  // documented fix — making transactions durable on the pooler. (node-pg, used by
+  // ElizaOS plugin-sql, is unaffected: it uses UNNAMED statements by default.)
+  const client = postgres(connectionString, { prepare: false });
   _db = drizzle(client, { schema });
   return _db;
 }


### PR DESCRIPTION
**Critical hotfix.** Root cause of the weeks-long broken cove games: postgres.js uses NAMED prepared statements which the Supabase `:6543` transaction pooler can't do reliably, intermittently dropping multi-statement transactions (every game settlement + the CT ledger).

- **Reproduced live:** ~1/6 on staging, **~1/3 on prod** (7 of ~20 slot session inserts silently lost, verified by direct DB query).
- **Fix verified on staging:** same repro 5/30 → **0/30** after deploy.
- One line: `postgres(connectionString, { prepare: false })` (Supabase's documented fix). Zero logic change; ElizaOS (node-pg) unaffected.

Merging this deploys the fix to prod. I'll re-run the prod reproduction after the container flips to confirm 0 failures.