### PR TITLE
fix(auth): malformed/empty JSON body returns 400, not uncaught 500

### DIFF
--- a/apps/api/src/routes/__tests__/auth-json-body.test.ts
+++ b/apps/api/src/routes/__tests__/auth-json-body.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'bun:test';
+import { Hono } from 'hono';
+import type { AppContext } from '../../types';
+import { authRoutes } from '../auth';
+
+const app = new Hono<AppContext>();
+app.route('/', authRoutes);
+
+describe('public auth JSON body parsing', () => {
+  it('returns 400 for an empty login body without touching the database', async () => {
+    const response = await app.request('/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 for a malformed login body without touching the database', async () => {
+    const response = await app.request('/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'not-json{',
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('keeps the anti-enumeration generic 200 for empty and malformed forgot-password bodies', async () => {
+    // Pre-fix behavior: `.catch(() => ({}))` coerced parse failures to {} and
+    // schema-invalid bodies get the generic success. Preserved byte-identical —
+    // a 400 here would give probes a distinguishable response.
+    const emptyResponse = await app.request('/forgot-password', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+    });
+    const malformedResponse = await app.request('/forgot-password', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'not-json{',
+    });
+
+    expect(emptyResponse.status).toBe(200);
+    expect(malformedResponse.status).toBe(200);
+    expect(await emptyResponse.json()).toEqual(await malformedResponse.json());
+  });
+
+  it('does not 400 a bodyless guest signup (coerces to {} — the pre-fix contract)', async () => {
+    // Without DATABASE_URL the handler proceeds past validation and fails
+    // later at the DB layer — anything but 400 proves the parse guard did
+    // not reject the missing body.
+    const response = await app.request('/guest', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+    });
+
+    expect(response.status).not.toBe(400);
+  });
+});
+
+const describeIfDb = process.env.DATABASE_URL ? describe : describe.skip;
+
+describeIfDb('public auth JSON body parsing (requires DATABASE_URL)', () => {
+  it('keeps valid-shape unknown credentials on the existing 401 path', async () => {
+    const response = await app.request('/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        email: `missing-${crypto.randomUUID()}@example.com`,
+        password: 'unknown-password',
+      }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { eq, and, or, isNull } from 'drizzle-orm';
 import { lucia } from '../lib/auth';
@@ -29,6 +29,15 @@ import { z } from 'zod';
 import { DEFAULT_AGENT_MODEL_KEY } from '@clawville/shared';
 
 export const authRoutes = new Hono<AppContext>();
+
+/** Body-parse guard: a malformed/empty JSON body is client error 400, never an uncaught 500. */
+async function readJsonBody(c: Context): Promise<unknown> {
+  try {
+    return await c.req.json();
+  } catch {
+    return null;
+  }
+}
 
 authRoutes.use('*', sessionMiddleware);
 
@@ -266,7 +275,7 @@ authRoutes.post('/signup', async (c) => {
     });
   }
 
-  const body = await c.req.json();
+  const body = await readJsonBody(c);
   const result = signupSchema.safeParse(body);
 
   if (!result.success) {
@@ -390,7 +399,7 @@ const loginSchema = z.object({
 });
 
 authRoutes.post('/login', async (c) => {
-  const body = await c.req.json();
+  const body = await readJsonBody(c);
   const result = loginSchema.safeParse(body);
 
   if (!result.success) {
@@ -512,13 +521,13 @@ authRoutes.post('/forgot-password', async (c) => {
     });
   }
 
-  const body = await c.req.json().catch(() => ({}));
+  const body = (await readJsonBody(c)) ?? {};
   const parsed = forgotPasswordSchema.safeParse(body);
 
-  // Invalid body: still return the generic success message — never
-  // let a 400 distinguish "email format wrong" from "email not on the
-  // list". The shape of the response stays identical so the client
-  // can't infer anything about the input.
+  // Invalid body — malformed JSON included — still returns the generic
+  // success message: never let a 400 distinguish "email format wrong"
+  // from "email not on the list". The response shape stays identical so
+  // the client can't infer anything about the input.
   if (!parsed.success) {
     return c.json({
       ok: true,
@@ -617,7 +626,7 @@ authRoutes.post('/reset-password', async (c) => {
     });
   }
 
-  const body = await c.req.json().catch(() => ({}));
+  const body = (await readJsonBody(c)) ?? {};
   const parsed = resetPasswordSchema.safeParse(body);
 
   // Generic 400 for any failure — body shape, missing fields, weak
@@ -984,7 +993,7 @@ authRoutes.post('/milady-session-exchange', async (c) => {
     });
   }
 
-  const body = await c.req.json();
+  const body = await readJsonBody(c);
   const parsed = miladyExchangeSchema.safeParse(body);
   if (!parsed.success) {
     throw new HTTPException(400, { message: 'sessionId is required' });
@@ -1231,7 +1240,9 @@ authRoutes.post('/guest', async (c) => {
     });
   }
 
-  const body = await c.req.json().catch(() => ({}));
+  // Missing/malformed body coerces to {} (all fields optional) — a bare
+  // `POST /guest` with no body has always minted a guest; keep that contract.
+  const body = (await readJsonBody(c)) ?? {};
   const parsed = guestBodySchema.safeParse(body);
   if (!parsed.success) {
     throw new HTTPException(400, { message: 'Invalid request body' });

--- a/apps/api/src/routes/dash-auth.ts
+++ b/apps/api/src/routes/dash-auth.ts
@@ -52,10 +52,8 @@ dashAuthRoutes.post('/login', async (c) => {
     );
   }
 
-  let body: { password?: unknown };
-  try {
-    body = await c.req.json();
-  } catch {
+  const body = await c.req.json<{ password?: unknown }>().catch(() => null);
+  if (body === null) {
     return c.json({ ok: false, error: 'invalid_json' }, 400);
   }
 


### PR DESCRIPTION
Prod critical alert tonight: `POST /api/auth/login` with an empty body (scanner probe) threw `SyntaxError: JSON Parse error: Unexpected EOF` from `c.req.json()` before zod ran → uncaught 500 + pager. Reproduced live; real logins unaffected.

Fix: `readJsonBody()` guard on the public auth surface (auth.ts ×6, dash-auth.ts ×1) — parse failure flows into the existing zod 400 path. The three routes that previously COERCED bad bodies to `{}` (`/guest`, `/forgot-password`, `/reset-password`) keep that contract byte-identical: bodyless guest signup still mints a guest; forgot-password keeps its anti-enumeration generic 200 (review caught Codex tightening these; reverted to exact prior semantics).

**Verified live on staging** (`aeb41b4b` deployed): empty-body → 400, bad-creds → 401.

Note: PR is from the fix branch (not staging) — staging currently also carries in-flight autonomy work (`57cd2121`) not yet ready for prod promotion.

Follow-up filed in memory: same bare-parse pattern at ~149 sites/45 files; systemic middleware fix gated on the partner harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014x5RrJK4BdmDXsGM2hzZjf