### PR TITLE
fix(test): contain xp-service module-mock leak flaking the money gate

### DIFF
--- a/apps/api/src/services/__tests__/xp-service.test.ts
+++ b/apps/api/src/services/__tests__/xp-service.test.ts
@@ -1,6 +1,9 @@
-import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
 import * as realDatabase from '@clawville/database';
 import * as realLedger from '../claw-token-ledger';
+
+const realDb = realDatabase.db;
+const realCreditClawTokens = realLedger.creditClawTokens;
 
 interface XpRow {
   id: string;
@@ -11,6 +14,7 @@ interface XpRow {
 
 const AVATAR_ID = '00000000-0000-4000-8000-000000000001';
 
+let xpSuiteActive = false;
 let row: XpRow;
 let lockTail: Promise<void>;
 let creditShouldFail: boolean;
@@ -126,9 +130,16 @@ const fakeDb = {
   },
 };
 
+const dbForMock = new Proxy(fakeDb as object, {
+  get(target, prop, receiver) {
+    if (!xpSuiteActive) return Reflect.get(realDb as object, prop, realDb);
+    return Reflect.get(target, prop, receiver);
+  },
+});
+
 mock.module('@clawville/database', () => ({
   ...realDatabase,
-  db: fakeDb,
+  db: dbForMock,
 }));
 
 mock.module('../claw-token-ledger', () => ({
@@ -137,6 +148,9 @@ mock.module('../claw-token-ledger', () => ({
     input: Parameters<typeof realLedger.creditClawTokens>[0],
     tx?: unknown,
   ) => {
+    if (!xpSuiteActive) {
+      return realCreditClawTokens(input as never, tx as never);
+    }
     if (!tx || !activeTransactions.has(tx)) {
       throw new Error('creditClawTokens must receive the active XP transaction');
     }
@@ -147,6 +161,14 @@ mock.module('../claw-token-ledger', () => ({
 }));
 
 const { awardXp } = await import('../xp-service');
+
+beforeAll(() => {
+  xpSuiteActive = true;
+});
+
+afterAll(() => {
+  xpSuiteActive = false;
+});
 
 beforeEach(() => {
   row = { id: AVATAR_ID, xp: 95, level: 1, total_xp: 95 };


### PR DESCRIPTION
The gates suite failed on the master push of #205 (same tree that passed the PR run): 10 `claw-token-ledger` F1/T0 failures, all `creditClawTokens must receive the active XP transaction`.

Root cause: `xp-service.test.ts` (#203) registers process-global `mock.module()` mocks — a throwing ledger guard + a transaction-only fake db — which bun leaks into every test file that runs later. CI file order is not stable on the Linux runners, so the gate flipped between runs on identical trees.

Fix (test-file-only, +24/-2): suite-active flag; while inactive, both mocks delegate to the real implementations captured before `mock.module` (bun mutates imported namespaces in place — capturing after would recurse). XP-suite strictness unchanged; `market.test.ts` / `x402-checkout.test.ts` verified already leak-safe.

Repro proven pre-fix (forced poison-first order: 15 pass / 10 fail with the exact CI error), green post-fix in both orders; full scoped suite 1456/0. Independently re-verified.

Implemented by Codex (gpt-5.6-sol high), reviewed by Fable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014x5RrJK4BdmDXsGM2hzZjf