### PR TITLE
Hotfix: chat history fetch was unbounded — whole room composed into every chat turn

### DIFF
--- a/packages/agent-runtime/src/eliza-runtime.history.test.ts
+++ b/packages/agent-runtime/src/eliza-runtime.history.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { ElizaRuntime } from './eliza-runtime';
+
+const AGENT_ID = '60000000-0000-0000-0000-000000000006';
+
+describe('conversation history fetch is bounded', () => {
+  it('passes count (the param core actually reads) — never limit — so history cannot fetch the whole room', async () => {
+    const getMemories = mock(async (params: Record<string, unknown>) => {
+      // Simulate core semantics: `count` bounds the result, `limit` is ignored.
+      // Returning a sentinel oversized array when count is absent makes an
+      // unbounded fetch fail the assertion below loudly.
+      if (typeof params.count !== 'number') {
+        return Array.from({ length: 500 }, (_, i) => ({
+          content: { text: `msg ${i}` },
+          entityId: 'someone',
+          createdAt: i,
+        }));
+      }
+      return Array.from({ length: Math.min(20, params.count as number) }, (_, i) => ({
+        content: { text: `msg ${i}` },
+        entityId: 'someone',
+        createdAt: i,
+      }));
+    });
+
+    const runtime = new ElizaRuntime({
+      agentId: AGENT_ID,
+      agentType: 'location-agent',
+      agentConfig: {},
+      customization: { name: 'History Test Teacher', bio: ['Persona.'] },
+    });
+    (runtime as any).state = 'running';
+    (runtime as any).runtime = { getMemories };
+
+    const history = await (runtime as any).getConversationHistory('room-1', 20);
+
+    expect(getMemories).toHaveBeenCalledTimes(1);
+    const params = getMemories.mock.calls[0]![0] as Record<string, unknown>;
+    expect(params.count).toBe(20);
+    expect(params.limit).toBeUndefined();
+    expect(params.tableName).toBe('messages');
+    expect(history.length).toBeLessThanOrEqual(20);
+  });
+});

--- a/packages/agent-runtime/src/eliza-runtime.ts
+++ b/packages/agent-runtime/src/eliza-runtime.ts
@@ -1217,8 +1217,14 @@ export class ElizaRuntime {
   private async getConversationHistory(roomId: UUID, limit = 20): Promise<Memory[]> {
     if (!this.runtime) return [];
     try {
-      // v2: `count` is deprecated in favor of `limit` on getMemories params
-      const memories = await this.runtime.getMemories({ roomId, limit, tableName: 'messages' } as any);
+      // v2 core getMemories reads `count` (defaulting to the WHOLE room when
+      // absent) and has NO `limit` param — passing `limit` fetched the entire
+      // conversation history every turn, which on long-lived autonomous
+      // teacher rooms composed 20-35k input tokens per reply (found 2026-07-20
+      // while verifying the teacher context diet on prod). plugin-sql orders
+      // desc(createdAt), so `count: limit` returns the newest N; the ascending
+      // re-sort below restores chronological order for the prompt.
+      const memories = await this.runtime.getMemories({ roomId, count: limit, tableName: 'messages' } as any);
       return memories.sort((a, b) => {
         const aTime = typeof a.createdAt === 'number' ? a.createdAt : Date.parse(String(a.createdAt || 0));
         const bTime = typeof b.createdAt === 'number' ? b.createdAt : Date.parse(String(b.createdAt || 0));


### PR DESCRIPTION
Cherry-pick of the history-bound fix (staging `02d4b360`) as a standalone hotfix so prod gets it without promoting unrelated in-flight staging work.

**Bug:** `getConversationHistory` passed `{ limit: 20 }` to ElizaOS core `getMemories`, but core reads `count` (defaulting to the ENTIRE room) and has no `limit` param — so every chat turn composed the room's full message history. On long-lived autonomous teacher rooms this meant 20–35k input tokens per reply, which is why prod teacher ledger lines stayed fat (in=19,865–34,976) after the context diet deployed: the diet fixed the bio-corpus leak, and this second, independent leak was hiding behind it. Fresh rooms (like the staging probe that showed in=2,726) looked healthy, which masked it.

**Fix:** pass `count: limit`. plugin-sql orders `desc(createdAt)`, so this returns the newest 20 and the existing ascending re-sort keeps the prompt chronological. Regression test locks the param shape (count set, limit never passed, oversized-room sentinel fails loudly).

**Verification:** agent-runtime 64/64 incl. new regression test, tsc clean. Post-merge proof: prod autonomous teacher turns (fire ~hourly) should drop from 19–35k to <8k in the `[InferenceRouter] served route=teacher` ledger.

PARITY: n/a — internal prompt composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGkoohSHctJbM5aUnzg4TZ