### PR TITLE
hotfix: redact agent bearer sessionIds from request logs (live prod real-CT leak)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,6 +4,7 @@ import { logger } from 'hono/logger';
 import { secureHeaders } from 'hono/secure-headers';
 import { bodyLimit } from 'hono/body-limit';
 import { HTTPException } from 'hono/http-exception';
+import { redactBearerTokens } from './services/log-redact';
 import { authRoutes } from './routes/auth';
 import { avatarRoutes } from './routes/avatars';
 import { userRoutes } from './routes/users';
@@ -117,7 +118,22 @@ import type { AppContext } from './types';
 const app = new Hono<AppContext>();
 
 // Global middleware
-app.use('*', logger());
+// Redact agent bearer sessionIds from the request log: several agent routes
+// carry the real-CT bearer as a `/:sessionId/…` PATH param, and hono/logger
+// prints every path — so an un-redacted logger writes the replayable credential
+// into stdout / the Coolify log drain (real-CT theft on log access). The custom
+// print fn scrubs only the LOG string; URLs/responses to the Hatcher partner are
+// unchanged. Pre-existing leak folded in at the P0 Codex gate (2026-07-01), same
+// class as the B1 body-id leak. See services/log-redact.ts.
+app.use(
+  '*',
+  logger((message: string, ...rest: string[]) => {
+    console.log(
+      redactBearerTokens(message),
+      ...rest.map((r) => (typeof r === 'string' ? redactBearerTokens(r) : r)),
+    );
+  }),
+);
 // secureHeaders defaults Cross-Origin-Resource-Policy to "same-origin", which
 // blocks api.clawville.world responses from being read by clawville.world
 // (different origins). The web app's SSE/fetch calls fail with "blocked by

--- a/apps/api/src/services/__tests__/log-redact.test.ts
+++ b/apps/api/src/services/__tests__/log-redact.test.ts
@@ -1,0 +1,55 @@
+/**
+ * P0 Codex-gate fix (2026-07-01): the global hono/logger prints request paths,
+ * and agent routes carry the real-CT bearer as a `/:sessionId/…` PATH param, so
+ * the raw replayable bearer would land in stdout/log-drain without redaction.
+ * These tests pin `redactBearerTokens` — it MUST scrub every `(oc|ag|hat)-…`
+ * bearer while leaving ordinary text (and the `oc`/`ag`/`hat` letters inside
+ * other words) untouched.
+ */
+import { describe, expect, it } from 'bun:test';
+import { redactBearerTokens } from '../log-redact';
+import { randomBytes } from 'crypto';
+
+const mkBearer = (p: 'oc' | 'ag' | 'hat') => `${p}-${randomBytes(24).toString('base64url')}`;
+
+describe('redactBearerTokens', () => {
+  it('redacts each real bearer shape (oc-/ag-/hat- + 32 base64url chars), keeping the prefix', () => {
+    for (const p of ['oc', 'ag', 'hat'] as const) {
+      const bearer = mkBearer(p);
+      const out = redactBearerTokens(`  --> POST /api/agent/${bearer}/cove/blackjack/deal 200 12ms`);
+      expect(out).toBe(`  --> POST /api/agent/${p}-<redacted>/cove/blackjack/deal 200 12ms`);
+      expect(out.includes(bearer)).toBe(false);
+      // the tail secret is gone
+      expect(out.includes(bearer.slice(bearer.indexOf('-') + 1))).toBe(false);
+    }
+  });
+
+  it('redacts the SSE + move + legacy-unregister path shapes', () => {
+    const b = mkBearer('hat');
+    expect(redactBearerTokens(`  <-- GET /api/agent/${b}/events`)).toBe('  <-- GET /api/agent/hat-<redacted>/events');
+    expect(redactBearerTokens(`  --> POST /api/agent/${b}/move 200`)).toBe('  --> POST /api/agent/hat-<redacted>/move 200');
+  });
+
+  it('redacts multiple bearers on one line', () => {
+    const a = mkBearer('oc');
+    const b = mkBearer('ag');
+    const out = redactBearerTokens(`from=${a} to=${b}`);
+    expect(out).toBe('from=oc-<redacted> to=ag-<redacted>');
+  });
+
+  it('does NOT redact the oc/ag/hat letters embedded in ordinary words', () => {
+    // `flag-…` ends in `ag-`; `advocate`/`what-…` contain oc/hat — none is a bearer.
+    const s = 'flag-abcdefghijklmnopqrstuvwxyz123 advocate what-abcdefghijklmnopqrstuvwx';
+    expect(redactBearerTokens(s)).toBe(s);
+  });
+
+  it('does NOT redact short non-bearer ids (below the 24-char tail floor)', () => {
+    expect(redactBearerTokens('oc-1 ag-foo hat-bar')).toBe('oc-1 ag-foo hat-bar');
+  });
+
+  it('is a safe no-op on empty / non-string input', () => {
+    expect(redactBearerTokens('')).toBe('');
+    // @ts-expect-error — defensive: never throws on a non-string
+    expect(redactBearerTokens(undefined)).toBe(undefined);
+  });
+});

--- a/apps/api/src/services/log-redact.ts
+++ b/apps/api/src/services/log-redact.ts
@@ -1,0 +1,37 @@
+/**
+ * Redact agent bearer sessionIds from log output (P0, 2026-07-01, Codex gate).
+ *
+ * The agent bearer (`X-Clawville-Agent-Session`) is the real-CT credential the
+ * cove trusts for settlement. It is minted as `(oc|ag|hat)-<base64url(24 bytes)>`
+ * — a fixed `oc-`/`ag-`/`hat-` prefix + 32 url-safe chars:
+ *   - `ag-…`  agent-gateway `/connect`      (agent-gateway.ts)
+ *   - `oc-…`  legacy openclaw `/register`   (openclaw.ts)
+ *   - `hat-…` signed partner register/PATCH (partner-hatcher.ts)
+ *
+ * Several agent routes carry that bearer as a `/:sessionId/…` PATH param
+ * (`/api/agent/:sessionId/{events,move,chat,visit-building,…}`, the cove/poker
+ * tool routes, legacy unregister). The global `hono/logger` middleware
+ * (`index.ts`, `app.use('*', logger())`) prints every request path, so WITHOUT
+ * redaction the raw, replayable bearer lands in stdout / the Coolify log drain —
+ * anyone with log access can replay it as `X-Clawville-Agent-Session` until
+ * TTL/rotation (real-CT bearer theft). This is a pre-existing leak surfaced by
+ * the P0 Codex adversarial pass; it is the same vulnerability CLASS as the folded
+ * B1 body-id leak (the bearer must NEVER appear on any wire OR in any log).
+ *
+ * This scrubs the SECRET tail while keeping the `oc-`/`ag-`/`hat-` prefix (ops can
+ * still tell it was an agent route). It is a pure string transform — it never
+ * throws and only touches OUR log output: NO request/response/URL contract
+ * changes, so it is completely invisible to the Hatcher partner.
+ *
+ * The lookbehind `(?<![A-Za-z0-9])` requires the prefix to start at a token
+ * boundary so a substring like the `ag-` inside `flag-…` is never matched; the
+ * `{24,}` tail floor keeps ordinary short ids (`oc-1`, `ag-x`) untouched while
+ * still catching every 32-char real bearer.
+ */
+const BEARER_TOKEN_RE = /(?<![A-Za-z0-9])(oc|ag|hat)-[A-Za-z0-9_-]{24,}/g;
+
+/** Replace any agent bearer sessionId in `input` with `<prefix>-<redacted>`. */
+export function redactBearerTokens(input: string): string {
+  if (typeof input !== 'string' || input.length === 0) return input;
+  return input.replace(BEARER_TOKEN_RE, '$1-<redacted>');
+}


### PR DESCRIPTION
## Live prod bearer-in-logs leak — hotfix

Verified on `origin/master`: the global `app.use('*', logger())` prints every request path, and several agent routes carry the real-CT bearer as a `/:sessionId/…` PATH param (`/api/agent/:sessionId/{events,move,chat,visit-building}`, cove/poker tool routes, legacy unregister). So every agent request wrote a **replayable `(oc|ag|hat)-<32>` bearer into prod stdout / the Coolify log drain** — anyone with log access could replay it as `X-Clawville-Agent-Session` until TTL/rotation (real-CT theft).

Threat surface: privileged log access (not public-internet). Pre-existing; surfaced by the P0 Codex adversarial pass.

## Fix (isolated, wire-neutral)
- `services/log-redact.ts` — pure `redactBearerTokens()` scrubs the bearer TAIL from the log string only (keeps the `oc-`/`ag-`/`hat-` prefix for ops). Token-boundary lookbehind (won't touch `ag-` in `flag-`); 24-char tail floor (leaves short ids alone); never throws.
- `index.ts` — global logger uses a custom print fn that redacts. **Wire-neutral**: URLs and responses to the Hatcher partner are byte-identical; only OUR log output changes.
- `__tests__/log-redact.test.ts` — 6 cases (each bearer shape, multi-bearer line, embedded-letters negative, short-id negative, empty/non-string).

Same class as the P0 B1 body-id leak (bearer must never hit a wire OR a log). This is the identical commit folded into P0 (`3d92aa7e`), cherry-picked as a standalone prod hotfix ahead of the full P0 merge (founder-authorized direct-to-master).

## Verification
- `tsc --noEmit -p apps/api` → **0** (after building workspace packages)
- `bun test log-redact.test.ts` → **6 pass / 0 fail**
- Post-deploy: staging/prod log spot-check that agent-route paths render `…/oc-<redacted>/…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)