### PR TITLE
fix(identity): lineage + canonical asset refs — clawville_genesis on-chain everywhere

### DIFF
--- a/apps/api/src/routes/agent-eip8004.ts
+++ b/apps/api/src/routes/agent-eip8004.ts
@@ -70,9 +70,9 @@ const SAP_AGENT_REGISTRY: Record<string, Eip8004Registration> = {
     name: 'clawville_genesis',
     description:
       'clawville_genesis — the first ClawVille agent identity (agent–human-economy metaverse at ' +
-      'https://clawville.world). SAP-registered on Solana devnet + mainnet (on-chain SAP agent name: ' +
-      'HermesTest) with settled USDC bounty escrows on both, and a Metaplex Core AgentIdentity ' +
-      'registered in the mpl-agent-014 (1DREG) registry.',
+      'https://clawville.world). SAP-registered on Solana devnet + mainnet (formerly HermesTest; ' +
+      'renamed on-chain 2026-07-01) with settled USDC bounty escrows on both, and a Metaplex Core ' +
+      'AgentIdentity registered in the mpl-agent-014 (1DREG) registry.',
     image: 'https://clawville.world/press/brand/clawlogo-itachi.jpg',
     synapseAgent: 'Ep7dD7biX7rZ6NSVzy8uEpgEEYipVfQ8ofwHzZmRM8dF',
     authority: '24i43XkDyJAJJBi7X3ARRCt3WBh16uJuSfVRLKXVEYBQ',
@@ -85,16 +85,16 @@ const SAP_AGENT_REGISTRY: Record<string, Eip8004Registration> = {
       },
     ],
     executives: [],
-    updatedAt: '2026-07-02T00:00:00Z',
+    updatedAt: '2026-07-02T01:00:00Z',
     extra: {
       metaplexIdentityAsset: {
-        mainnet: 'E3tgkW9sy2FdqcR1iLJGaA5P7vJZWz8Vu93HHZkzDhmM',
+        mainnet: '7R9Xu32UDvXAbGs9vqN8BF6LcJXXkZ5dsUTmknJUCXYD',
         devnet: '8pv2wEMMzhxN51JSsjB4jJM1bjgm8kxZpnA9c2qX3fNX',
       },
       agentIdentityRegistration: {
         registry: 'mpl-agent-014',
         program: '1DREGFgysWYxLnRnKQnwrxnJQeSMk2HmGaC6whw2B2p',
-        mainnet: 'cbfZqAiuzLQkknmYkNCcb6UmpQ3zDwohrnKR4zWbTL8',
+        mainnet: '6ytuvccFCrcwoN7sdVx8aTVnovHWVRUutNiDvPa5ELZD',
         devnet: '5XYgD16jLKWawfxms9NmLguebphQ7oy6uPE2xnm2cLvn',
       },
       bountySettlements: {


### PR DESCRIPTION
Follow-up to #179 after the on-chain operations:

- SAP `update_agent` executed on devnet + mainnet — the agent's on-chain SAP name is now `clawville_genesis` (OOBE explorer picks this up). Description updated to '(formerly HermesTest; renamed on-chain 2026-07-01)'.
- Mainnet identity asset re-minted as `7R9Xu32UDvXAbGs9vqN8BF6LcJXXkZ5dsUTmknJUCXYD` (old `E3tgkW9s…` BURNED — mainnet's mpl-core build rejects UpdateV2 with NoApprovals while the AgentIdentity adapter hooks update). `extra` refs updated to the canonical asset + registration `6ytuvccF…`.

Verified on staging (`19c5c2f4`): description + canonical asset confirmed via curl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVvMSjPfKJoWMTmj1qNqWE