### PR TITLE
fix(ci): green the money-invariant gate (renumbered migrations + wager-program build)

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -60,12 +60,13 @@ jobs:
         # The money tests transitively import npc-simulation.ts → @clawville/
         # agent-runtime, so build agent-runtime; turbo pulls its deps
         # (database, shared, agent-templates) in dependency order. This is the
-        # minimal set the suite resolves (verified 546/0 with exactly these
-        # dists). NOT '--filter=./packages/*' (drags in apps/web + wager-program).
+        # PR #203's wager client/reconciliation tests also import
+        # @clawville/wager-program, so CI must build its dist too. This remains
+        # explicit rather than '--filter=./packages/*', which drags in apps/web.
         # Requires the same-commit agent-runtime build fixes (declared
         # @clawville/database dep + test-file tsc exclude) — without them a fresh
         # CI build of agent-runtime errors TS2307, masked locally by turbo cache.
-        run: bunx turbo run build --filter=@clawville/agent-runtime
+        run: bunx turbo run build --filter=@clawville/agent-runtime --filter=@clawville/wager-program
 
       - name: Run the money/cove/poker invariant suite
         # SCOPED to the service test dirs (poker tournament/cash/sims + the

--- a/apps/api/src/services/__tests__/building-reward.test.ts
+++ b/apps/api/src/services/__tests__/building-reward.test.ts
@@ -433,7 +433,7 @@ describe('creditBuildingChatRewardOncePerDay (shared durable claim)', () => {
     expect(routeSource).not.toContain('!avatar.isGuest');
   });
 
-  it('0032 commits guards before split backfill/index migrations', () => {
+  it('0037 commits guards before split backfill/index migrations', () => {
     const migrationDir = join(
       import.meta.dir,
       '..',
@@ -445,9 +445,9 @@ describe('creditBuildingChatRewardOncePerDay (shared durable claim)', () => {
       'database',
       'migrations',
     );
-    const migration = readFileSync(join(migrationDir, '0032_supply_mint_idempotency.sql'), 'utf8');
-    const backfill = readFileSync(join(migrationDir, '0032a_supply_mint_chat_backfill.sql'), 'utf8');
-    const activity = readFileSync(join(migrationDir, '0032b_activity_result_uniqueness.sql'), 'utf8');
+    const migration = readFileSync(join(migrationDir, '0037_supply_mint_idempotency.sql'), 'utf8');
+    const backfill = readFileSync(join(migrationDir, '0038_supply_mint_chat_backfill.sql'), 'utf8');
+    const activity = readFileSync(join(migrationDir, '0039_activity_result_uniqueness.sql'), 'utf8');
     const xpTriggerAt = migration.indexOf(
       'CREATE TRIGGER "guard_atomic_xp_update_before_update"',
     );


### PR DESCRIPTION
Gates suite red on master since #203. Two root causes, both CI/test-only — no runtime code changed:

1. `building-reward.test.ts` hardcoded `0032_supply_mint_idempotency.sql` / `0032a` / `0032b`; the Wave1 merge renumbered them to `0037`/`0038`/`0039`. Paths + test title updated, zero assertions changed (all asserted strings verified present in the renamed files).
2. `gates.yml` built only `@clawville/agent-runtime`; #203 added wager client/reconciliation tests importing `@clawville/wager-program` (`main: dist/index.js`), never built in CI → `Cannot find module` (2 unhandled errors + 2 phantom fails). Added `--filter=@clawville/wager-program`.

Implemented by Codex (gpt-5.6-sol high), reviewed by Fable. 54/54 locally across the three affected files. The gates run on this PR is the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014x5RrJK4BdmDXsGM2hzZjf