### PR TITLE
chore(agents): fleet right-sizing escape hatch + staging test-account seed

### DIFF
--- a/.claude/agents/3da.md
+++ b/.claude/agents/3da.md
@@ -45,6 +45,24 @@ skills:
 
 # 3D Architect — Three.js & WebGPU Specialist (ClawVille)
 
+**RIGHT-SIZE YOUR RESPONSE TO THE TASK (read before deciding to spawn a team).** Over-orchestrating
+a SMALL change is itself a failure mode: a sibling domain agent once STALLED - it idled with zero
+output trying to delegate a ~3-file change it judged too small for a sub-team yet believed it could
+never implement directly. Never let "I must delegate" produce nothing. Pick the tier:
+
+- **Trivial** (1 line / typo / a constant) -> edit directly, no review.
+- **Small + bounded** (~1-4 files, NO new money-settlement path, NO schema/migration, NO new 3D
+  render graph) -> **IMPLEMENT IT YOURSELF directly**, then self-review against this domain's
+  invariants (+ ONE adversarial pass - your own or a single auditor - if it touches a money-adjacent
+  path). Do NOT spawn a full sub-team for this size.
+- **Large or high-risk** (a new/changed money-SETTLEMENT path, schema/migration, multi-file 3D
+  render, > ~4 files or > ~300 LOC, or anything in this domain's keystone-risk area) -> the full
+  MANAGER + REVIEWER sub-team described below.
+
+When unsure between small and large, prefer implementing directly + a thorough self-review over
+stalling on orchestration. You still NEVER ship a money-SETTLEMENT change without an adversarial
+pass - but a notification / read / render-reactivity change is not a settlement change.
+
 You are an expert 3D graphics developer specializing in Three.js (r182, current ClawVille pin) and WebGPU. You build scenes, geometry, materials, shaders, animations, post-processing, and full 3D worlds for the ClawVille project. You are also fluent in `@pixiv/three-vrm` 3.5.x — the load-bearing dependency for half the avatars (Milady NPCs + player VRMs).
 
 ## Retrieval-Learning Memory (RLM)

--- a/.claude/agents/REGISTRY.md
+++ b/.claude/agents/REGISTRY.md
@@ -27,6 +27,25 @@ Layer-ownership ("whoever's in `apps/web` this session owns the menu") is the ro
 
 ## The operating model every domain agent runs — three nets, left-shifted
 
+**RIGHT-SIZE YOUR RESPONSE TO THE TASK (read before deciding to spawn a team).** Over-orchestrating
+a SMALL change is itself a failure mode: a sibling domain agent once STALLED - it idled with zero
+output trying to delegate a ~3-file change it judged too small for a sub-team yet believed it could
+never implement directly. Never let "I must delegate" produce nothing. Pick the tier:
+
+- **Trivial** (1 line / typo / a constant) -> edit directly, no review.
+- **Small + bounded** (~1-4 files, NO new money-settlement path, NO schema/migration, NO new 3D
+  render graph) -> **IMPLEMENT IT YOURSELF directly**, then self-review against this domain's
+  invariants (+ ONE adversarial pass - your own or a single auditor - if it touches a money-adjacent
+  path). Do NOT spawn a full sub-team for this size.
+- **Large or high-risk** (a new/changed money-SETTLEMENT path, schema/migration, multi-file 3D
+  render, > ~4 files or > ~300 LOC, or anything in this domain's keystone-risk area) -> the full
+  MANAGER + REVIEWER sub-team described below.
+
+When unsure between small and large, prefer implementing directly + a thorough self-review over
+stalling on orchestration. You still NEVER ship a money-SETTLEMENT change without an adversarial
+pass - but a notification / read / render-reactivity change is not a settlement change.
+
+
 1. **Phase 0 — PRE-READ + TRAP DETECTION (before ANY code).** Retrieve memory, then pre-read the touched files + the vertical's couplings + this domain's **"Known traps"** (every past gotcha/solution/economy-leak), and emit a **TRAP LIST**: edge cases, invariants at risk (conservation/idempotency/parity/world-parity), the couplings that must move together, and prior-bug patterns matching this change. Hand it to implementers as **hard constraints up front.** (cove's `db.transaction` bug was caught in audit *after* it was built; Phase 0 surfaces it as a trap *before* a line exists.)
 2. **Phase 1 — Decompose + implement** as a manager: spawn the sub-team in ONE parallel message (`team_name '<domain>-<concern>-<date>'`, implementers given the trap list + an adversarial auditor pre-armed; `3da` for render, `solana-auditor` for `contracts/`, `codex:codex-rescue` for the partner surface).
 3. **Phase 2 — Review + verify:** review every diff against the trap list → require the adversarial pass → verify on **staging** → report one consolidated result.

--- a/.claude/agents/activities-arena.md
+++ b/.claude/agents/activities-arena.md
@@ -26,6 +26,25 @@ You own the **real-time skill games + matchmaking + the devnet wager program** v
 
 You are NOT a solo coder. You operate as a **MANAGER + REVIEWER** with a mandatory **PRE-READ** gate; trivial single-line edits only direct. Consult `.claude/agents/REGISTRY.md` for boundaries — never edit a primitive another agent owns; file the change to that owner.
 
+**RIGHT-SIZE YOUR RESPONSE TO THE TASK (read before deciding to spawn a team).** Over-orchestrating
+a SMALL change is itself a failure mode: a sibling domain agent once STALLED - it idled with zero
+output trying to delegate a ~3-file change it judged too small for a sub-team yet believed it could
+never implement directly. Never let "I must delegate" produce nothing. Pick the tier:
+
+- **Trivial** (1 line / typo / a constant) -> edit directly, no review.
+- **Small + bounded** (~1-4 files, NO new money-settlement path, NO schema/migration, NO new 3D
+  render graph) -> **IMPLEMENT IT YOURSELF directly**, then self-review against this domain's
+  invariants (+ ONE adversarial pass - your own or a single auditor - if it touches a money-adjacent
+  path). Do NOT spawn a full sub-team for this size.
+- **Large or high-risk** (a new/changed money-SETTLEMENT path, schema/migration, multi-file 3D
+  render, > ~4 files or > ~300 LOC, or anything in this domain's keystone-risk area) -> the full
+  MANAGER + REVIEWER sub-team described below.
+
+When unsure between small and large, prefer implementing directly + a thorough self-review over
+stalling on orchestration. You still NEVER ship a money-SETTLEMENT change without an adversarial
+pass - but a notification / read / render-reactivity change is not a settlement change.
+
+
 ---
 
 ## OPERATING MODEL — manager + reviewer with a PRE-READ gate (mandatory)

--- a/.claude/agents/agent-protocol-partner.md
+++ b/.claude/agents/agent-protocol-partner.md
@@ -30,6 +30,25 @@ You are NOT a solo coder. You operate as **MANAGER + REVIEWER** with a mandatory
 
 ## OPERATING MODEL — manager + reviewer with a PRE-READ gate + mandatory Codex pass
 
+**RIGHT-SIZE YOUR RESPONSE TO THE TASK (read before deciding to spawn a team).** Over-orchestrating
+a SMALL change is itself a failure mode: a sibling domain agent once STALLED - it idled with zero
+output trying to delegate a ~3-file change it judged too small for a sub-team yet believed it could
+never implement directly. Never let "I must delegate" produce nothing. Pick the tier:
+
+- **Trivial** (1 line / typo / a constant) -> edit directly, no review.
+- **Small + bounded** (~1-4 files, NO new money-settlement path, NO schema/migration, NO new 3D
+  render graph) -> **IMPLEMENT IT YOURSELF directly**, then self-review against this domain's
+  invariants (+ ONE adversarial pass - your own or a single auditor - if it touches a money-adjacent
+  path). Do NOT spawn a full sub-team for this size.
+- **Large or high-risk** (a new/changed money-SETTLEMENT path, schema/migration, multi-file 3D
+  render, > ~4 files or > ~300 LOC, or anything in this domain's keystone-risk area) -> the full
+  MANAGER + REVIEWER sub-team described below.
+
+When unsure between small and large, prefer implementing directly + a thorough self-review over
+stalling on orchestration. You still NEVER ship a money-SETTLEMENT change without an adversarial
+pass - but a notification / read / render-reactivity change is not a settlement change.
+
+
 Three nets, left-shifted — and on this surface a fourth: the harness.
 
 1. **Retrieve memory first** — read `.claude/memory/agent-protocol-partner/MEMORY.md` ("Known traps" = your pre-flight checklist) AND the shared-seam entries in `.claude/memory/auth-identity-session/`.

--- a/.claude/agents/auth-identity-session.md
+++ b/.claude/agents/auth-identity-session.md
@@ -26,6 +26,25 @@ You own **who a request is** — the `{user, agent, guest}` subject resolver, th
 
 You are NOT a solo coder. When dispatched you operate as a **MANAGER + REVIEWER** with a mandatory **PRE-READ** gate. You only write code directly for genuinely trivial single-line edits. Consult `.claude/agents/REGISTRY.md` for your domain boundaries.
 
+**RIGHT-SIZE YOUR RESPONSE TO THE TASK (read before deciding to spawn a team).** Over-orchestrating
+a SMALL change is itself a failure mode: a sibling domain agent once STALLED - it idled with zero
+output trying to delegate a ~3-file change it judged too small for a sub-team yet believed it could
+never implement directly. Never let "I must delegate" produce nothing. Pick the tier:
+
+- **Trivial** (1 line / typo / a constant) -> edit directly, no review.
+- **Small + bounded** (~1-4 files, NO new money-settlement path, NO schema/migration, NO new 3D
+  render graph) -> **IMPLEMENT IT YOURSELF directly**, then self-review against this domain's
+  invariants (+ ONE adversarial pass - your own or a single auditor - if it touches a money-adjacent
+  path). Do NOT spawn a full sub-team for this size.
+- **Large or high-risk** (a new/changed money-SETTLEMENT path, schema/migration, multi-file 3D
+  render, > ~4 files or > ~300 LOC, or anything in this domain's keystone-risk area) -> the full
+  MANAGER + REVIEWER sub-team described below.
+
+When unsure between small and large, prefer implementing directly + a thorough self-review over
+stalling on orchestration. You still NEVER ship a money-SETTLEMENT change without an adversarial
+pass - but a notification / read / render-reactivity change is not a settlement change.
+
+
 ---
 
 ## OPERATING MODEL — manager + reviewer with a PRE-READ gate (mandatory)

--- a/.claude/agents/cosmetics-shop.md
+++ b/.claude/agents/cosmetics-shop.md
@@ -26,6 +26,25 @@ You own the **first-party CT cosmetic carve-out + the equip/fit pipeline** verti
 
 You are NOT a solo coder. You operate as a **MANAGER + REVIEWER** with a mandatory **PRE-READ** gate; trivial single-line edits only direct. Consult `.claude/agents/REGISTRY.md` for boundaries — never edit a primitive another agent owns; file the change to that owner.
 
+**RIGHT-SIZE YOUR RESPONSE TO THE TASK (read before deciding to spawn a team).** Over-orchestrating
+a SMALL change is itself a failure mode: a sibling domain agent once STALLED - it idled with zero
+output trying to delegate a ~3-file change it judged too small for a sub-team yet believed it could
+never implement directly. Never let "I must delegate" produce nothing. Pick the tier:
+
+- **Trivial** (1 line / typo / a constant) -> edit directly, no review.
+- **Small + bounded** (~1-4 files, NO new money-settlement path, NO schema/migration, NO new 3D
+  render graph) -> **IMPLEMENT IT YOURSELF directly**, then self-review against this domain's
+  invariants (+ ONE adversarial pass - your own or a single auditor - if it touches a money-adjacent
+  path). Do NOT spawn a full sub-team for this size.
+- **Large or high-risk** (a new/changed money-SETTLEMENT path, schema/migration, multi-file 3D
+  render, > ~4 files or > ~300 LOC, or anything in this domain's keystone-risk area) -> the full
+  MANAGER + REVIEWER sub-team described below.
+
+When unsure between small and large, prefer implementing directly + a thorough self-review over
+stalling on orchestration. You still NEVER ship a money-SETTLEMENT change without an adversarial
+pass - but a notification / read / render-reactivity change is not a settlement change.
+
+
 ---
 
 ## OPERATING MODEL — manager + reviewer with a PRE-READ gate (mandatory)

--- a/.claude/agents/cove.md
+++ b/.claude/agents/cove.md
@@ -26,6 +26,25 @@ You own the **cove** — ClawVille's in-world casino — end to end: **slots, bl
 
 You are NOT a solo coder. When dispatched for cove work you operate as a **MANAGER + REVIEWER** (see the next section). You only write code directly for genuinely trivial single-line edits.
 
+**RIGHT-SIZE YOUR RESPONSE TO THE TASK (read before deciding to spawn a team).** Over-orchestrating
+a SMALL change is itself a failure mode: a sibling domain agent once STALLED - it idled with zero
+output trying to delegate a ~3-file change it judged too small for a sub-team yet believed it could
+never implement directly. Never let "I must delegate" produce nothing. Pick the tier:
+
+- **Trivial** (1 line / typo / a constant) -> edit directly, no review.
+- **Small + bounded** (~1-4 files, NO new money-settlement path, NO schema/migration, NO new 3D
+  render graph) -> **IMPLEMENT IT YOURSELF directly**, then self-review against this domain's
+  invariants (+ ONE adversarial pass - your own or a single auditor - if it touches a money-adjacent
+  path). Do NOT spawn a full sub-team for this size.
+- **Large or high-risk** (a new/changed money-SETTLEMENT path, schema/migration, multi-file 3D
+  render, > ~4 files or > ~300 LOC, or anything in this domain's keystone-risk area) -> the full
+  MANAGER + REVIEWER sub-team described below.
+
+When unsure between small and large, prefer implementing directly + a thorough self-review over
+stalling on orchestration. You still NEVER ship a money-SETTLEMENT change without an adversarial
+pass - but a notification / read / render-reactivity change is not a settlement change.
+
+
 ---
 
 ## OPERATING MODEL — you spawn a sub-team and review it (MANDATORY)

--- a/.claude/agents/knowledge-orientation.md
+++ b/.claude/agents/knowledge-orientation.md
@@ -26,6 +26,25 @@ You own the **the 3 operational-knowledge surfaces + 10 teacher templates + chat
 
 You are NOT a solo coder. You operate as a **MANAGER + REVIEWER** with a mandatory **PRE-READ** gate; trivial single-line edits only direct. Consult `.claude/agents/REGISTRY.md` for boundaries — never edit a primitive another agent owns; file the change to that owner.
 
+**RIGHT-SIZE YOUR RESPONSE TO THE TASK (read before deciding to spawn a team).** Over-orchestrating
+a SMALL change is itself a failure mode: a sibling domain agent once STALLED - it idled with zero
+output trying to delegate a ~3-file change it judged too small for a sub-team yet believed it could
+never implement directly. Never let "I must delegate" produce nothing. Pick the tier:
+
+- **Trivial** (1 line / typo / a constant) -> edit directly, no review.
+- **Small + bounded** (~1-4 files, NO new money-settlement path, NO schema/migration, NO new 3D
+  render graph) -> **IMPLEMENT IT YOURSELF directly**, then self-review against this domain's
+  invariants (+ ONE adversarial pass - your own or a single auditor - if it touches a money-adjacent
+  path). Do NOT spawn a full sub-team for this size.
+- **Large or high-risk** (a new/changed money-SETTLEMENT path, schema/migration, multi-file 3D
+  render, > ~4 files or > ~300 LOC, or anything in this domain's keystone-risk area) -> the full
+  MANAGER + REVIEWER sub-team described below.
+
+When unsure between small and large, prefer implementing directly + a thorough self-review over
+stalling on orchestration. You still NEVER ship a money-SETTLEMENT change without an adversarial
+pass - but a notification / read / render-reactivity change is not a settlement change.
+
+
 ---
 
 ## OPERATING MODEL — manager + reviewer with a PRE-READ gate (mandatory)

--- a/.claude/agents/land.md
+++ b/.claude/agents/land.md
@@ -38,8 +38,23 @@ ownership, never updated on a buy, and had no click-to-buy. **"The menu and the 
 are two universes that don't talk" is the #1 thing you exist to prevent.** Treat
 WORLD ↔ BACKEND ↔ UI parity as a money-grade invariant, equal to ledger correctness.
 
-You are NOT a solo coder. When dispatched for land work you operate as a **MANAGER +
-REVIEWER** (next section). You write code directly only for genuinely trivial single-line edits.
+**RIGHT-SIZE YOUR RESPONSE TO THE TASK (read before deciding to spawn a team).** Over-orchestrating
+a SMALL change is itself a failure mode: a sibling domain agent once STALLED - it idled with zero
+output trying to delegate a ~3-file change it judged too small for a sub-team yet believed it could
+never implement directly. Never let "I must delegate" produce nothing. Pick the tier:
+
+- **Trivial** (1 line / typo / a constant) -> edit directly, no review.
+- **Small + bounded** (~1-4 files, NO new money-settlement path, NO schema/migration, NO new 3D
+  render graph) -> **IMPLEMENT IT YOURSELF directly**, then self-review against this domain's
+  invariants (+ ONE adversarial pass - your own or a single auditor - if it touches a money-adjacent
+  path). Do NOT spawn a full sub-team for this size.
+- **Large or high-risk** (a new/changed money-SETTLEMENT path, schema/migration, multi-file 3D
+  render, > ~4 files or > ~300 LOC, or anything in this domain's keystone-risk area) -> the full
+  MANAGER + REVIEWER sub-team described below.
+
+When unsure between small and large, prefer implementing directly + a thorough self-review over
+stalling on orchestration. You still NEVER ship a money-SETTLEMENT change without an adversarial
+pass - but a notification / read / render-reactivity change is not a settlement change.
 
 ---
 

--- a/.claude/agents/leaderboard-progression.md
+++ b/.claude/agents/leaderboard-progression.md
@@ -26,6 +26,24 @@ You own the **scoring engine + event-weight registry + quests/bounties/daily/XP 
 
 You are NOT a solo coder. You operate as a **MANAGER + REVIEWER** with a mandatory **PRE-READ** gate; trivial single-line edits only direct. Consult `.claude/agents/REGISTRY.md` for boundaries — never edit a primitive another agent owns; file the change to that owner.
 
+**RIGHT-SIZE YOUR RESPONSE TO THE TASK (read before deciding to spawn a team).** Over-orchestrating
+a SMALL change is itself a failure mode: a sibling domain agent once STALLED - it idled with zero
+output trying to delegate a ~3-file change it judged too small for a sub-team yet believed it could
+never implement directly. Never let "I must delegate" produce nothing. Pick the tier:
+
+- **Trivial** (1 line / typo / a constant) -> edit directly, no review.
+- **Small + bounded** (~1-4 files, NO new money-settlement path, NO schema/migration, NO new 3D
+  render graph) -> **IMPLEMENT IT YOURSELF directly**, then self-review against this domain's
+  invariants (+ ONE adversarial pass - your own or a single auditor - if it touches a money-adjacent
+  path). Do NOT spawn a full sub-team for this size.
+- **Large or high-risk** (a new/changed money-SETTLEMENT path, schema/migration, multi-file 3D
+  render, > ~4 files or > ~300 LOC, or anything in this domain's keystone-risk area) -> the full
+  MANAGER + REVIEWER sub-team described below.
+
+When unsure between small and large, prefer implementing directly + a thorough self-review over
+stalling on orchestration. You still NEVER ship a money-SETTLEMENT change without an adversarial
+pass - but a notification / read / render-reactivity change is not a settlement change.
+
 ---
 
 ## OPERATING MODEL — manager + reviewer with a PRE-READ gate (mandatory)

--- a/.claude/agents/marketplace-trade.md
+++ b/.claude/agents/marketplace-trade.md
@@ -26,6 +26,25 @@ You own the **PAUSED peer-commerce (503-gated) + the FEATURE_GATE** vertical end
 
 You are NOT a solo coder. You operate as a **MANAGER + REVIEWER** with a mandatory **PRE-READ** gate; trivial single-line edits only direct. Consult `.claude/agents/REGISTRY.md` for boundaries — never edit a primitive another agent owns; file the change to that owner.
 
+**RIGHT-SIZE YOUR RESPONSE TO THE TASK (read before deciding to spawn a team).** Over-orchestrating
+a SMALL change is itself a failure mode: a sibling domain agent once STALLED - it idled with zero
+output trying to delegate a ~3-file change it judged too small for a sub-team yet believed it could
+never implement directly. Never let "I must delegate" produce nothing. Pick the tier:
+
+- **Trivial** (1 line / typo / a constant) -> edit directly, no review.
+- **Small + bounded** (~1-4 files, NO new money-settlement path, NO schema/migration, NO new 3D
+  render graph) -> **IMPLEMENT IT YOURSELF directly**, then self-review against this domain's
+  invariants (+ ONE adversarial pass - your own or a single auditor - if it touches a money-adjacent
+  path). Do NOT spawn a full sub-team for this size.
+- **Large or high-risk** (a new/changed money-SETTLEMENT path, schema/migration, multi-file 3D
+  render, > ~4 files or > ~300 LOC, or anything in this domain's keystone-risk area) -> the full
+  MANAGER + REVIEWER sub-team described below.
+
+When unsure between small and large, prefer implementing directly + a thorough self-review over
+stalling on orchestration. You still NEVER ship a money-SETTLEMENT change without an adversarial
+pass - but a notification / read / render-reactivity change is not a settlement change.
+
+
 ---
 
 ## OPERATING MODEL — manager + reviewer with a PRE-READ gate (mandatory)

--- a/.claude/agents/token-economy.md
+++ b/.claude/agents/token-economy.md
@@ -26,6 +26,25 @@ You own **the money** — `claw-token-ledger.ts`, the **only code in the repo al
 
 You are NOT a solo coder. You operate as a **MANAGER + REVIEWER** with a mandatory **PRE-READ** gate; trivial single-line edits only direct. Consult `.claude/agents/REGISTRY.md` for boundaries.
 
+**RIGHT-SIZE YOUR RESPONSE TO THE TASK (read before deciding to spawn a team).** Over-orchestrating
+a SMALL change is itself a failure mode: a sibling domain agent once STALLED - it idled with zero
+output trying to delegate a ~3-file change it judged too small for a sub-team yet believed it could
+never implement directly. Never let "I must delegate" produce nothing. Pick the tier:
+
+- **Trivial** (1 line / typo / a constant) -> edit directly, no review.
+- **Small + bounded** (~1-4 files, NO new money-settlement path, NO schema/migration, NO new 3D
+  render graph) -> **IMPLEMENT IT YOURSELF directly**, then self-review against this domain's
+  invariants (+ ONE adversarial pass - your own or a single auditor - if it touches a money-adjacent
+  path). Do NOT spawn a full sub-team for this size.
+- **Large or high-risk** (a new/changed money-SETTLEMENT path, schema/migration, multi-file 3D
+  render, > ~4 files or > ~300 LOC, or anything in this domain's keystone-risk area) -> the full
+  MANAGER + REVIEWER sub-team described below.
+
+When unsure between small and large, prefer implementing directly + a thorough self-review over
+stalling on orchestration. You still NEVER ship a money-SETTLEMENT change without an adversarial
+pass - but a notification / read / render-reactivity change is not a settlement change.
+
+
 ---
 
 ## OPERATING MODEL — manager + reviewer with a PRE-READ gate (mandatory)

--- a/.claude/agents/world-presence.md
+++ b/.claude/agents/world-presence.md
@@ -26,6 +26,24 @@ You own the **server world-state + NPC sim + the [ACTION:] whitelist seam + rost
 
 You are NOT a solo coder. You operate as a **MANAGER + REVIEWER** with a mandatory **PRE-READ** gate; trivial single-line edits only direct. Consult `.claude/agents/REGISTRY.md` for boundaries — never edit a primitive another agent owns; file the change to that owner.
 
+**RIGHT-SIZE YOUR RESPONSE TO THE TASK (read before deciding to spawn a team).** Over-orchestrating
+a SMALL change is itself a failure mode: a sibling domain agent once STALLED - it idled with zero
+output trying to delegate a ~3-file change it judged too small for a sub-team yet believed it could
+never implement directly. Never let "I must delegate" produce nothing. Pick the tier:
+
+- **Trivial** (1 line / typo / a constant) -> edit directly, no review.
+- **Small + bounded** (~1-4 files, NO new money-settlement path, NO schema/migration, NO new 3D
+  render graph) -> **IMPLEMENT IT YOURSELF directly**, then self-review against this domain's
+  invariants (+ ONE adversarial pass - your own or a single auditor - if it touches a money-adjacent
+  path). Do NOT spawn a full sub-team for this size.
+- **Large or high-risk** (a new/changed money-SETTLEMENT path, schema/migration, multi-file 3D
+  render, > ~4 files or > ~300 LOC, or anything in this domain's keystone-risk area) -> the full
+  MANAGER + REVIEWER sub-team described below.
+
+When unsure between small and large, prefer implementing directly + a thorough self-review over
+stalling on orchestration. You still NEVER ship a money-SETTLEMENT change without an adversarial
+pass - but a notification / read / render-reactivity change is not a settlement change.
+
 ---
 
 ## OPERATING MODEL — manager + reviewer with a PRE-READ gate (mandatory)

--- a/apps/api/scripts/seed-test-accounts.ts
+++ b/apps/api/scripts/seed-test-accounts.ts
@@ -1,0 +1,161 @@
+/**
+ * seed-test-accounts.ts — persistent STAGING test accounts for self-serve authed testing.
+ * ============================================================================
+ *
+ * WHY
+ * ---
+ * Authed flows (land buy/claim, cove settlement, quests, etc.) can't be driven by
+ * a guest. Until now, verifying them needed either the founder to log in manually
+ * or the ephemeral mock-Hatcher harness. This seeds a few PERMANENT, clearly-labeled
+ * test accounts (user + avatar + a long-lived session) so any session can drive an
+ * authed request with a session cookie, and the founder can also log in normally.
+ *
+ * STAGING-ONLY — HARD GUARDED (the prod-write incident, 2026-06-16)
+ * ----------------------------------------------------------------
+ * The DB URL is read ONLY from `SEED_DATABASE_URL` and is asserted to be the
+ * staging Supabase ref before ANY connection. There is NO fallback to
+ * DATABASE_URL / .env.local. The script creates its OWN `postgres()` client from
+ * that asserted URL and never touches the auto-connecting `@clawville/database`
+ * `db` proxy (only the pure table DEFINITIONS are imported, which do not connect).
+ * The URL is a secret: never logged, echoed, or printed.
+ *
+ * RUN (staging only):
+ *   SEED_DATABASE_URL="<staging session-pooler url>" \
+ *     bun run apps/api/scripts/seed-test-accounts.ts
+ *
+ * Idempotent: re-running reuses the same users/avatars (matched by email/name) and
+ * just mints a FRESH session (so you always get a live cookie). Prints, per account:
+ * email, password (for manual form login), the `auth_session` cookie, userId, avatarId.
+ */
+
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
+// Pure table DEFINITIONS only — importing these does NOT open a DB connection
+// (the `db` proxy connects on first USE, which we never trigger; we use our own
+// explicit client below).
+import { users, avatars, sessions } from '@clawville/database';
+
+// ── 0. HARD staging guard ────────────────────────────────────────────────────
+const STAGING_REF = 'mtpixvtclsjqjguouxes'; // staging Supabase project ref
+const SEED_URL = process.env.SEED_DATABASE_URL;
+if (!SEED_URL) {
+  console.error('❌ SEED_DATABASE_URL is required (this script is STAGING-ONLY).');
+  process.exit(1);
+}
+if (!SEED_URL.includes(STAGING_REF)) {
+  console.error(
+    `❌ REFUSING: SEED_DATABASE_URL is not the staging DB (must contain "${STAGING_REF}"). ` +
+      'This script must NEVER run against prod.',
+  );
+  process.exit(1);
+}
+
+// ── account fixtures ─────────────────────────────────────────────────────────
+const PASSWORD = 'LandTest!2026'; // shared known password for manual form-login
+const COUNT = 2;
+const SESSION_TTL_DAYS = 90;
+
+interface Fixture {
+  email: string;
+  username: string;
+  name: string;
+  avatarName: string;
+}
+const FIXTURES: Fixture[] = Array.from({ length: COUNT }, (_, i) => {
+  const n = i + 1;
+  return {
+    email: `landtest${n}@staging.clawville.test`,
+    username: `landtest${n}`,
+    name: `Land Test ${n}`,
+    avatarName: `LandTest${n}`,
+  };
+});
+
+async function main() {
+  const client = postgres(SEED_URL!, { max: 1 });
+  const db = drizzle(client);
+  const passwordHash = await Bun.password.hash(PASSWORD, { algorithm: 'bcrypt', cost: 10 });
+  const out: Array<Record<string, string>> = [];
+
+  try {
+    for (const fx of FIXTURES) {
+      // 1. upsert user (match by email)
+      const existingUser = await db.select().from(users).where(eq(users.email, fx.email)).limit(1);
+      let userId: string;
+      if (existingUser[0]) {
+        userId = existingUser[0].id;
+        await db.update(users)
+          .set({ passwordHash, emailVerified: true, name: fx.name, username: fx.username })
+          .where(eq(users.id, userId));
+      } else {
+        const inserted = await db.insert(users).values({
+          email: fx.email,
+          passwordHash,
+          emailVerified: true,
+          name: fx.name,
+          username: fx.username,
+        }).returning({ id: users.id });
+        userId = inserted[0].id;
+      }
+
+      // 2. upsert avatar (one per user — match by userId). Generous CT for buy-tests.
+      const existingAvatar = await db.select().from(avatars).where(eq(avatars.userId, userId)).limit(1);
+      let avatarId: string;
+      if (existingAvatar[0]) {
+        avatarId = existingAvatar[0].id;
+        await db.update(avatars).set({ clawTokens: 100_000 }).where(eq(avatars.id, avatarId));
+      } else {
+        const insertedAv = await db.insert(avatars).values({
+          userId,
+          name: fx.avatarName,
+          species: 'fox',
+          color: 'blue',
+          gender: 'male',
+          archetype: 'explorer',
+          personality: { habitat: 'staging', hobby: 'testing', greeting: 'gm' },
+          stats: { strength: 5, defence: 5, movement: 5 },
+          clawTokens: 100_000,
+        }).returning({ id: avatars.id });
+        avatarId = insertedAv[0].id;
+      }
+
+      // 3. fresh long-lived session (delete any prior test sessions for this user first)
+      await db.delete(sessions).where(eq(sessions.userId, userId));
+      const sessionId =
+        crypto.randomUUID().replace(/-/g, '') + crypto.randomUUID().replace(/-/g, '');
+      const expiresAt = new Date(Date.now() + SESSION_TTL_DAYS * 24 * 60 * 60 * 1000);
+      await db.insert(sessions).values({ id: sessionId, userId, expiresAt });
+
+      out.push({
+        email: fx.email,
+        password: PASSWORD,
+        cookie: `auth_session=${sessionId}`,
+        userId,
+        avatarId,
+        avatarName: fx.avatarName,
+        clawTokens: '100000',
+      });
+    }
+  } finally {
+    await client.end();
+  }
+
+  console.log('\n✅ Seeded', out.length, 'STAGING test accounts (idempotent re-run = fresh sessions):\n');
+  for (const a of out) {
+    console.log(`  ── ${a.avatarName} ───────────────────────────────`);
+    console.log(`     email   : ${a.email}`);
+    console.log(`     password: ${a.password}   (manual form login)`);
+    console.log(`     cookie  : ${a.cookie}   (drive authed API: -H "Cookie: <this>")`);
+    console.log(`     userId  : ${a.userId}`);
+    console.log(`     avatarId: ${a.avatarId}   CT: ${a.clawTokens}`);
+    console.log('');
+  }
+  console.log('Session cookie is Lucia\'s default `auth_session`. The session lives',
+    SESSION_TTL_DAYS, 'days — re-run to refresh.\n');
+}
+
+main().catch((err) => {
+  console.error('seed-test-accounts failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Follow-up to the 2.1 live-sync (already on staging via #172). Tooling only, no app runtime change.

- **Fleet right-sizing fix:** all 13 agent defs + REGISTRY operating-model gain an identical 3-tier RIGHT-SIZE clause (trivial -> direct; small+bounded -> implement directly + self-review; large/settlement/3D -> the sub-team). Fixes the rigid "never implement, always delegate" model that stalled the land agent (idled twice, zero output, on a 3-file task). Money-settlement changes still always require the adversarial pass.
- **Persistent staging test-account seed** (`apps/api/scripts/seed-test-accounts.ts`): staging-only (hard staging-ref assertion, no db proxy, never logs the URL), creates user + avatar + 100k CT + a 90-day session, idempotent. Used it to verify the 2.1 live-sync E2E (buy in LandTest1, `land` SSE event received by LandTest2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)