### PR TITLE
HOTFIX: loading bar visible again — portal loader above the stage cover

### DIFF
--- a/apps/web/src/components/game/sea-loading-screen.tsx
+++ b/apps/web/src/components/game/sea-loading-screen.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useGameStore } from '@/stores/game';
 
 // ---------------------------------------------------------------------------
@@ -304,7 +305,14 @@ export default function SeaLoadingScreen({ forceReady }: Props) {
 
   if (!visible) return null;
 
-  return (
+  // Portal to <body>: inside the (world) route group the page-children layer
+  // is `absolute z-10` (WorldStageRoot), a stacking context that traps this
+  // overlay's zIndex 9999 BELOW the sibling StageTransition cover (real
+  // z-[9999]) — users saw "WARMING SCENE" on black instead of the progress
+  // bar for the whole first boot (field incident 2026-07-28; pre-existing
+  // since the P1a cutover). Rendering into <body> (appended AFTER the stage
+  // root) restores a true top-level 9999 that wins by DOM order.
+  return createPortal(
     <>
       {/* All keyframes inline — component is fully self-contained */}
       <style>{`
@@ -714,6 +722,7 @@ export default function SeaLoadingScreen({ forceReady }: Props) {
           )}
         </div>
       </div>
-    </>
+    </>,
+    document.body,
   );
 }


### PR DESCRIPTION
Surgical cherry-pick onto the reverted master (staging->master would re-promote the reverted watchdog). Pre-existing P1a stacking bug: loader trapped under the WARMING SCENE cover. Verified live mid-boot (portaled, topmost, bar filling). tsc 0, build 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zrHfC4GMDkC23irEQ9Wz2